### PR TITLE
Add support for displaying and comparing enums

### DIFF
--- a/src/DotLiquid/Condition.cs
+++ b/src/DotLiquid/Condition.cs
@@ -117,6 +117,15 @@ namespace DotLiquid
 				}
 				catch (Exception)
 				{
+                    // If an exception occurred trying to convert right's type to left, 
+                    // try to change the left's type to the right
+                    try
+                    {
+                        left = Convert.ChangeType(left, right.GetType());
+                    }
+                    catch (Exception)
+                    {
+                    }
 				}
 			}
 

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -415,6 +415,8 @@ namespace DotLiquid
 				return obj;
 			if (obj is Guid)
 				return obj;
+            if (obj is Enum)
+                return obj;
 			if (TypeUtility.IsAnonymousType(obj.GetType()))
 				return obj;
 			if (obj is KeyValuePair<string, object>)


### PR DESCRIPTION
Currently whenever an Enum property is used in dotliquid it results in a 'Liquid syntax error'. This fixes that. For example, given the following classes: 

    public class Person
    {
        public string NickName { get; set; }
        public Gender Gender {get; set; }
    }
    public enum Gender
    {
        Unknown = 0,
        Male = 1,
        Female = 2
    }

And the following liquid template:

	<p>Output the Name: {{ Person.NickName }}</p>
	<p>Output the Gender: {{ Person.Gender }}</p>
	<p> Enum First Compare say's "{% if Person.Gender == 'Male' %}he's a Dude!{% else %}NOT a Dude!{% endif %}"</p>
	<p> Enum Second Compare say's "{% if 'Male' == Person.Gender %}he's a Dude!{% else %}NOT a Dude!{% endif %}"</p>

The current result is:

	Output the Name: David
	Output the Gender: Liquid syntax error: Object 'Male' is invalid because it is neither a built-in type nor implements ILiquidizable
	Enum First Compare say's "Liquid syntax error: Object 'Male' is invalid because it is neither a built-in type nor implements ILiquidizable"
	Enum Second Compare say's "Liquid syntax error: Object 'Male' is invalid because it is neither a built-in type nor implements ILiquidizable"

Adding the check for Enum in the Liquidize(object obj) method of Context.cs fixes the display, but there's still an issue when comparing (with Enum on left side of compare):

	Output the Name: David
	Output the Gender: Male
	Enum First Compare say's "NOT a Dude!"
	Enum Second Compare say's "he's a Dude!"

Updating the EqualVariables(object left, object right) method in Condition.cs fixes the compare issue:

    Output the Name: David
    Output the Gender: Male
    Enum First Compare say's "he's a Dude!"
    Enum Second Compare say's "he's a Dude!"

