### PR TITLE
Adding container (service provider) support for tags initialization

### DIFF
--- a/src/DotLiquid/Block.cs
+++ b/src/DotLiquid/Block.cs
@@ -41,7 +41,7 @@ namespace DotLiquid
 						Type tagType;
 						if ((tagType = Template.GetTagType(fullTokenMatch.Groups[1].Value)) != null)
 						{
-							Tag tag = (Tag) Activator.CreateInstance(tagType);
+							Tag tag = (Tag)Template.ServiceProvider.GetService(tagType);
 							tag.Initialize(fullTokenMatch.Groups[1].Value, fullTokenMatch.Groups[2].Value, tokens);
 							NodeList.Add(tag);
 

--- a/src/DotLiquid/DotLiquid.csproj
+++ b/src/DotLiquid/DotLiquid.csproj
@@ -47,9 +47,11 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Providers\ActivatorServiceProvider.cs" />
     <Compile Include="FileSystems\EmbeddedFileSystem.cs" />
     <Compile Include="IValueTypeConvertible.cs" />
     <Compile Include="LiquidTypeAttribute.cs" />
+    <Compile Include="Providers\FuncServiceProvider.cs" />
     <Compile Include="RenderParameters.cs" />
     <Compile Include="Tags\Raw.cs" />
     <Compile Include="Util\StrFTime.cs" />

--- a/src/DotLiquid/Providers/ActivatorServiceProvider.cs
+++ b/src/DotLiquid/Providers/ActivatorServiceProvider.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace DotLiquid.Providers
+{
+    public class ActivatorServiceProvider : IServiceProvider
+    {
+        public object GetService(Type serviceType)
+        {
+            return Activator.CreateInstance(serviceType);
+        }
+    }
+}

--- a/src/DotLiquid/Providers/FuncServiceProvider.cs
+++ b/src/DotLiquid/Providers/FuncServiceProvider.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace DotLiquid.Providers
+{
+    public class FuncServiceProvider : IServiceProvider
+    {
+        private readonly Func<Type, object> _serviceProvider;
+
+        public FuncServiceProvider(Func<Type,object> serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public object GetService(Type serviceType)
+        {
+            return _serviceProvider(serviceType);
+        }
+    }
+}

--- a/src/DotLiquid/Template.cs
+++ b/src/DotLiquid/Template.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using DotLiquid.FileSystems;
+using DotLiquid.Providers;
 using DotLiquid.Util;
 using DotLiquid.NamingConventions;
 
@@ -30,7 +31,7 @@ namespace DotLiquid
 		private static Dictionary<string, Type> Tags { get; set; }
         private static readonly Dictionary<Type, Func<object, object>> SafeTypeTransformers;
 		private static readonly Dictionary<Type, Func<object, object>> ValueTypeTransformers;
-
+	    public static IServiceProvider ServiceProvider {  get; private set; }
 		static Template()
 		{
 			NamingConvention = new RubyNamingConvention();
@@ -38,6 +39,7 @@ namespace DotLiquid
 			Tags = new Dictionary<string, Type>();
             SafeTypeTransformers = new Dictionary<Type, Func<object, object>>();
 			ValueTypeTransformers = new Dictionary<Type, Func<object, object>>();
+		    ServiceProvider = new ActivatorServiceProvider();
 		}
 
 		public static void RegisterTag<T>(string name)
@@ -45,6 +47,16 @@ namespace DotLiquid
 		{
 			Tags[name] = typeof(T);
 		}
+
+	    public static void RegisterServiceProvider(IServiceProvider serviceProvider)
+	    {
+	        ServiceProvider = ServiceProvider;
+	    }
+
+        public static void RegisterServiceProvider(Func<Type,object> serviceProvider)
+        {
+            ServiceProvider = new FuncServiceProvider(serviceProvider);
+        }
 
 		public static Type GetTagType(string name)
 		{

--- a/src/DotLiquid/Template.cs
+++ b/src/DotLiquid/Template.cs
@@ -43,7 +43,7 @@ namespace DotLiquid
 		}
 
 		public static void RegisterTag<T>(string name)
-			where T : Tag, new()
+			where T : Tag
 		{
 			Tags[name] = typeof(T);
 		}


### PR DESCRIPTION
Added container enables user to create more complex tags and blocks without relying to much on building dynamic hash tables. 