### PR TITLE
Fix issue with RubyNamingConvention when the Culture is set to Turkish

### DIFF
--- a/src/DotLiquid.Tests/NamingConventionTests.cs
+++ b/src/DotLiquid.Tests/NamingConventionTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using DotLiquid.NamingConventions;
 using NUnit.Framework;
 
@@ -34,8 +35,20 @@ namespace DotLiquid.Tests
 			Assert.AreEqual("id", namingConvention.GetMemberName("ID"));
 			Assert.AreEqual("hellocruelworld", namingConvention.GetMemberName("HELLOCRUELWORLD"));
 		}
+        
+        [Test]
+        public void TestRubyWithTurkishCulture()
+        {
+            System.Threading.Thread.CurrentThread.CurrentCulture =
+             System.Threading.Thread.CurrentThread.CurrentUICulture = new CultureInfo("tr-TR");
 
-		[Test]
+            RubyNamingConvention namingConvention = new RubyNamingConvention();
+
+            // in Turkish ID.ToLower() returns a localized i, and this fails
+            Assert.AreEqual("id", namingConvention.GetMemberName("ID"));
+        }
+
+        [Test]
 		public void TestCSharpConventionDoesNothing()
 		{
 			CSharpNamingConvention namingConvention = new CSharpNamingConvention();

--- a/src/DotLiquid/NamingConventions/RubyNamingConvention.cs
+++ b/src/DotLiquid/NamingConventions/RubyNamingConvention.cs
@@ -26,7 +26,7 @@ namespace DotLiquid.NamingConventions
 		public string GetMemberName(string name)
 		{
 			// Replace any capital letters, apart from the first character, with _x, the same way Ruby does
-			return _regex2.Replace(_regex1.Replace(name, "$1_$2"), "$1_$2").ToLower();
+			return _regex2.Replace(_regex1.Replace(name, "$1_$2"), "$1_$2").ToLowerInvariant();
 		}
 	}
 }


### PR DESCRIPTION
When the underlying Thread culture is set to Turkish, the RubyNamingConvention returns unexpected results in some cases. I detected the problem with turkish language, but it seems posible to happen with another. 

Added a test to simulate the issue, and a easy fix that solves, using ToLowerInvariant instead ToLower.

