### PR TITLE
Fixed Issue with 'An item with the same key has already been added.' #164 

### DIFF
--- a/src/DotLiquid/Drop.cs
+++ b/src/DotLiquid/Drop.cs
@@ -19,11 +19,14 @@ namespace DotLiquid
             // Cache all methods and properties of this object, but don't include those 
 			// defined at or above the base Drop class.
             const BindingFlags bindingFlags = BindingFlags.Public | BindingFlags.Instance;
-    		CachedMethods = GetMemberDictionary(
-				type.GetMethods(bindingFlags).Where(mi => mi.GetParameters().Length == 0),
-				mi => filterMemberCallback(mi));
-            CachedProperties = GetMemberDictionary(type.GetProperties(bindingFlags),
-				mi => filterMemberCallback(mi));
+    		CachedMethods = GetMemberDictionary(type.GetMethods(bindingFlags)
+                                                    .Where(mi => mi.GetParameters().Length == 0
+                                                                && mi.DeclaringType == type),
+                                                mi => filterMemberCallback(mi));
+
+            CachedProperties = GetMemberDictionary(type.GetProperties(bindingFlags)
+                                                       .Where(pi => pi.DeclaringType == type),
+                    mi => filterMemberCallback(mi));
         }
 
 		private Dictionary<string, T> GetMemberDictionary<T>(IEnumerable<T> members,


### PR DESCRIPTION
Fixed Issue with 'An item with the same key has already been added.' #164 

Both methods and props have to be checked on  mi.DeclaringType == type - meaning, only CURRENT entity props/methods.

If not, then a duplicated of the members / methods can be included into the result dictionary for the following POCOs:
```
  public class Entity 
    {
        public string Name { get; set; }
    } 

 public class MyEntity :Entity
    {
        public new string Name { get; set; }
    }
```