### PR TITLE
Changed default naming convention to CSharp

### DIFF
--- a/src/DotLiquid/Template.cs
+++ b/src/DotLiquid/Template.cs
@@ -31,7 +31,7 @@ namespace DotLiquid
 
 		static Template()
 		{
-			NamingConvention = new RubyNamingConvention();
+			NamingConvention = new CSharpNamingConvention(); // we live in a .net world baby!
 			FileSystem = new BlankFileSystem();
 			Tags = new Dictionary<string, Type>();
 		}


### PR DESCRIPTION
A lot of people are using CSharp naming conventions in .NET projects so it makes sense to use that by default, instead of Ruby naming, which is less common in the .NET world.
