### PR TITLE
Allow non-global template configuration

### DIFF
--- a/src/DotLiquid.Tests/BlockTests.cs
+++ b/src/DotLiquid.Tests/BlockTests.cs
@@ -67,8 +67,8 @@ namespace DotLiquid.Tests
 		[Test]
 		public void TestWithCustomTag()
 		{
-			Template.RegisterTag<Block>("testtag");
-			Assert.DoesNotThrow(() => Template.Parse("{% testtag %} {% endtesttag %}"));
+		    var config = new TemplateConfiguration().RegisterTag<Block>("testtag");
+			Assert.DoesNotThrow(() => Template.Parse("{% testtag %} {% endtesttag %}", config));
 		}
 	}
 }

--- a/src/DotLiquid.Tests/ContextTests.cs
+++ b/src/DotLiquid.Tests/ContextTests.cs
@@ -278,9 +278,11 @@ namespace DotLiquid.Tests
 		[Test]
 		public void TestOverrideGlobalFilter()
 		{
-			Template.RegisterFilter(typeof(GlobalFilters));
-			Assert.AreEqual("Global test", Template.Parse("{{'test' | notice }}").Render());
-			Assert.AreEqual("Local test", Template.Parse("{{'test' | notice }}").Render(new RenderParameters { Filters = new[] { typeof(LocalFilters) } }));
+		    var config = new TemplateConfiguration();
+		    config.RegisterFilter(typeof (GlobalFilters));
+			Assert.AreEqual("Global test", Template.Parse("{{'test' | notice }}", config).Render());
+		    Assert.AreEqual("Local test", Template.Parse("{{'test' | notice }}", config)
+		        .Render(new RenderParameters {Filters = new[] {typeof (LocalFilters)}}));
 		}
 
 		[Test]

--- a/src/DotLiquid.Tests/FilterTests.cs
+++ b/src/DotLiquid.Tests/FilterTests.cs
@@ -207,11 +207,12 @@ namespace DotLiquid.Tests
 		[Test]
 		public void TestLocalGlobal()
 		{
-			Template.RegisterFilter(typeof(MoneyFilter));
+		    var config = new TemplateConfiguration();
+		    config.RegisterFilter(typeof (MoneyFilter));
 
-			Assert.AreEqual(" 1000$ ", Template.Parse("{{1000 | money}}").Render());
-			Assert.AreEqual(" 1000$ CAD ", Template.Parse("{{1000 | money}}").Render(new RenderParameters { Filters = new[] { typeof(CanadianMoneyFilter) } }));
-			Assert.AreEqual(" 1000$ CAD ", Template.Parse("{{1000 | money}}").Render(new RenderParameters { Filters = new[] { typeof(CanadianMoneyFilter) } }));
+			Assert.AreEqual(" 1000$ ", Template.Parse("{{1000 | money}}", config).Render());
+			Assert.AreEqual(" 1000$ CAD ", Template.Parse("{{1000 | money}}", config).Render(new RenderParameters { Filters = new[] { typeof(CanadianMoneyFilter) } }));
+			Assert.AreEqual(" 1000$ CAD ", Template.Parse("{{1000 | money}}", config).Render(new RenderParameters { Filters = new[] { typeof(CanadianMoneyFilter) } }));
 		}
 
 		[Test]

--- a/src/DotLiquid.Tests/Tags/IncludeTagTests.cs
+++ b/src/DotLiquid.Tests/Tags/IncludeTagTests.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using DotLiquid.Exceptions;
 using DotLiquid.FileSystems;
 using NUnit.Framework;
@@ -38,6 +39,9 @@ namespace DotLiquid.Tests.Tags
 
 					case "pick_a_source":
 						return "from TestFileSystem";
+
+                    case "nested_config":
+				        return "custom tag: {% foo %}";
 
 					default:
 						return templatePath;
@@ -170,5 +174,23 @@ namespace DotLiquid.Tests.Tags
 				RethrowErrors = true
 			}));
 		}
+
+	    [Test]
+	    public void TestForwardingTemplateConfiguration()
+	    {
+	        var config = new TemplateConfiguration {FileSystem = new TestFileSystem()}
+	            .RegisterTag<FooTag>("foo");
+
+	        var template = Template.Parse("This comes from {% include 'nested_config' %}", config);
+	        Assert.AreEqual("This comes from custom tag: foo", template.Render());
+	    }
 	}
+
+    public class FooTag : Tag
+    {
+        public override void Render(Context context, TextWriter result)
+        {
+            result.Write("foo");
+        }
+    }
 }

--- a/src/DotLiquid.Tests/Tags/IncludeTagTests.cs
+++ b/src/DotLiquid.Tests/Tags/IncludeTagTests.cs
@@ -131,9 +131,9 @@ namespace DotLiquid.Tests.Tags
 		[Test]
 		public void TestRecursivelyIncludedTemplateDoesNotProductEndlessLoop()
 		{
-			Template.FileSystem = new InfiniteFileSystem();
+            var config = new TemplateConfiguration { FileSystem = new InfiniteFileSystem() };
 
-			Assert.Throws<StackLevelException>(() => Template.Parse("{% include 'loop' %}").Render(new RenderParameters { RethrowErrors = true }));
+			Assert.Throws<StackLevelException>(() => Template.Parse("{% include 'loop' %}", config).Render(new RenderParameters { RethrowErrors = true }));
 		}
 
 		[Test]
@@ -154,8 +154,8 @@ namespace DotLiquid.Tests.Tags
 		[Test]
 		public void TestUndefinedTemplateVariableWithLocalFileSystem()
 		{
-			Template.FileSystem = new LocalFileSystem(string.Empty);
-			Assert.Throws<FileSystemException>(() => Template.Parse(" hello {% include notthere %} world ").Render(new RenderParameters
+		    var config = new TemplateConfiguration {FileSystem = new LocalFileSystem(string.Empty)};
+            Assert.Throws<FileSystemException>(() => Template.Parse(" hello {% include notthere %} world ", config).Render(new RenderParameters
 			{
 				RethrowErrors = true
 			}));
@@ -164,8 +164,8 @@ namespace DotLiquid.Tests.Tags
 		[Test]
 		public void TestMissingTemplateWithLocalFileSystem()
 		{
-			Template.FileSystem = new LocalFileSystem(string.Empty);
-			Assert.Throws<FileSystemException>(() => Template.Parse(" hello {% include 'doesnotexist' %} world ").Render(new RenderParameters
+            var config = new TemplateConfiguration { FileSystem = new LocalFileSystem(string.Empty) };
+			Assert.Throws<FileSystemException>(() => Template.Parse(" hello {% include 'doesnotexist' %} world ", config).Render(new RenderParameters
 			{
 				RethrowErrors = true
 			}));

--- a/src/DotLiquid.Tests/TemplateTests.cs
+++ b/src/DotLiquid.Tests/TemplateTests.cs
@@ -171,8 +171,9 @@ namespace DotLiquid.Tests
         [Test]
 		public void TestRegisterSimpleType()
 		{
-			Template.RegisterSafeType(typeof(MySimpleType), new[] { "Name" });
-			Template template = Template.Parse("{{context.Name}}");
+            var config = new TemplateConfiguration();
+            config.RegisterSafeType(typeof (MySimpleType), new[] {"Name"});
+			Template template = Template.Parse("{{context.Name}}", config);
 
 			var output = template.Render(Hash.FromAnonymousObject(new { context = new MySimpleType() { Name = "worked" } }));
 
@@ -182,8 +183,9 @@ namespace DotLiquid.Tests
 		[Test]
 		public void TestRegisterSimpleTypeToString()
 		{
-			Template.RegisterSafeType(typeof(MySimpleType), new[] { "ToString" });
-			Template template = Template.Parse("{{context}}");
+		    var config = new TemplateConfiguration();
+		    config.RegisterSafeType(typeof (MySimpleType), new[] {"ToString"});
+		    Template template = Template.Parse("{{context}}", config);
 
 			var output = template.Render(Hash.FromAnonymousObject(new { context = new MySimpleType() }));
 
@@ -194,12 +196,9 @@ namespace DotLiquid.Tests
         [Test]
         public void TestRegisterSimpleTypeToStringWhenTransformReturnsComplexType()
         {
-            Template.RegisterSafeType(typeof(MySimpleType), o =>
-                {
-                    return o;
-                });
+            var config = new TemplateConfiguration().RegisterSafeType(typeof (MySimpleType), o => o);
 
-            Template template = Template.Parse("{{context}}");
+            Template template = Template.Parse("{{context}}", config);
 
             var output = template.Render(Hash.FromAnonymousObject(new { context = new MySimpleType() }));
 
@@ -210,8 +209,8 @@ namespace DotLiquid.Tests
 		[Test]
 		public void TestRegisterSimpleTypeTransformer()
 		{
-			Template.RegisterSafeType(typeof(MySimpleType), o => o.ToString());
-			Template template = Template.Parse("{{context}}");
+		    var config = new TemplateConfiguration().RegisterSafeType(typeof (MySimpleType), o => o.ToString());
+			Template template = Template.Parse("{{context}}", config);
 
 			var output = template.Render(Hash.FromAnonymousObject(new { context = new MySimpleType() }));
 
@@ -222,9 +221,9 @@ namespace DotLiquid.Tests
         [Test]
         public void TestRegisterRegisterSafeTypeWithValueTypeTransformer()
         {
-            Template.RegisterSafeType(typeof(MySimpleType), new[] { "Name" }, m => m.ToString());
-
-            Template template = Template.Parse("{{context}}{{context.Name}}"); // 
+            var config = new TemplateConfiguration()
+                .RegisterSafeType(typeof (MySimpleType), new[] {"Name"}, m => m.ToString());
+            Template template = Template.Parse("{{context}}{{context.Name}}", config);
 
             var output = template.Render(Hash.FromAnonymousObject(new { context = new MySimpleType() { Name = "Bar" } }));
 
@@ -247,9 +246,10 @@ namespace DotLiquid.Tests
         [Test]
         public void TestNestedRegisterRegisterSafeTypeWithValueTypeTransformer()
         {
-            Template.RegisterSafeType(typeof(NestedMySimpleType), new[] { "Name", "Nested" }, m => m.ToString());
+            var config = new TemplateConfiguration()
+                .RegisterSafeType(typeof (NestedMySimpleType), new[] {"Name", "Nested"}, m => m.ToString());
 
-            Template template = Template.Parse("{{context}}{{context.Name}} {{context.Nested}}{{context.Nested.Name}}"); // 
+            Template template = Template.Parse("{{context}}{{context.Name}} {{context.Nested}}{{context.Nested.Name}}", config);
 
             var inner = new NestedMySimpleType() { Name = "Bar2" };
 
@@ -262,9 +262,8 @@ namespace DotLiquid.Tests
         [Test]
         public void TestOverrideDefaultBoolRenderingWithValueTypeTransformer()
         {
-            Template.RegisterValueTypeTransformer(typeof(bool), m => (bool)m ? "Win" : "Fail");
-
-            Template template = Template.Parse("{{var1}} {{var2}}");
+            var config = new TemplateConfiguration().RegisterValueTypeTransformer(typeof(bool), m => (bool)m ? "Win" : "Fail");
+            Template template = Template.Parse("{{var1}} {{var2}}", config);
 
             var output = template.Render(Hash.FromAnonymousObject(new { var1 = true, var2 = false }));
 
@@ -275,11 +274,11 @@ namespace DotLiquid.Tests
 		public void TestHtmlEncodingFilter()
 		{
 #if NET35
-			Template.RegisterValueTypeTransformer(typeof(string), m => HttpUtility.HtmlEncode((string) m));
+			var config = new TemplateConfiguration().RegisterValueTypeTransformer(typeof(string), m => HttpUtility.HtmlEncode((string) m));
 #else
-            Template.RegisterValueTypeTransformer(typeof(string), m => WebUtility.HtmlEncode((string) m));
+            var config = new TemplateConfiguration().RegisterValueTypeTransformer(typeof(string), m => WebUtility.HtmlEncode((string)m));
 #endif
-			Template template = Template.Parse("{{var1}} {{var2}}");
+			Template template = Template.Parse("{{var1}} {{var2}}", config);
 
 			var output = template.Render(Hash.FromAnonymousObject(new { var1 = "<html>", var2 = "Some <b>bold</b> text." }));
 
@@ -300,8 +299,9 @@ namespace DotLiquid.Tests
         public void TestRegisterSimpleTypeTransformIntoAnonymousType()
         {
             // specify a transform function
-            Template.RegisterSafeType(typeof(MySimpleType2), x => new { Name = ((MySimpleType2)x).Name } );
-            Template template = Template.Parse("{{context.Name}}");
+            var config = new TemplateConfiguration().RegisterSafeType(typeof (MySimpleType2),
+                x => new {Name = ((MySimpleType2) x).Name});
+            Template template = Template.Parse("{{context.Name}}", config);
 
             var output = template.Render(Hash.FromAnonymousObject(new { context = new MySimpleType2 { Name = "worked" } }));
 
@@ -312,8 +312,9 @@ namespace DotLiquid.Tests
 		public void TestRegisterInterfaceTransformIntoAnonymousType()
 		{
 			// specify a transform function
-			Template.RegisterSafeType(typeof(IMySimpleInterface2), x => new { Name = ((IMySimpleInterface2) x).Name });
-			Template template = Template.Parse("{{context.Name}}");
+		    var config = new TemplateConfiguration().RegisterSafeType(typeof (IMySimpleInterface2),
+		        x => new {Name = ((IMySimpleInterface2) x).Name});
+			Template template = Template.Parse("{{context.Name}}", config);
 
 			var output = template.Render(Hash.FromAnonymousObject(new { context = new MySimpleType2 { Name = "worked" } }));
 
@@ -329,8 +330,9 @@ namespace DotLiquid.Tests
 		public void TestRegisterSimpleTypeTransformIntoUnsafeType()
 		{
 			// specify a transform function
-			Template.RegisterSafeType(typeof(MySimpleType2), x => new MyUnsafeType2 { Name = ((MySimpleType2)x).Name });
-			Template template = Template.Parse("{{context.Name}}");
+		    var config = new TemplateConfiguration().RegisterSafeType(typeof (MySimpleType2),
+		        x => new MyUnsafeType2 {Name = ((MySimpleType2) x).Name});
+			Template template = Template.Parse("{{context.Name}}", config);
 
 			var output = template.Render(Hash.FromAnonymousObject(new { context = new MySimpleType2 { Name = "worked" } }));
 

--- a/src/DotLiquid.Tests/Util/StrFTimeTests.cs
+++ b/src/DotLiquid.Tests/Util/StrFTimeTests.cs
@@ -10,31 +10,31 @@ namespace DotLiquid.Tests.Util
 	public class StrFTimeTests
 	{
 		[SetCulture("en-GB")]
-		[TestCase("%a", Result = "Mon")]
-		[TestCase("%A", Result = "Monday")]
+		[TestCase("%a", Result = "Sun")]
+		[TestCase("%A", Result = "Sunday")]
 		[TestCase("%b", Result = "Jan")]
 		[TestCase("%B", Result = "January")]
-		[TestCase("%c", Result = "Mon Jan 09 14:32:14 2012")]
-		[TestCase("%d", Result = "09")]
-		[TestCase("%e", Result = " 9")]
+		[TestCase("%c", Result = "Sun Jan 08 14:32:14 2012")]
+		[TestCase("%d", Result = "08")]
+		[TestCase("%e", Result = " 8")]
 		[TestCase("%H", Result = "14")]
 		[TestCase("%I", Result = "02")]
-		[TestCase("%j", Result = "009")]
+		[TestCase("%j", Result = "008")]
 		[TestCase("%m", Result = "01")]
 		[TestCase("%M", Result = "32")]
 		[TestCase("%p", Result = "PM")]
 		[TestCase("%S", Result = "14")]
 		[TestCase("%U", Result = "02")]
-		[TestCase("%W", Result = "03")]
-		[TestCase("%w", Result = "1")]
-		[TestCase("%x", Result = "09/01/2012")]
+		[TestCase("%W", Result = "01")]
+		[TestCase("%w", Result = "0")]
+		[TestCase("%x", Result = "08/01/2012")]
 		[TestCase("%X", Result = "14:32:14")]
 		[TestCase("%y", Result = "12")]
 		[TestCase("%Y", Result = "2012")]
 		[TestCase("%", Result = "%")]
 		public string TestFormat(string format)
 		{
-			return new DateTime(2012, 1, 9, 14, 32, 14).ToStrFTime(format);
+			return new DateTime(2012, 1, 8, 14, 32, 14).ToStrFTime(format);
 		}
 
 		[Test]

--- a/src/DotLiquid/Block.cs
+++ b/src/DotLiquid/Block.cs
@@ -36,12 +36,13 @@ namespace DotLiquid
 							EndTag();
 							return;
 						}
-
+                        
 						// Fetch the tag from registered blocks
 						Type tagType;
-						if ((tagType = Template.GetTagType(fullTokenMatch.Groups[1].Value)) != null)
+						if ((tagType = Configuration.GetTagType(fullTokenMatch.Groups[1].Value)) != null)
 						{
 							Tag tag = (Tag) Activator.CreateInstance(tagType);
+						    tag.Configuration = Configuration;
 							tag.Initialize(fullTokenMatch.Groups[1].Value, fullTokenMatch.Groups[2].Value, tokens);
 							NodeList.Add(tag);
 

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -17,11 +17,14 @@ namespace DotLiquid
 		public List<Hash> Environments { get; private set; }
 		public List<Hash> Scopes { get; private set; }
 		public Hash Registers { get; private set; }
-		public List<Exception> Errors { get; private set; }
+	    public TemplateConfiguration Configuration { get; private set; }
+	    public List<Exception> Errors { get; private set; }
 
-		public Context(List<Hash> environments, Hash outerScope, Hash registers, bool rethrowErrors)
+		public Context(List<Hash> environments, Hash outerScope, Hash registers, bool rethrowErrors,
+            TemplateConfiguration configuration)
 		{
 			Environments = environments;
+            Configuration = configuration;
 
 			Scopes = new List<Hash>();
 			if (outerScope != null)
@@ -29,13 +32,13 @@ namespace DotLiquid
 
 			Registers = registers;
 
-			Errors = new List<Exception>();
+		    Errors = new List<Exception>();
 			_rethrowErrors = rethrowErrors;
 			SquashInstanceAssignsWithEnvironments();
 		}
 
 		public Context()
-			: this(new List<Hash>(), new Hash(), new Hash(), false)
+			: this(new List<Hash>(), new Hash(), new Hash(), false, TemplateConfiguration.Global)
 		{
 		}
 

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -262,7 +262,7 @@ namespace DotLiquid
 			scope = scope ?? Environments.LastOrDefault() ?? Scopes.Last();
 			variable = variable ?? LookupAndEvaluate(scope, key);
 
-			variable = Liquidize(variable);
+			variable = Liquidize(variable, Configuration);
 			if (variable is IContextAware)
 				((IContextAware) variable).Context = this;
 			return variable;
@@ -306,7 +306,7 @@ namespace DotLiquid
 					if (@object is KeyValuePair<string, object> && ((KeyValuePair<string, object>) @object).Key == (string) part)
 					{
 						object res = ((KeyValuePair<string, object>) @object).Value;
-						@object = Liquidize(res);
+						@object = Liquidize(res, Configuration);
 					}
 						// If object is a hash- or array-like object we look for the
 						// presence of the key and if its available we return it
@@ -314,7 +314,7 @@ namespace DotLiquid
 					{
 						// If its a proc we will replace the entry with the proc
 						object res = LookupAndEvaluate(@object, part);
-						@object = Liquidize(res);
+						@object = Liquidize(res, Configuration);
 					}
 						// Some special cases. If the part wasn't in square brackets and
 						// no key with the same name was found we interpret following calls
@@ -396,7 +396,7 @@ namespace DotLiquid
 			return value;
 		}
         
-		private static object Liquidize(object obj)
+		private static object Liquidize(object obj, TemplateConfiguration configuration)
 		{
 			if (obj == null)
 				return obj;
@@ -422,7 +422,7 @@ namespace DotLiquid
 				return obj;
 			if (obj is KeyValuePair<string, object>)
 				return obj;
-            var safeTypeTransformer = Template.GetSafeTypeTransformer(obj.GetType());
+            var safeTypeTransformer = configuration.GetSafeTypeTransformer(obj.GetType());
 			if (safeTypeTransformer != null)
 				return safeTypeTransformer(obj);
             if (obj.GetType().GetCustomAttributes(typeof(LiquidTypeAttribute), false).Any())

--- a/src/DotLiquid/DotLiquid.csproj
+++ b/src/DotLiquid/DotLiquid.csproj
@@ -52,6 +52,7 @@
     <Compile Include="LiquidTypeAttribute.cs" />
     <Compile Include="RenderParameters.cs" />
     <Compile Include="Tags\Raw.cs" />
+    <Compile Include="TemplateConfiguration.cs" />
     <Compile Include="Util\StrFTime.cs" />
     <Compile Include="Exceptions\ArgumentException.cs" />
     <Compile Include="Exceptions\FileSystemException.cs" />

--- a/src/DotLiquid/Liquid.cs
+++ b/src/DotLiquid/Liquid.cs
@@ -1,8 +1,4 @@
-using System.Reflection;
 using System.Resources;
-using DotLiquid.NamingConventions;
-using DotLiquid.Tags;
-using DotLiquid.Tags.Html;
 using DotLiquid.Util;
 
 namespace DotLiquid
@@ -41,24 +37,7 @@ namespace DotLiquid
 
 		static Liquid()
 		{
-			Template.RegisterTag<Tags.Assign>("assign");
-			Template.RegisterTag<Tags.Block>("block");
-			Template.RegisterTag<Tags.Capture>("capture");
-			Template.RegisterTag<Tags.Case>("case");
-			Template.RegisterTag<Tags.Comment>("comment");
-			Template.RegisterTag<Tags.Cycle>("cycle");
-			Template.RegisterTag<Tags.Extends>("extends");
-			Template.RegisterTag<Tags.For>("for");
-			Template.RegisterTag<Tags.If>("if");
-			Template.RegisterTag<Tags.IfChanged>("ifchanged");
-			Template.RegisterTag<Tags.Include>("include");
-			Template.RegisterTag<Tags.Literal>("literal");
-			Template.RegisterTag<Tags.Unless>("unless");
-			Template.RegisterTag<Tags.Raw>("raw");
-
-			Template.RegisterTag<Tags.Html.TableRow>("tablerow");
-
-			Template.RegisterFilter(typeof(StandardFilters));
+            Template.RegisterFilter(typeof(StandardFilters));
 		}
 	}
 }

--- a/src/DotLiquid/Liquid.cs
+++ b/src/DotLiquid/Liquid.cs
@@ -34,10 +34,5 @@ namespace DotLiquid
 		public static readonly string LiteralShorthand = R.Q(@"^(?:\{\{\{\s?)(.*?)(?:\s*\}\}\})$");
 		public static readonly string CommentShorthand = R.Q(@"^(?:\{\s?\#\s?)(.*?)(?:\s*\#\s?\})$");
 		public static bool UseRubyDateFormat = false;
-
-		static Liquid()
-		{
-            Template.RegisterFilter(typeof(StandardFilters));
-		}
 	}
 }

--- a/src/DotLiquid/RenderParameters.cs
+++ b/src/DotLiquid/RenderParameters.cs
@@ -33,7 +33,8 @@ namespace DotLiquid
 			if (LocalVariables != null)
 				environments.Add(LocalVariables);
 			environments.Add(template.Assigns);
-			context = new Context(environments, template.InstanceAssigns, template.Registers, RethrowErrors);
+			context = new Context(environments, template.InstanceAssigns, template.Registers, RethrowErrors,
+                template.Configuration);
 			registers = Registers;
 			filters = Filters;
 		}

--- a/src/DotLiquid/Strainer.cs
+++ b/src/DotLiquid/Strainer.cs
@@ -14,18 +14,16 @@ namespace DotLiquid
 	/// </summary>
 	public class Strainer
 	{
-		private static readonly Dictionary<string, Type> Filters = new Dictionary<string, Type>();
-
-		public static void GlobalFilter(Type filter)
+		public static void aGlobalFilter(Type filter)
 		{
-			Filters[filter.AssemblyQualifiedName] = filter;
+            TemplateConfiguration.Global.RegisterFilter(filter);
 		}
 
 		public static Strainer Create(Context context)
 		{
 			Strainer strainer = new Strainer(context);
-			foreach (var keyValue in Filters)
-				strainer.Extend(keyValue.Value);
+			foreach (var filter in context.Configuration.GetFilters())
+                strainer.Extend(filter);
 			return strainer;
 		}
 

--- a/src/DotLiquid/Tag.cs
+++ b/src/DotLiquid/Tag.cs
@@ -8,6 +8,7 @@ namespace DotLiquid
 		public List<object> NodeList { get; protected set; }
 		protected string TagName { get; private set; }
 		protected string Markup { get; private set; }
+        internal TemplateConfiguration Configuration { get; set; }
 
 		/// <summary>
 		/// Only want to allow Tags to be created in inherited classes or tests.

--- a/src/DotLiquid/Tags/Extends.cs
+++ b/src/DotLiquid/Tags/Extends.cs
@@ -102,7 +102,7 @@ namespace DotLiquid.Tags
 		public override void Render(Context context, TextWriter result)
 		{
             // Get the template or template content and then either copy it (since it will be modified) or parse it
-			IFileSystem fileSystem = context.Registers["file_system"] as IFileSystem ?? Template.FileSystem;
+		    IFileSystem fileSystem = context.Registers["file_system"] as IFileSystem ?? context.Configuration.FileSystem;
             object file = fileSystem.ReadTemplateFile(context, _templateName);
 		    Template template = file as Template;
             template = template ?? Template.Parse(file == null ? null : file.ToString());

--- a/src/DotLiquid/Tags/Extends.cs
+++ b/src/DotLiquid/Tags/Extends.cs
@@ -105,7 +105,7 @@ namespace DotLiquid.Tags
 		    IFileSystem fileSystem = context.Registers["file_system"] as IFileSystem ?? context.Configuration.FileSystem;
             object file = fileSystem.ReadTemplateFile(context, _templateName);
 		    Template template = file as Template;
-            template = template ?? Template.Parse(file == null ? null : file.ToString());
+		    template = template ?? Template.Parse(file == null ? null : file.ToString(), context.Configuration);
 
 		    List<Block> parentBlocks = FindBlocks(template.Root, null);
             List<Block> orphanedBlocks = ((List<Block>)context.Scopes[0]["extends"]) ?? new List<Block>();

--- a/src/DotLiquid/Tags/Include.cs
+++ b/src/DotLiquid/Tags/Include.cs
@@ -42,7 +42,7 @@ namespace DotLiquid.Tags
 		{
 		    IFileSystem fileSystem = context.Registers["file_system"] as IFileSystem ?? context.Configuration.FileSystem;
 			string source = fileSystem.ReadTemplateFile(context, _templateName);
-			Template partial = Template.Parse(source);
+			Template partial = Template.Parse(source, context.Configuration);
 
 			string shortenedTemplateName = _templateName.Substring(1, _templateName.Length - 2);
 			object variable = context[_variableName ?? shortenedTemplateName];

--- a/src/DotLiquid/Tags/Include.cs
+++ b/src/DotLiquid/Tags/Include.cs
@@ -40,7 +40,7 @@ namespace DotLiquid.Tags
 
 		public override void Render(Context context, TextWriter result)
 		{
-			IFileSystem fileSystem = context.Registers["file_system"] as IFileSystem ?? Template.FileSystem;
+		    IFileSystem fileSystem = context.Registers["file_system"] as IFileSystem ?? context.Configuration.FileSystem;
 			string source = fileSystem.ReadTemplateFile(context, _templateName);
 			Template partial = Template.Parse(source);
 

--- a/src/DotLiquid/Template.cs
+++ b/src/DotLiquid/Template.cs
@@ -59,7 +59,7 @@ namespace DotLiquid
 		/// <param name="filter"></param>
 		public static void RegisterFilter(Type filter)
 		{
-			Strainer.GlobalFilter(filter);
+		    TemplateConfiguration.Global.RegisterFilter(filter);
 		}
 
 		/// <summary>

--- a/src/DotLiquid/Template.cs
+++ b/src/DotLiquid/Template.cs
@@ -25,16 +25,23 @@ namespace DotLiquid
 	/// </summary>
 	public class Template
 	{
-		public static INamingConvention NamingConvention;
-		public static IFileSystem FileSystem { get; set; }
+	    public static INamingConvention NamingConvention;
+
+	    public static IFileSystem FileSystem
+	    {
+	        get { return TemplateConfiguration.Global.FileSystem; }
+            set { TemplateConfiguration.Global.FileSystem = value; }
+	    }
+
 		private static Dictionary<string, Type> Tags { get; set; }
         private static readonly Dictionary<Type, Func<object, object>> SafeTypeTransformers;
 		private static readonly Dictionary<Type, Func<object, object>> ValueTypeTransformers;
 
+        public TemplateConfiguration Configuration { get; private set; }
+
 		static Template()
 		{
-			NamingConvention = new RubyNamingConvention();
-			FileSystem = new BlankFileSystem();
+            NamingConvention = new RubyNamingConvention();
 			Tags = new Dictionary<string, Type>();
             SafeTypeTransformers = new Dictionary<Type, Func<object, object>>();
 			ValueTypeTransformers = new Dictionary<Type, Func<object, object>>();
@@ -139,12 +146,23 @@ namespace DotLiquid
 		/// Creates a new <tt>Template</tt> object from liquid source code
 		/// </summary>
 		/// <param name="source"></param>
+		/// <param name="configuration"></param>
+		/// <returns></returns>
+		public static Template Parse(string source, TemplateConfiguration configuration)
+		{
+			Template template = new Template(configuration);
+			template.ParseInternal(source);
+			return template;
+		}
+
+		/// <summary>
+		/// Creates a new <tt>Template</tt> object from liquid source code
+		/// </summary>
+		/// <param name="source"></param>
 		/// <returns></returns>
 		public static Template Parse(string source)
 		{
-			Template template = new Template();
-			template.ParseInternal(source);
-			return template;
+		    return Parse(source, TemplateConfiguration.Global);
 		}
 
 		private Hash _registers, _assigns, _instanceAssigns;
@@ -172,12 +190,20 @@ namespace DotLiquid
 			get { return (_errors = _errors ?? new List<Exception>()); }
 		}
 
-		/// <summary>
-		/// Creates a new <tt>Template</tt> from an array of tokens. Use <tt>Template.parse</tt> instead
-		/// </summary>
-		internal Template()
-		{
-		}
+        /// <summary>
+        /// Creates a new <tt>Template</tt> from an array of tokens. Use <tt>Template.parse</tt> instead
+        /// </summary>
+        public Template(TemplateConfiguration configuration)
+        {
+            this.Configuration = configuration;
+        }
+
+        /// <summary>
+        /// Creates a new <tt>Template</tt> from an array of tokens. Use <tt>Template.parse</tt> instead
+        /// </summary>
+        public Template() : this(TemplateConfiguration.Global)
+        {
+        }
 
 		/// <summary>
 		/// Parse source code.

--- a/src/DotLiquid/Template.cs
+++ b/src/DotLiquid/Template.cs
@@ -33,14 +33,12 @@ namespace DotLiquid
             set { TemplateConfiguration.Global.FileSystem = value; }
 	    }
 
-		private static readonly Dictionary<Type, Func<object, object>> ValueTypeTransformers;
 
         public TemplateConfiguration Configuration { get; private set; }
 
 		static Template()
 		{
             NamingConvention = new RubyNamingConvention();
-			ValueTypeTransformers = new Dictionary<Type, Func<object, object>>();
 		}
 
 		public static void RegisterTag<T>(string name)
@@ -101,23 +99,12 @@ namespace DotLiquid
         /// <param name="func">Function that converts the specified type into a Liquid Drop-compatible object (eg, implements ILiquidizable)</param>
         public static void RegisterValueTypeTransformer(Type type, Func<object, object> func)
         {
-            ValueTypeTransformers[type] = func;
+            TemplateConfiguration.Global.RegisterValueTypeTransformer(type, func);
         }
 
 		public static Func<object, object> GetValueTypeTransformer(Type type)
 		{
-            // Check for concrete types
-			if (ValueTypeTransformers.ContainsKey(type))
-				return ValueTypeTransformers[type];
-
-            // Check for interfaces
-		    foreach (var interfaceType in ValueTypeTransformers.Where(x => x.Key.IsInterface))
-		    {
-                if (type.GetInterfaces().Contains(interfaceType.Key))
-                    return interfaceType.Value;
-		    }
-
-			return null;
+		    return TemplateConfiguration.Global.GetValueTypeTransformer(type);
 		}
 
         public static Func<object, object> GetSafeTypeTransformer(Type type)

--- a/src/DotLiquid/Template.cs
+++ b/src/DotLiquid/Template.cs
@@ -33,7 +33,6 @@ namespace DotLiquid
             set { TemplateConfiguration.Global.FileSystem = value; }
 	    }
 
-		private static Dictionary<string, Type> Tags { get; set; }
         private static readonly Dictionary<Type, Func<object, object>> SafeTypeTransformers;
 		private static readonly Dictionary<Type, Func<object, object>> ValueTypeTransformers;
 
@@ -42,7 +41,6 @@ namespace DotLiquid
 		static Template()
 		{
             NamingConvention = new RubyNamingConvention();
-			Tags = new Dictionary<string, Type>();
             SafeTypeTransformers = new Dictionary<Type, Func<object, object>>();
 			ValueTypeTransformers = new Dictionary<Type, Func<object, object>>();
 		}
@@ -50,14 +48,12 @@ namespace DotLiquid
 		public static void RegisterTag<T>(string name)
 			where T : Tag, new()
 		{
-			Tags[name] = typeof(T);
+            TemplateConfiguration.Global.RegisterTag<T>(name);
 		}
 
 		public static Type GetTagType(string name)
 		{
-			Type result;
-			Tags.TryGetValue(name, out result);
-			return result;
+		    return TemplateConfiguration.Global.GetTagType(name);
 		}
 
 		/// <summary>
@@ -216,8 +212,8 @@ namespace DotLiquid
 			source = DotLiquid.Tags.Literal.FromShortHand(source);
 			source = DotLiquid.Tags.Comment.FromShortHand(source);
 
-			Root = new Document();
-			Root.Initialize(null, null, Tokenize(source));
+		    Root = new Document {Configuration = this.Configuration};
+		    Root.Initialize(null, null, Tokenize(source));
 			return this;
 		}
 

--- a/src/DotLiquid/Template.cs
+++ b/src/DotLiquid/Template.cs
@@ -33,7 +33,6 @@ namespace DotLiquid
             set { TemplateConfiguration.Global.FileSystem = value; }
 	    }
 
-        private static readonly Dictionary<Type, Func<object, object>> SafeTypeTransformers;
 		private static readonly Dictionary<Type, Func<object, object>> ValueTypeTransformers;
 
         public TemplateConfiguration Configuration { get; private set; }
@@ -41,7 +40,6 @@ namespace DotLiquid
 		static Template()
 		{
             NamingConvention = new RubyNamingConvention();
-            SafeTypeTransformers = new Dictionary<Type, Func<object, object>>();
 			ValueTypeTransformers = new Dictionary<Type, Func<object, object>>();
 		}
 
@@ -72,9 +70,9 @@ namespace DotLiquid
 		/// <param name="type">The type to register</param>
 		/// <param name="allowedMembers">An array of property and method names that are allowed to be called on the object.</param>
 		public static void RegisterSafeType(Type type, string[] allowedMembers)
-        {
-			RegisterSafeType(type, x => new DropProxy(x, allowedMembers));
-        }
+		{
+		    TemplateConfiguration.Global.RegisterSafeType(type, allowedMembers);
+		}
 
         /// <summary>
         /// Registers a simple type. DotLiquid will wrap the object in a <see cref="DropProxy"/> object.
@@ -83,7 +81,7 @@ namespace DotLiquid
         /// <param name="allowedMembers">An array of property and method names that are allowed to be called on the object.</param>
         public static void RegisterSafeType(Type type, string[] allowedMembers, Func<object, object> func)
         {
-            RegisterSafeType(type, x => new DropProxy(x, allowedMembers, func));
+            TemplateConfiguration.Global.RegisterSafeType(type, allowedMembers, func);
         }
 
         /// <summary>
@@ -93,7 +91,7 @@ namespace DotLiquid
         /// <param name="func">Function that converts the specified type into a Liquid Drop-compatible object (eg, implements ILiquidizable)</param>
 		public static void RegisterSafeType(Type type, Func<object, object> func)
         {
-			SafeTypeTransformers[type] = func;
+            TemplateConfiguration.Global.RegisterSafeType(type, func);
         }
 
         /// <summary>
@@ -123,20 +121,9 @@ namespace DotLiquid
 		}
 
         public static Func<object, object> GetSafeTypeTransformer(Type type)
-		{
-            // Check for concrete types
-			if (SafeTypeTransformers.ContainsKey(type))
-                return SafeTypeTransformers[type];
-
-            // Check for interfaces
-            foreach (var interfaceType in SafeTypeTransformers.Where(x => x.Key.IsInterface))
-            {
-                if (type.GetInterfaces().Contains(interfaceType.Key))
-                    return interfaceType.Value;
-            }
-
-			return null;
-		}
+        {
+            return TemplateConfiguration.Global.GetSafeTypeTransformer(type);
+        }
 
 		/// <summary>
 		/// Creates a new <tt>Template</tt> object from liquid source code

--- a/src/DotLiquid/TemplateConfiguration.cs
+++ b/src/DotLiquid/TemplateConfiguration.cs
@@ -22,12 +22,15 @@ namespace DotLiquid
         private readonly Dictionary<Type, Func<object, object>> _valueTypeTransformers =
             new Dictionary<Type, Func<object, object>>();
 
+        private readonly Dictionary<string, Type> _filters = new Dictionary<string, Type>();
+
         public IFileSystem FileSystem { get; set; }
 
         public TemplateConfiguration()
         {
             FileSystem = new BlankFileSystem();
             RegisterDefaultTags();
+            RegisterFilter(typeof(StandardFilters));
         }
 
         public void RegisterTag<T>(string name)
@@ -41,6 +44,16 @@ namespace DotLiquid
             Type result;
             _tags.TryGetValue(name, out result);
             return result;
+        }
+
+        public void RegisterFilter(Type filter)
+        {
+            _filters[filter.AssemblyQualifiedName] = filter;
+        }
+
+        public IEnumerable<Type> GetFilters()
+        {
+            return _filters.Values;
         }
 
         /// <summary>

--- a/src/DotLiquid/TemplateConfiguration.cs
+++ b/src/DotLiquid/TemplateConfiguration.cs
@@ -1,0 +1,21 @@
+﻿using DotLiquid.FileSystems;
+
+namespace DotLiquid
+{
+    public class TemplateConfiguration
+    {
+        private static TemplateConfiguration _global;
+
+        public static TemplateConfiguration Global
+        {
+            get { return _global ?? (_global = new TemplateConfiguration()); }
+        }
+
+        public IFileSystem FileSystem { get; set; }
+
+        public TemplateConfiguration()
+        {
+            this.FileSystem = new BlankFileSystem();
+        }
+    }
+}

--- a/src/DotLiquid/TemplateConfiguration.cs
+++ b/src/DotLiquid/TemplateConfiguration.cs
@@ -33,10 +33,11 @@ namespace DotLiquid
             RegisterFilter(typeof(StandardFilters));
         }
 
-        public void RegisterTag<T>(string name)
+        public TemplateConfiguration RegisterTag<T>(string name)
             where T : Tag, new()
         {
             _tags[name] = typeof(T);
+            return this;
         }
 
         public Type GetTagType(string name)
@@ -46,9 +47,10 @@ namespace DotLiquid
             return result;
         }
 
-        public void RegisterFilter(Type filter)
+        public TemplateConfiguration RegisterFilter(Type filter)
         {
             _filters[filter.AssemblyQualifiedName] = filter;
+            return this;
         }
 
         public IEnumerable<Type> GetFilters()
@@ -61,9 +63,9 @@ namespace DotLiquid
         /// </summary>
         /// <param name="type">The type to register</param>
         /// <param name="allowedMembers">An array of property and method names that are allowed to be called on the object.</param>
-        public void RegisterSafeType(Type type, string[] allowedMembers)
+        public TemplateConfiguration RegisterSafeType(Type type, string[] allowedMembers)
         {
-            RegisterSafeType(type, x => new DropProxy(x, allowedMembers));
+            return RegisterSafeType(type, x => new DropProxy(x, allowedMembers));
         }
 
         /// <summary>
@@ -71,9 +73,9 @@ namespace DotLiquid
         /// </summary>
         /// <param name="type">The type to register</param>
         /// <param name="allowedMembers">An array of property and method names that are allowed to be called on the object.</param>
-        public void RegisterSafeType(Type type, string[] allowedMembers, Func<object, object> func)
+        public TemplateConfiguration RegisterSafeType(Type type, string[] allowedMembers, Func<object, object> func)
         {
-            RegisterSafeType(type, x => new DropProxy(x, allowedMembers, func));
+            return RegisterSafeType(type, x => new DropProxy(x, allowedMembers, func));
         }
 
         /// <summary>
@@ -81,9 +83,10 @@ namespace DotLiquid
         /// </summary>
         /// <param name="type">The type to register</param>
         /// <param name="func">Function that converts the specified type into a Liquid Drop-compatible object (eg, implements ILiquidizable)</param>
-        public void RegisterSafeType(Type type, Func<object, object> func)
+        public TemplateConfiguration RegisterSafeType(Type type, Func<object, object> func)
         {
             _safeTypeTransformers[type] = func;
+            return this;
         }
 
         public Func<object, object> GetSafeTypeTransformer(Type type)
@@ -107,9 +110,10 @@ namespace DotLiquid
         /// </summary>
         /// <param name="type">The type to register</param>
         /// <param name="func">Function that converts the specified type into a Liquid Drop-compatible object (eg, implements ILiquidizable)</param>
-        public void RegisterValueTypeTransformer(Type type, Func<object, object> func)
+        public TemplateConfiguration RegisterValueTypeTransformer(Type type, Func<object, object> func)
         {
             _valueTypeTransformers[type] = func;
+            return this;
         }
 
         public Func<object, object> GetValueTypeTransformer(Type type)

--- a/src/DotLiquid/TemplateConfiguration.cs
+++ b/src/DotLiquid/TemplateConfiguration.cs
@@ -1,4 +1,6 @@
-﻿using DotLiquid.FileSystems;
+﻿using System;
+using System.Collections.Generic;
+using DotLiquid.FileSystems;
 
 namespace DotLiquid
 {
@@ -11,11 +13,47 @@ namespace DotLiquid
             get { return _global ?? (_global = new TemplateConfiguration()); }
         }
 
+        private readonly Dictionary<string, Type> _tags = new Dictionary<string, Type>();
+
         public IFileSystem FileSystem { get; set; }
 
         public TemplateConfiguration()
         {
-            this.FileSystem = new BlankFileSystem();
+            FileSystem = new BlankFileSystem();
+            RegisterDefaultTags();
+        }
+
+        public void RegisterTag<T>(string name)
+            where T : Tag, new()
+        {
+            _tags[name] = typeof(T);
+        }
+
+        public Type GetTagType(string name)
+        {
+            Type result;
+            _tags.TryGetValue(name, out result);
+            return result;
+        }
+
+        private void RegisterDefaultTags()
+        {
+            RegisterTag<Tags.Assign>("assign");
+            RegisterTag<Tags.Block>("block");
+            RegisterTag<Tags.Capture>("capture");
+            RegisterTag<Tags.Case>("case");
+            RegisterTag<Tags.Comment>("comment");
+            RegisterTag<Tags.Cycle>("cycle");
+            RegisterTag<Tags.Extends>("extends");
+            RegisterTag<Tags.For>("for");
+            RegisterTag<Tags.If>("if");
+            RegisterTag<Tags.IfChanged>("ifchanged");
+            RegisterTag<Tags.Include>("include");
+            RegisterTag<Tags.Literal>("literal");
+            RegisterTag<Tags.Unless>("unless");
+            RegisterTag<Tags.Raw>("raw");
+
+            RegisterTag<Tags.Html.TableRow>("tablerow");
         }
     }
 }

--- a/src/DotLiquid/TemplateConfiguration.cs
+++ b/src/DotLiquid/TemplateConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using DotLiquid.FileSystems;
 
 namespace DotLiquid
@@ -14,6 +15,9 @@ namespace DotLiquid
         }
 
         private readonly Dictionary<string, Type> _tags = new Dictionary<string, Type>();
+
+        private readonly Dictionary<Type, Func<object, object>> _safeTypeTransformers =
+            new Dictionary<Type, Func<object, object>>();
 
         public IFileSystem FileSystem { get; set; }
 
@@ -34,6 +38,52 @@ namespace DotLiquid
             Type result;
             _tags.TryGetValue(name, out result);
             return result;
+        }
+
+        /// <summary>
+        /// Registers a simple type. DotLiquid will wrap the object in a <see cref="DropProxy"/> object.
+        /// </summary>
+        /// <param name="type">The type to register</param>
+        /// <param name="allowedMembers">An array of property and method names that are allowed to be called on the object.</param>
+        public void RegisterSafeType(Type type, string[] allowedMembers)
+        {
+            RegisterSafeType(type, x => new DropProxy(x, allowedMembers));
+        }
+
+        /// <summary>
+        /// Registers a simple type. DotLiquid will wrap the object in a <see cref="DropProxy"/> object.
+        /// </summary>
+        /// <param name="type">The type to register</param>
+        /// <param name="allowedMembers">An array of property and method names that are allowed to be called on the object.</param>
+        public void RegisterSafeType(Type type, string[] allowedMembers, Func<object, object> func)
+        {
+            RegisterSafeType(type, x => new DropProxy(x, allowedMembers, func));
+        }
+
+        /// <summary>
+        /// Registers a simple type using the specified transformer.
+        /// </summary>
+        /// <param name="type">The type to register</param>
+        /// <param name="func">Function that converts the specified type into a Liquid Drop-compatible object (eg, implements ILiquidizable)</param>
+        public void RegisterSafeType(Type type, Func<object, object> func)
+        {
+            _safeTypeTransformers[type] = func;
+        }
+
+        public Func<object, object> GetSafeTypeTransformer(Type type)
+        {
+            // Check for concrete types
+            if (_safeTypeTransformers.ContainsKey(type))
+                return _safeTypeTransformers[type];
+
+            // Check for interfaces
+            foreach (var interfaceType in _safeTypeTransformers.Where(x => x.Key.IsInterface))
+            {
+                if (type.GetInterfaces().Contains(interfaceType.Key))
+                    return interfaceType.Value;
+            }
+
+            return null;
         }
 
         private void RegisterDefaultTags()

--- a/src/DotLiquid/Variable.cs
+++ b/src/DotLiquid/Variable.cs
@@ -62,7 +62,7 @@ namespace DotLiquid
 
 			if (output != null)
 			{
-                var transformer = Template.GetValueTypeTransformer(output.GetType());
+                var transformer = context.Configuration.GetValueTypeTransformer(output.GetType());
                 
                 if(transformer != null)
                     output = transformer(output);


### PR DESCRIPTION
Fixes #93. This is what I got:

### Before
```cs
Template.RegisterFilter(typeof(SomeFilters)); // Filter registration
Template.RegisterValueTypeTransformer(type, func); // Value type transformer
Template.RegisterSafeType(type, allowedMembers); // Safe type
Template.RegisterTag<MyTag>("my");  // Tag registration
Template.FileSystem = new MyFileSystem(); // File system

Template.NamingConvention = new SomeNamingConvention();

var template = Template.Parse("the template");
var result = template.Render();
```

### After
```cs
var config = new TemplateConfiguration();
config.RegisterFilter(typeof(SomeFilters)); // Filter registration
config.RegisterValueTypeTransformer(type, func); // Value type transformer
config.RegisterSafeType(type, allowedMembers); // Safe type
config.RegisterTag<MyTag>("my");  // Tag registration
config.FileSystem = new MyFileSystem(); // File system

Template.NamingConvention = new SomeNamingConvention(); // The naming convention was kept global for now, since it could too heavily impact performance and caching

var template = Template.Parse("the template", config);
var result = template.Render();
```

The global methods were all kept so that it doesn't break the interface. Also, the syntax for each configuration was kept the same (including overloads), except for being on the `TemplateConfiguration` instance.

I ran performance tests and no difference was detected on the time taken to run all the tests. Is this good to go?

### Motivation
In case anyone fails to understand the importance of this feature, here is my real-world scenario.

**1. Support different schemas**: I have different schemas of my application running at the same time on the same application. Each schema supports completely different structures for the entities and have tags with different behaviors, although both run on DotLiquid. Therefore, I need to be able to conditionally use a different DotLiquid configuration for each schema.

**2. Validation**: My application supports editing entities through a REST API, so I need to validate their contents so that they don't break at run time. I've found that the best way to do this is by registering fake tags that, instead of fully running their production code, just verify the integrity of their contents and configuration.

**3. Testing**: I don't want my unit tests to depend on a global, static, configuration. If I am testing a class, the test configuration should be as isolated and as close to my tests as possible.