### PR TITLE
Recognize DateTimeOffset as a safe type

### DIFF
--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -409,6 +409,8 @@ namespace DotLiquid
 				return obj;
 			if (obj is DateTime)
 				return obj;
+			if (obj is DateTimeOffset)
+				return obj;
 			if (obj is TimeSpan)
 				return obj;
 			if (obj is Guid)


### PR DESCRIPTION
This is a simple change. I was previously unable to use DateTimeOffset in the templates because it was not recognized as a safe type.
