### PR TITLE
Add 'blockquote' filter

### DIFF
--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -261,5 +261,80 @@ namespace DotLiquid.Tests
 		{
 			Helper.AssertTemplateResult("1", "{{ 3 | modulo:2 }}");
 		}
+
+		[Test]
+		public void TestBlockquote()
+		{
+			Hash assigns = Hash.FromAnonymousObject(
+				new {
+					intro = 
+@"This is the README file for the latest git version of Subsurface.", 
+					quote = 
+@"Building the Qt version under Linux
+----------------------------------------------------------------------
+
+On Debian you need libqt4-dev, libmarble-dev, libzip-dev.
+Unfortunately the marble version in Debian stable (and possibly
+Ubuntu) appears broken and missing essential header files used in the
+current git version of Subsurface.", 
+					outro = 
+@"Building the Qt version under MacOSX
+------------------------------------
+
+You might have built MacPorts packages with +quartz dependencies to
+build the previous Subsurface/Gtk version."
+				});
+
+			Helper.AssertTemplateResult(
+@"This is the README file for the latest git version of Subsurface.
+
+	Building the Qt version under Linux
+	----------------------------------------------------------------------
+
+	On Debian you need libqt4-dev, libmarble-dev, libzip-dev.
+	Unfortunately the marble version in Debian stable (and possibly
+	Ubuntu) appears broken and missing essential header files used in the
+	current git version of Subsurface.
+
+Building the Qt version under MacOSX
+------------------------------------
+
+You might have built MacPorts packages with +quartz dependencies to
+build the previous Subsurface/Gtk version.", 
+
+@"{{ intro}}
+
+{{ quote | blockquote:4,80 }}
+
+{{ outro }}", assigns);
+
+			Helper.AssertTemplateResult(
+@"This is the README file for the latest git version of Subsurface.
+
+	Building the Qt version under Linux
+	----------------------------------------
+	------------------------------
+
+	On Debian you need libqt4-dev, 
+	libmarble-dev, libzip-dev. 
+	Unfortunately the marble version in 
+	Debian stable (and possibly 
+	Ubuntu) appears broken and missing 
+	essential header files used in the 
+	current git version of Subsurface.
+
+Building the Qt version under MacOSX
+------------------------------------
+
+You might have built MacPorts packages with +quartz dependencies to
+build the previous Subsurface/Gtk version.", 
+
+@"{{ intro}}
+
+{{ quote | blockquote:4,40 }}
+
+{{ outro }}", assigns);
+		}
+
 	}
 }

--- a/src/DotLiquid/StandardFilters.cs
+++ b/src/DotLiquid/StandardFilters.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Text;
 #if !NET35
 using System.Net;
 #endif
@@ -573,6 +574,79 @@ namespace DotLiquid
 				: ExpressionUtility.CreateExpression(operation, input.GetType(), operand.GetType(), input.GetType(), true)
 					.DynamicInvoke(input, operand);
 		}
+
+		/// <summary>
+		/// Offset all lines of <paramref name="input"/> by <paramref name="indent"/> characters
+		/// and wrap lines longer than <paramref name="width"/> characters.
+		/// </summary>
+		/// <param name="input"></param>
+		/// <param name="indent"></param>
+		/// <param name="width"></param>
+		/// <returns></returns>
+		public static object Blockquote(string input, int indent = 4, int width = 50)
+		{
+			if(string.IsNullOrWhiteSpace(input)) return input;
+
+			var indentation = new string(' ', indent);
+			var blockquote = new StringBuilder();
+
+			foreach(var line in GetBlockquoteLines(input, width))
+			{
+				if(string.IsNullOrWhiteSpace(line))
+					blockquote.AppendLine();
+				else
+					blockquote.AppendFormat("{0}{1}{2}", indentation, line, Environment.NewLine);
+			}
+
+			// FIXME: Somehow we need to strip
+			return blockquote.ToString().Trim(Environment.NewLine.ToCharArray());
+		}
+
+		private static IEnumerable<string> GetBlockquoteLines(string input, int width)
+		{
+			var lines = input.Split('\n');
+
+			foreach(var line in lines.Select(l => l.TrimEnd('\r')))
+			{
+				if(string.IsNullOrWhiteSpace(line))
+					yield return line;
+				else if(line.Length > width)
+				{
+					foreach(var fragment in GetBlockquoteLineFragments(line, width))
+						yield return fragment;
+				} 
+				else
+					yield return line;
+			}
+		}
+
+		private static IEnumerable<string> GetBlockquoteLineFragments(string line, int width)
+		{
+			var fragment = new StringBuilder();
+			var words = line.Split(' ');
+
+			foreach(var word in words)
+			{
+				if(word.Length > width)
+				{
+					foreach(var chunk in word.Chunk(width))
+						yield return chunk;
+				}
+				else
+				{
+					if(fragment.Length + word.Length > width)
+					{
+						yield return fragment.ToString();
+						fragment.Clear();
+					}
+
+					fragment.AppendFormat("{0} ", word);
+				}
+			}
+
+			if(fragment.Length > 0)
+				yield return fragment.ToString();
+		}
 	}
 
 	internal static class StringExtensions
@@ -580,6 +654,14 @@ namespace DotLiquid
 		public static bool IsNullOrWhiteSpace(this string s)
 		{
 			return string.IsNullOrEmpty(s) || s.Trim().Length == 0;
+		}
+
+		public static IEnumerable<string> Chunk(this string s, int chunkSize)
+		{
+			var count = (int)Math.Ceiling((double)s.Length / (double)chunkSize);
+			var offsets = Enumerable.Range(0, count).Select(i => new { offset = i * chunkSize}).ToList();
+			
+			return offsets.Select(i => s.Substring(i.offset, i.offset + chunkSize >= s.Length ? s.Length - i.offset : chunkSize));
 		}
 	}
 }


### PR DESCRIPTION
Blockquote filter indents all lines from input by the specified amount of characters and wraps long lines appropriately.

Effectively, `{{ my-variable-with-text | blockquote 4, 40 }}` transforms this:

```
Building the Qt version under Linux
----------------------------------------------------------------------

On Debian you need libqt4-dev, libmarble-dev, libzip-dev.
Unfortunately the marble version in Debian stable (and possibly
Ubuntu) appears broken and missing essential header files used in the
current git version of Subsurface.
```

into this:

```
    Building the Qt version under Linux
    ----------------------------------------
    ------------------------------

    On Debian you need libqt4-dev, 
    libmarble-dev, libzip-dev. 
    Unfortunately the marble version in 
    Debian stable (and possibly 
    Ubuntu) appears broken and missing 
    essential header files used in the 
    current git version of Subsurface.
```
