### PR TITLE
Make cols attribute of tablerow tag optional

### DIFF
--- a/src/DotLiquid.Tests/Tags/Html/TableRowTests.cs
+++ b/src/DotLiquid.Tests/Tags/Html/TableRowTests.cs
@@ -38,6 +38,15 @@ namespace DotLiquid.Tests.Tags.Html
 		}
 
 		[Test]
+		public void TestHtmlNoColCounter()
+		{
+			Helper.AssertTemplateResult(
+				string.Format("<tr class=\"row1\">{0}<td class=\"col1\">1</td><td class=\"col2\">2</td><td class=\"col3\">3</td><td class=\"col4\">4</td><td class=\"col5\">5</td><td class=\"col6\">6</td></tr>{0}", Environment.NewLine),
+				"{% tablerow n in numbers %}{{tablerowloop.col}}{% endtablerow %}",
+				Hash.FromAnonymousObject(new { numbers = new[] { 1, 2, 3, 4, 5, 6 } }));
+		}
+
+		[Test]
 		public void TestHtmlOffsetLimit()
 		{
 			Helper.AssertTemplateResult(

--- a/src/DotLiquid/Tags/Html/TableRow.cs
+++ b/src/DotLiquid/Tags/Html/TableRow.cs
@@ -56,7 +56,11 @@ namespace DotLiquid.Tags.Html
 			collection = collection.ToList();
 			int length = collection.Count();
 
-			int cols = Convert.ToInt32(context[_attributes["cols"]]);
+			int cols = length;
+			if (_attributes.ContainsKey("cols"))
+			{
+				cols = Convert.ToInt32(context[_attributes["cols"]]);
+			}
 
 			int row = 1;
 			int col = 0;


### PR DESCRIPTION
Not specifying the "cols" attribute of "tablerow" was resulting in the error message "Liquid error: The given key was not present in the dictionary." appearing in the rendered content.
