### PR TITLE
Ensured that numbers are output using the format provider of the current...

### DIFF
--- a/src/DotLiquid.Tests/OutputTests.cs
+++ b/src/DotLiquid.Tests/OutputTests.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.IO;
 using NUnit.Framework;
 
 namespace DotLiquid.Tests
@@ -64,7 +66,8 @@ namespace DotLiquid.Tests
 			_assigns = Hash.FromAnonymousObject(new
 			{
 				best_cars = "bmw",
-				car = Hash.FromAnonymousObject(new { bmw = "good", gm = "bad" })
+				car = Hash.FromAnonymousObject(new { bmw = "good", gm = "bad" }),
+                number = 3.145
 			});
 		}
 
@@ -133,5 +136,35 @@ namespace DotLiquid.Tests
 		{
 			Assert.AreEqual(" <a href=\"http://typo.leetsoft.com\">Typo</a> ", Template.Parse(" {{ 'Typo' | link_to: 'http://typo.leetsoft.com' }} ").Render(new RenderParameters { LocalVariables = _assigns, Filters = new[] { typeof(FunnyFilter) } }));
 		}
+
+        string Render(CultureInfo culture)
+	    {
+
+            var renderParams = new RenderParameters()
+            {
+                LocalVariables = _assigns 
+            };
+	        using (var writer = new StringWriter(culture))
+	        {
+	            Template.Parse("{{number}}").Render(writer, renderParams);
+	            return writer.ToString();
+	        }
+	        
+	    }
+
+	    [Test]
+	    public void TestCulture()
+	    {
+	        Assert.AreEqual(Render(CultureInfo.InvariantCulture), "3.145");
+
+            NumberFormatInfo nfi = new NumberFormatInfo();
+            nfi.NumberDecimalSeparator = ",";
+	        var c = new CultureInfo("en-US")
+	        {
+	            NumberFormat = nfi
+	        };
+	        Assert.AreEqual(Render(c), "3,145");
+	        
+	    }
 	}
 }

--- a/src/DotLiquid/Variable.cs
+++ b/src/DotLiquid/Variable.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -80,8 +81,13 @@ namespace DotLiquid
 				else if (output is bool)
 					outputString = output.ToString().ToLower();
 				else
-					outputString = output.ToString();
-				result.Write(outputString);
+				{
+				    var formatable = output as IFormattable;
+                    outputString = formatable != null
+                        ? formatable.ToString(null, result.FormatProvider)
+                        : output.ToString();
+				}
+			    result.Write(outputString);
 			}
 		}
 


### PR DESCRIPTION
On my dev machine the culture is german and by default all numbers are printed like

    3,14159
    
however my template was output to a file that should use the invariant culture. Numbers
should use decimal points like

    3.14159
    
Previous to this fix numbers were being output using

   output.ToString()
   
with no format provider passed. Thus the current culture would be used.
    
This fix ensures the numbers are output using the same format provider as stored in the textwriter used to generate the output.