### PR TITLE
Break and continue tags

### DIFF
--- a/src/DotLiquid.Tests/ExceptionHandlingTests.cs
+++ b/src/DotLiquid.Tests/ExceptionHandlingTests.cs
@@ -17,6 +17,11 @@ namespace DotLiquid.Tests
 			{
 				throw new SyntaxException("syntax exception");
 			}
+
+		    public void InterruptException()
+		    {
+		        throw new InterruptException("interrupted");
+		    }
 		}
 
 		[Test]
@@ -59,5 +64,16 @@ namespace DotLiquid.Tests
 			Assert.AreEqual(1, template.Errors.Count);
 			Assert.IsInstanceOf<ArgumentException>(template.Errors[0]);
 		}
+
+	    [Test]
+	    public void TestInterruptException()
+	    {
+	        Template template = null;
+	        Assert.DoesNotThrow(() => { template = Template.Parse(" {{ errors.interrupt_exception }} "); });
+	        var localVariables = Hash.FromAnonymousObject(new {errors = new ExceptionDrop()});
+	        var exception = Assert.Throws<InterruptException>(() => template.Render(localVariables));
+
+            Assert.AreEqual("interrupted", exception.Message);
+	    }
 	}
 }

--- a/src/DotLiquid.Tests/Tags/StandardTagTests.cs
+++ b/src/DotLiquid.Tests/Tags/StandardTagTests.cs
@@ -239,6 +239,40 @@ namespace DotLiquid.Tests.Tags
 			Helper.AssertTemplateResult(expected, markup, assigns);
 		}
 
+        [Test]
+        public void TestForWithBreak()
+        {
+            var assigns = Hash.FromAnonymousObject(new { array = new { items = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 } } });
+            var markup = "{% for i in array.items %}{{ i }}{% if i > 3 %}{% break %}{% endif %}{% endfor %}";
+            var expected = "1234";
+            Helper.AssertTemplateResult(expected, markup, assigns);
+        }
+
+        [Test]
+        public void TestForWithContinue()
+        {
+            var assigns = Hash.FromAnonymousObject(new { array = new { items = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 } } });
+            var markup = "{% for i in array.items %}{% if i == 3 %}{% continue %}{% endif %}{{ i }}{% endfor %}";
+            var expected = "1245678910";
+            Helper.AssertTemplateResult(expected, markup, assigns);
+        }
+
+        [Test]
+        public void TestBreakOutsideFor()
+        {
+            var markup = "123{% break %}456";
+            var expected = "123";
+            Helper.AssertTemplateResult(expected, markup);
+        }
+
+        [Test]
+        public void TestContinueOutsideFor()
+        {
+        var markup = "123{% continue %}456";
+        var expected = "123";
+        Helper.AssertTemplateResult(expected, markup);
+        }
+
 		[Test]
 		public void TestAssign()
 		{

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -64,6 +64,9 @@ namespace DotLiquid
 
 		public string HandleError(Exception ex)
 		{
+		    if (ex is InterruptException)
+		        throw ex;
+
 			Errors.Add(ex);
 			if (_rethrowErrors)
 				throw ex;

--- a/src/DotLiquid/Document.cs
+++ b/src/DotLiquid/Document.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.IO;
+using DotLiquid.Exceptions;
 
 namespace DotLiquid
 {
@@ -29,5 +31,19 @@ namespace DotLiquid
 		protected override void AssertMissingDelimitation()
 		{
 		}
+
+	    public override void Render(Context context, TextWriter result)
+	    {
+	        try
+	        {
+	            base.Render(context, result);
+	        }
+	        catch (BreakInterrupt)
+	        {
+	        }
+	        catch (ContinueInterrupt)
+	        {
+	        }
+	    }
 	}
 }

--- a/src/DotLiquid/DotLiquid.csproj
+++ b/src/DotLiquid/DotLiquid.csproj
@@ -52,6 +52,8 @@
     <Compile Include="IValueTypeConvertible.cs" />
     <Compile Include="LiquidTypeAttribute.cs" />
     <Compile Include="RenderParameters.cs" />
+    <Compile Include="Tags\Break.cs" />
+    <Compile Include="Tags\Continue.cs" />
     <Compile Include="Tags\Raw.cs" />
     <Compile Include="Util\StrFTime.cs" />
     <Compile Include="Exceptions\ArgumentException.cs" />

--- a/src/DotLiquid/DotLiquid.csproj
+++ b/src/DotLiquid/DotLiquid.csproj
@@ -47,6 +47,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Exceptions\InterruptException.cs" />
     <Compile Include="FileSystems\EmbeddedFileSystem.cs" />
     <Compile Include="IValueTypeConvertible.cs" />
     <Compile Include="LiquidTypeAttribute.cs" />

--- a/src/DotLiquid/Exceptions/InterruptException.cs
+++ b/src/DotLiquid/Exceptions/InterruptException.cs
@@ -6,4 +6,20 @@
         {
         }
     }
+
+    public class BreakInterrupt : InterruptException
+    {
+        public BreakInterrupt()
+            : base("Misplaced 'break' statement")
+        {
+        }
+    }
+
+    public class ContinueInterrupt : InterruptException
+    {
+        public ContinueInterrupt()
+            : base("Misplaced 'continue' statement")
+        {
+        }
+    }
 }

--- a/src/DotLiquid/Exceptions/InterruptException.cs
+++ b/src/DotLiquid/Exceptions/InterruptException.cs
@@ -1,0 +1,9 @@
+﻿namespace DotLiquid.Exceptions
+{
+    public class InterruptException : LiquidException
+    {
+        public InterruptException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/src/DotLiquid/Liquid.cs
+++ b/src/DotLiquid/Liquid.cs
@@ -49,6 +49,8 @@ namespace DotLiquid
 			Template.RegisterTag<Tags.Cycle>("cycle");
 			Template.RegisterTag<Tags.Extends>("extends");
 			Template.RegisterTag<Tags.For>("for");
+			Template.RegisterTag<Tags.Break>("break");
+			Template.RegisterTag<Tags.Continue>("continue");
 			Template.RegisterTag<Tags.If>("if");
 			Template.RegisterTag<Tags.IfChanged>("ifchanged");
 			Template.RegisterTag<Tags.Include>("include");

--- a/src/DotLiquid/Tags/Break.cs
+++ b/src/DotLiquid/Tags/Break.cs
@@ -1,0 +1,13 @@
+﻿using System.IO;
+using DotLiquid.Exceptions;
+
+namespace DotLiquid.Tags
+{
+    public class Break : Tag
+    {
+        public override void Render(Context context, TextWriter result)
+        {
+            throw new BreakInterrupt();
+        }
+    }
+}

--- a/src/DotLiquid/Tags/Continue.cs
+++ b/src/DotLiquid/Tags/Continue.cs
@@ -1,0 +1,13 @@
+﻿using System.IO;
+using DotLiquid.Exceptions;
+
+namespace DotLiquid.Tags
+{
+    public class Continue : Tag
+    {
+        public override void Render(Context context, TextWriter result)
+        {
+            throw new ContinueInterrupt();
+        }
+    }
+}

--- a/src/DotLiquid/Tags/For.cs
+++ b/src/DotLiquid/Tags/For.cs
@@ -111,22 +111,36 @@ namespace DotLiquid.Tags
 			// Store our progress through the collection for the continue flag
 			context.Registers.Get<Hash>("for")[_name] = from + length;
 
-			context.Stack(() => segment.EachWithIndex((item, index) =>
-			{
-				context[_variableName] = item;
-				context["forloop"] = Hash.FromAnonymousObject(new
-				{
-					name = _name,
-					length = length,
-					index = index + 1,
-					index0 = index,
-					rindex = length - index,
-					rindex0 = length - index - 1,
-					first = (index == 0),
-					last = (index == length - 1)
-				});
-				RenderAll(NodeList, context, result);
-			}));
+		    context.Stack(() =>
+		    {
+		        for (var index = 0; index < segment.Count; index++)
+		        {
+		            var item = segment[index];
+		            context[_variableName] = item;
+		            context["forloop"] = Hash.FromAnonymousObject(new
+		            {
+		                name = _name,
+		                length = length,
+		                index = index + 1,
+		                index0 = index,
+		                rindex = length - index,
+		                rindex0 = length - index - 1,
+		                first = (index == 0),
+		                last = (index == length - 1)
+		            });
+		            try
+		            {
+		                RenderAll(NodeList, context, result);
+		            }
+		            catch (BreakInterrupt)
+		            {
+		                break;
+		            }
+		            catch (ContinueInterrupt)
+		            {
+		            }
+		        }
+		    });
 		}
 
 		private static List<object> SliceCollectionUsingEach(IEnumerable collection, int from, int? to)


### PR DESCRIPTION
Fixes #100. Here is the change summary:

**New exception**: `InterruptException` - this allows interruptions to be sent from anywhere. This exception, and any other that inherits from it, will not be caught by the template rendering, no matter if `RethrowErrors` is set to `True` or `False`.

**New tag**: `break` - this will act as a normal `break` statement inside a `for` loop, interrupting its execution.

**New tag**: `continue` - this will act as a normal `continue` statement inside a `for` loop, interrupting the current iteration and continuing to the next.

Both `break` and `continue` tags, if used outside of a `for` loop, wiil abort the entire rendering, without any errors.