### PR TITLE
Allow interfaces to be registered as safe types

### DIFF
--- a/src/DotLiquid/Template.cs
+++ b/src/DotLiquid/Template.cs
@@ -105,15 +105,33 @@ namespace DotLiquid
 
 		public static Func<object, object> GetValueTypeTransformer(Type type)
 		{
+            // Check for concrete types
 			if (ValueTypeTransformers.ContainsKey(type))
 				return ValueTypeTransformers[type];
+
+            // Check for interfaces
+		    foreach (var interfaceType in ValueTypeTransformers.Where(x => x.Key.IsInterface))
+		    {
+                if (type.GetInterfaces().Contains(interfaceType.Key))
+                    return interfaceType.Value;
+		    }
+
 			return null;
 		}
 
         public static Func<object, object> GetSafeTypeTransformer(Type type)
 		{
+            // Check for concrete types
 			if (SafeTypeTransformers.ContainsKey(type))
-				return SafeTypeTransformers[type];
+                return SafeTypeTransformers[type];
+
+            // Check for interfaces
+            foreach (var interfaceType in SafeTypeTransformers.Where(x => x.Key.IsInterface))
+            {
+                if (type.GetInterfaces().Contains(interfaceType.Key))
+                    return interfaceType.Value;
+            }
+
 			return null;
 		}
 


### PR DESCRIPTION
Code checks to see if a concrete registered type has been registered for an object, or if not, whether an interface has been registered.
