### PR TITLE
Added ability so Slice can deal with negative offsets

### DIFF
--- a/src/DotLiquid.Tests/FilterTests.cs
+++ b/src/DotLiquid.Tests/FilterTests.cs
@@ -212,6 +212,7 @@ namespace DotLiquid.Tests
             Assert.AreEqual("bl", new Variable("var | slice: 0, 2").Render(_context));
             Assert.AreEqual("l", new Variable("var | slice: 1").Render(_context));
             Assert.AreEqual("", new Variable("var | slice: 4, 1").Render(_context));
+            Assert.AreEqual("ub", new Variable("var | slice: -2, 2").Render(_context));
             Assert.AreEqual(null, new Variable("var | slice: 5, 1").Render(_context));
         }
 

--- a/src/DotLiquid/StandardFilters.cs
+++ b/src/DotLiquid/StandardFilters.cs
@@ -42,6 +42,8 @@ namespace DotLiquid
         {
             if (input == null || start > input.Length)
                 return null;
+            if (start < 0)
+                start += input.Length;
             if (start + len > input.Length)
                 len = input.Length - start;
             return input.Substring(start, len);


### PR DESCRIPTION
When you go to https://github.com/Shopify/liquid/wiki/Liquid-for-Designers, you can see that "slice" function should be able to deal with negative offsets as well.