### PR TITLE
Jyeohamilton/lockcontentionfix

### DIFF
--- a/src/DotLiquid.Tests/DotLiquid.Tests.csproj
+++ b/src/DotLiquid.Tests/DotLiquid.Tests.csproj
@@ -95,6 +95,9 @@
     <None Include="Formosatek-OpenSource.snk" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/DotLiquid.Tests/RegexpTests.cs
+++ b/src/DotLiquid.Tests/RegexpTests.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
 using DotLiquid.Util;
 using NUnit.Framework;
 
@@ -9,56 +12,61 @@ namespace DotLiquid.Tests
 		[Test]
 		public void TestEmpty()
 		{
-			CollectionAssert.IsEmpty(R.Scan(string.Empty, Liquid.QuotedFragment));
+			CollectionAssert.IsEmpty(Run(string.Empty, Liquid.QuotedFragment));
 		}
 
 		[Test]
 		public void TestQuote()
 		{
-			CollectionAssert.AreEqual(new[] { "\"arg 1\"" }, R.Scan("\"arg 1\"", Liquid.QuotedFragment));
+			CollectionAssert.AreEqual(new[] { "\"arg 1\"" }, Run("\"arg 1\"", Liquid.QuotedFragment));
 		}
 
 		[Test]
 		public void TestWords()
 		{
-			CollectionAssert.AreEqual(new[] { "arg1", "arg2" }, R.Scan("arg1 arg2", Liquid.QuotedFragment));
+			CollectionAssert.AreEqual(new[] { "arg1", "arg2" }, Run("arg1 arg2", Liquid.QuotedFragment));
 		}
 
 		[Test]
 		public void TestTags()
 		{
-			CollectionAssert.AreEqual(new[] { "<tr>", "</tr>" }, R.Scan("<tr> </tr>", Liquid.QuotedFragment));
-			CollectionAssert.AreEqual(new[] { "<tr></tr>" }, R.Scan("<tr></tr>", Liquid.QuotedFragment));
-			CollectionAssert.AreEqual(new[] { "<style", "class=\"hello\">", "</style>" }, R.Scan("<style class=\"hello\">' </style>", Liquid.QuotedFragment));
+			CollectionAssert.AreEqual(new[] { "<tr>", "</tr>" }, Run("<tr> </tr>", Liquid.QuotedFragment));
+			CollectionAssert.AreEqual(new[] { "<tr></tr>" }, Run("<tr></tr>", Liquid.QuotedFragment));
+			CollectionAssert.AreEqual(new[] { "<style", "class=\"hello\">", "</style>" }, Run("<style class=\"hello\">' </style>", Liquid.QuotedFragment));
 		}
 
 		[Test]
 		public void TestQuotedWords()
 		{
-			CollectionAssert.AreEqual(new[] { "arg1", "arg2", "\"arg 3\"" }, R.Scan("arg1 arg2 \"arg 3\"", Liquid.QuotedFragment));
+			CollectionAssert.AreEqual(new[] { "arg1", "arg2", "\"arg 3\"" }, Run("arg1 arg2 \"arg 3\"", Liquid.QuotedFragment));
 		}
 
 		[Test]
 		public void TestQuotedWords2()
 		{
-			CollectionAssert.AreEqual(new[] { "arg1", "arg2", "'arg 3'" }, R.Scan("arg1 arg2 'arg 3'", Liquid.QuotedFragment));
+			CollectionAssert.AreEqual(new[] { "arg1", "arg2", "'arg 3'" }, Run("arg1 arg2 'arg 3'", Liquid.QuotedFragment));
 		}
 
 		[Test]
 		public void TestQuotedWordsInTheMiddle()
 		{
-			CollectionAssert.AreEqual(new[] { "arg1", "arg2", "\"arg 3\"", "arg4" }, R.Scan("arg1 arg2 \"arg 3\" arg4", Liquid.QuotedFragment));
+			CollectionAssert.AreEqual(new[] { "arg1", "arg2", "\"arg 3\"", "arg4" }, Run("arg1 arg2 \"arg 3\" arg4", Liquid.QuotedFragment));
 		}
 
 		[Test]
 		public void TestVariableParser()
 		{
-			CollectionAssert.AreEqual(new[] { "var" }, R.Scan("var", Liquid.VariableParser));
-			CollectionAssert.AreEqual(new[] { "var", "method" }, R.Scan("var.method", Liquid.VariableParser));
-			CollectionAssert.AreEqual(new[] { "var", "[method]" }, R.Scan("var[method]", Liquid.VariableParser));
-			CollectionAssert.AreEqual(new[] { "var", "[method]", "[0]" }, R.Scan("var[method][0]", Liquid.VariableParser));
-			CollectionAssert.AreEqual(new[] { "var", "[\"method\"]", "[0]" }, R.Scan("var[\"method\"][0]", Liquid.VariableParser));
-			CollectionAssert.AreEqual(new[] { "var", "[method]", "[0]", "method" }, R.Scan("var[method][0].method", Liquid.VariableParser));
+			CollectionAssert.AreEqual(new[] { "var" }, Run("var", Liquid.VariableParser));
+			CollectionAssert.AreEqual(new[] { "var", "method" }, Run("var.method", Liquid.VariableParser));
+			CollectionAssert.AreEqual(new[] { "var", "[method]" }, Run("var[method]", Liquid.VariableParser));
+			CollectionAssert.AreEqual(new[] { "var", "[method]", "[0]" }, Run("var[method][0]", Liquid.VariableParser));
+			CollectionAssert.AreEqual(new[] { "var", "[\"method\"]", "[0]" }, Run("var[\"method\"][0]", Liquid.VariableParser));
+			CollectionAssert.AreEqual(new[] { "var", "[method]", "[0]", "method" }, Run("var[method][0].method", Liquid.VariableParser));
 		}
+
+	    private static List<string> Run(string input, string pattern)
+	    {
+	        return R.Scan(input, new Regex(pattern));
+	    }
 	}
 }

--- a/src/DotLiquid.Website.Tests/DotLiquid.Website.Tests.csproj
+++ b/src/DotLiquid.Website.Tests/DotLiquid.Website.Tests.csproj
@@ -83,6 +83,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/DotLiquid/Block.cs
+++ b/src/DotLiquid/Block.cs
@@ -9,11 +9,11 @@ namespace DotLiquid
 {
 	public class Block : Tag
 	{
-		private static readonly Regex IsTag = new Regex(string.Format(@"^{0}", Liquid.TagStart));
-		private static readonly Regex IsVariable = new Regex(string.Format(@"^{0}", Liquid.VariableStart));
-		private static readonly Regex ContentOfVariable = new Regex(string.Format(@"^{0}(.*){1}$", Liquid.VariableStart, Liquid.VariableEnd));
+		private static readonly Regex IsTag = R.B(@"^{0}", Liquid.TagStart);
+		private static readonly Regex IsVariable = R.B(@"^{0}", Liquid.VariableStart);
+		private static readonly Regex ContentOfVariable = R.B(@"^{0}(.*){1}$", Liquid.VariableStart, Liquid.VariableEnd);
 
-		internal static readonly Regex FullToken = new Regex(string.Format(@"^{0}\s*(\w+)\s*(.*)?{1}$", Liquid.TagStart, Liquid.TagEnd));
+		internal static readonly Regex FullToken = R.B(@"^{0}\s*(\w+)\s*(.*)?{1}$", Liquid.TagStart, Liquid.TagEnd);
 
 		protected override void Parse(List<string> tokens)
 		{

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -359,7 +359,7 @@ namespace DotLiquid
 
 			if ((obj is IDictionary && ((IDictionary) obj).Contains(part)))
 				return true;
-			
+
 			if ((obj is IList) && (part is int))
 				return true;
 

--- a/src/DotLiquid/NamingConventions/RubyNamingConvention.cs
+++ b/src/DotLiquid/NamingConventions/RubyNamingConvention.cs
@@ -17,8 +17,8 @@ namespace DotLiquid.NamingConventions
 	/// </example>
 	public class RubyNamingConvention : INamingConvention
 	{
-		private readonly Regex _regex1 = R.C(@"([A-Z]+)([A-Z][a-z])");
-		private readonly Regex _regex2 = R.C(@"([a-z\d])([A-Z])");
+		private static readonly Regex _regex1 = R.C(@"([A-Z]+)([A-Z][a-z])");
+		private static readonly Regex _regex2 = R.C(@"([a-z\d])([A-Z])");
 
 		public StringComparer StringComparer
 		{

--- a/src/DotLiquid/NamingConventions/RubyNamingConvention.cs
+++ b/src/DotLiquid/NamingConventions/RubyNamingConvention.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Text.RegularExpressions;
 
+using DotLiquid.Util;
+
 namespace DotLiquid.NamingConventions
 {
 	/// <summary>
@@ -15,8 +17,8 @@ namespace DotLiquid.NamingConventions
 	/// </example>
 	public class RubyNamingConvention : INamingConvention
 	{
-		private readonly Regex _regex1 = new Regex(@"([A-Z]+)([A-Z][a-z])");
-		private readonly Regex _regex2 = new Regex(@"([a-z\d])([A-Z])");
+		private readonly Regex _regex1 = R.C(@"([A-Z]+)([A-Z][a-z])");
+		private readonly Regex _regex2 = R.C(@"([a-z\d])([A-Z])");
 
 		public StringComparer StringComparer
 		{

--- a/src/DotLiquid/Tags/Block.cs
+++ b/src/DotLiquid/Tags/Block.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
 using DotLiquid.Exceptions;
+using DotLiquid.Util;
 
 namespace DotLiquid.Tags
 {
@@ -62,7 +63,7 @@ namespace DotLiquid.Tags
 	/// </summary>
 	public class Block : DotLiquid.Block
 	{
-		private static readonly Regex Syntax = new Regex(@"(\w+)");
+		private static readonly Regex Syntax = R.C(@"(\w+)");
 
 		internal string BlockName { get; set; }
 

--- a/src/DotLiquid/Tags/Capture.cs
+++ b/src/DotLiquid/Tags/Capture.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using DotLiquid.Exceptions;
+using DotLiquid.Util;
 
 namespace DotLiquid.Tags
 {
@@ -21,7 +22,7 @@ namespace DotLiquid.Tags
 	/// </summary>
 	public class Capture : DotLiquid.Block
 	{
-		private static readonly Regex Syntax = new Regex(@"(\w+)");
+		private static readonly Regex Syntax = R.C(@"(\w+)");
 
 		private string _to;
 

--- a/src/DotLiquid/Tags/Case.cs
+++ b/src/DotLiquid/Tags/Case.cs
@@ -2,13 +2,14 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
 using DotLiquid.Exceptions;
+using DotLiquid.Util;
 
 namespace DotLiquid.Tags
 {
 	public class Case : DotLiquid.Block
 	{
-		private static readonly Regex Syntax = new Regex(string.Format(@"({0})", Liquid.QuotedFragment));
-		private static readonly Regex WhenSyntax = new Regex(string.Format(@"({0})(?:(?:\s+or\s+|\s*\,\s*)({0}.*))?", Liquid.QuotedFragment));
+		private static readonly Regex Syntax = R.B(@"({0})", Liquid.QuotedFragment);
+		private static readonly Regex WhenSyntax = R.B(@"({0})(?:(?:\s+or\s+|\s*\,\s*)({0}.*))?", Liquid.QuotedFragment);
 
 		private List<Condition> _blocks;
 		private string _left;

--- a/src/DotLiquid/Tags/Comment.cs
+++ b/src/DotLiquid/Tags/Comment.cs
@@ -1,16 +1,20 @@
 using System.IO;
 using System.Text.RegularExpressions;
 
+using DotLiquid.Util;
+
 namespace DotLiquid.Tags
 {
 	public class Comment : DotLiquid.Block
 	{
+		private static readonly Regex ShortHandRegex = R.C(Liquid.CommentShorthand);
+
 		public static string FromShortHand(string @string)
 		{
 			if (@string == null)
 				return @string;
 
-			Match match = Regex.Match(@string, Liquid.CommentShorthand);
+			Match match = ShortHandRegex.Match(@string);
 			return match.Success ? string.Format(@"{{% comment %}}{0}{{% endcomment %}}", match.Groups[1].Value) : @string;
 		}
 

--- a/src/DotLiquid/Tags/Cycle.cs
+++ b/src/DotLiquid/Tags/Cycle.cs
@@ -22,8 +22,9 @@ namespace DotLiquid.Tags
 	/// </summary>
 	public class Cycle : Tag
 	{
-		private static readonly Regex SimpleSyntax = R.B(R.Q(@"^{0}+"), Liquid.QuotedFragment);
+	    private static readonly Regex SimpleSyntax = R.B(R.Q(@"^{0}+"), Liquid.QuotedFragment);
 		private static readonly Regex NamedSyntax = R.B(R.Q(@"^({0})\s*\:\s*(.*)"), Liquid.QuotedFragment);
+	    private static readonly Regex QuotedFragmentRegex = R.B(R.Q(@"\s*({0})\s*"), Liquid.QuotedFragment);
 
 		private string[] _variables;
 		private string _name;
@@ -57,7 +58,7 @@ namespace DotLiquid.Tags
 		{
 			return markup.Split(',').Select(var =>
 			{
-				Match match = Regex.Match(var, string.Format(R.Q(@"\s*({0})\s*"), Liquid.QuotedFragment));
+				Match match = QuotedFragmentRegex.Match(var);
 				return (match.Success && !string.IsNullOrEmpty(match.Groups[1].Value))
 					? match.Groups[1].Value
 					: null;

--- a/src/DotLiquid/Tags/Extends.cs
+++ b/src/DotLiquid/Tags/Extends.cs
@@ -58,7 +58,7 @@ namespace DotLiquid.Tags
 	/// </example>
 	public class Extends : DotLiquid.Block
 	{
-		private static readonly Regex Syntax = new Regex(string.Format(@"^({0})", Liquid.QuotedFragment));
+		private static readonly Regex Syntax = R.B(@"^({0})", Liquid.QuotedFragment);
 
 		private string _templateName;
 
@@ -101,45 +101,45 @@ namespace DotLiquid.Tags
 
 		public override void Render(Context context, TextWriter result)
 		{
-            // Get the template or template content and then either copy it (since it will be modified) or parse it
+			// Get the template or template content and then either copy it (since it will be modified) or parse it
 			IFileSystem fileSystem = context.Registers["file_system"] as IFileSystem ?? Template.FileSystem;
-            object file = fileSystem.ReadTemplateFile(context, _templateName);
-		    Template template = file as Template;
-            template = template ?? Template.Parse(file == null ? null : file.ToString());
+			object file = fileSystem.ReadTemplateFile(context, _templateName);
+			Template template = file as Template;
+			template = template ?? Template.Parse(file == null ? null : file.ToString());
 
-		    List<Block> parentBlocks = FindBlocks(template.Root, null);
-            List<Block> orphanedBlocks = ((List<Block>)context.Scopes[0]["extends"]) ?? new List<Block>();
-		    BlockRenderState blockState = BlockRenderState.Find(context) ?? new BlockRenderState();
+			List<Block> parentBlocks = FindBlocks(template.Root, null);
+			List<Block> orphanedBlocks = ((List<Block>)context.Scopes[0]["extends"]) ?? new List<Block>();
+			BlockRenderState blockState = BlockRenderState.Find(context) ?? new BlockRenderState();
 
-            context.Stack(() =>
-            {
-                context["blockstate"] = blockState;         // Set or copy the block state down to this scope
-                context["extends"] = new List<Block>();     // Holds Blocks that were not found in the parent
-                foreach (Block block in NodeList.OfType<Block>().Concat(orphanedBlocks))
-                {
-                    Block pb = parentBlocks.Find(b => b.BlockName == block.BlockName);
-                    
-                    if (pb != null)
-                    {
-                        Block parent;
-                        if (blockState.Parents.TryGetValue(block, out parent))
-                            blockState.Parents[pb] = parent;
-                        pb.AddParent(blockState.Parents, pb.GetNodeList(blockState));
-                        blockState.NodeLists[pb] = block.GetNodeList(blockState);
-                    }
-                    else if(IsExtending(template))
-                    {
-                        ((List<Block>)context.Scopes[0]["extends"]).Add(block);
-                    }
-                }
-			    template.Render(result, RenderParameters.FromContext(context));
-            });
+			context.Stack(() =>
+			{
+				context["blockstate"] = blockState;         // Set or copy the block state down to this scope
+				context["extends"] = new List<Block>();     // Holds Blocks that were not found in the parent
+				foreach (Block block in NodeList.OfType<Block>().Concat(orphanedBlocks))
+				{
+					Block pb = parentBlocks.Find(b => b.BlockName == block.BlockName);
+					
+					if (pb != null)
+					{
+						Block parent;
+						if (blockState.Parents.TryGetValue(block, out parent))
+							blockState.Parents[pb] = parent;
+						pb.AddParent(blockState.Parents, pb.GetNodeList(blockState));
+						blockState.NodeLists[pb] = block.GetNodeList(blockState);
+					}
+					else if(IsExtending(template))
+					{
+						((List<Block>)context.Scopes[0]["extends"]).Add(block);
+					}
+				}
+				template.Render(result, RenderParameters.FromContext(context));
+			});
 		}
 
-        public bool IsExtending(Template template)
-        {
-            return template.Root.NodeList.Any(node => node is Extends);
-        }
+		public bool IsExtending(Template template)
+		{
+			return template.Root.NodeList.Any(node => node is Extends);
+		}
 
 		private List<Block> FindBlocks(object node, List<Block> blocks)
 		{
@@ -157,10 +157,10 @@ namespace DotLiquid.Tags
 
 						if (block != null)
 						{
-                            if (blocks.All(bl => bl.BlockName != block.BlockName)) blocks.Add(block);
+							if (blocks.All(bl => bl.BlockName != block.BlockName)) blocks.Add(block);
 						}
 						
-                        FindBlocks(n, blocks);
+						FindBlocks(n, blocks);
 					});
 				}
 			}

--- a/src/DotLiquid/Tags/If.cs
+++ b/src/DotLiquid/Tags/If.cs
@@ -22,7 +22,9 @@ namespace DotLiquid.Tags
 	{
 		private string SyntaxHelp = Liquid.ResourceManager.GetString("IfTagSyntaxException");
 		private static readonly Regex Syntax = R.B(R.Q(@"({0})\s*([=!<>a-z_]+)?\s*({0})?"), Liquid.QuotedFragment);
+		
 		private static readonly string ExpressionsAndOperators = string.Format(R.Q(@"(?:\b(?:\s?and\s?|\s?or\s?)\b|(?:\s*(?!\b(?:\s?and\s?|\s?or\s?)\b)(?:{0}|\S+)\s*)+)"), Liquid.QuotedFragment);
+		private static readonly Regex ExpressionsAndOperatorsRegex = R.C(ExpressionsAndOperators);
 
 		protected List<Condition> Blocks { get; private set; }
 
@@ -67,7 +69,7 @@ namespace DotLiquid.Tags
 			}
 			else
 			{
-				List<string> expressions = R.Scan(markup, ExpressionsAndOperators);
+				List<string> expressions = R.Scan(markup, ExpressionsAndOperatorsRegex);
 				expressions.Reverse();
 				string syntax = expressions.Shift();
 				if (string.IsNullOrEmpty(syntax))

--- a/src/DotLiquid/Tags/Include.cs
+++ b/src/DotLiquid/Tags/Include.cs
@@ -11,7 +11,7 @@ namespace DotLiquid.Tags
 {
 	public class Include : DotLiquid.Block
 	{
-		private static readonly Regex Syntax = new Regex(string.Format(@"({0}+)(\s+(?:with|for)\s+({0}+))?", Liquid.QuotedFragment));
+		private static readonly Regex Syntax = R.B(@"({0}+)(\s+(?:with|for)\s+({0}+))?", Liquid.QuotedFragment);
 
 		private string _templateName, _variableName;
 		private Dictionary<string, string> _attributes;

--- a/src/DotLiquid/Tags/Literal.cs
+++ b/src/DotLiquid/Tags/Literal.cs
@@ -21,12 +21,14 @@ namespace DotLiquid.Tags
 	/// </summary>
 	public class Literal : DotLiquid.Block
 	{
+		private static readonly Regex LiteralRegex = R.C(Liquid.LiteralShorthand);
+	
 		public static string FromShortHand(string @string)
 		{
 			if (@string == null)
 				return @string;
 
-			Match match = Regex.Match(@string, Liquid.LiteralShorthand);
+			Match match = LiteralRegex.Match(@string);
 			return match.Success ? string.Format(@"{{% literal %}}{0}{{% endliteral %}}", match.Groups[1].Value) : @string;
 		}
 

--- a/src/DotLiquid/Util/R.cs
+++ b/src/DotLiquid/Util/R.cs
@@ -28,16 +28,31 @@ namespace DotLiquid.Util
 		/// The .NET Regex constructor contains a static cache lookup that requires acquisition of a lock, so in a multithreaded system
 		/// under high load, there will be severe lock contention if regexes are constantly being constructed by different threads.
 		/// Using compiled regexes and making them "static readonly" completely avoids this problem.
-		/// In recent versions of .NET, compiled regexes also generally perform measurably faster than uncompiled ones when used repeatedly.
+		/// In recent versions of .NET, compiled regexes also generally perform measurably faster than uncompiled ones (when used a large number of times).
+		/// There is of course an initial cost for compilation, but the benefits for high-scale applications far outweigh the initial cost and
+		/// low-scale applications are unlikely to care about the difference anyway.
 		/// </summary>
 		/// <param name="pattern">regex pattern</param>
 		/// <param name="options">regex options; use the default (Compiled) unless there is a good reason not to</param>
 		/// <returns>the regex</returns>
 		public static Regex C(string pattern, RegexOptions options = RegexOptions.Compiled)
 		{
-			return new Regex(pattern, options);
+			var regex = new Regex(pattern, options);
+			
+			// execute once to trigger the lazy compilation (not strictly necessary, but avoids the first real execution taking a longer time than subsequent ones)
+			regex.IsMatch(string.Empty);
+
+			return regex;
 		}
 
+		/// <summary>
+		/// Scan the input text finding all matches for the given regex.
+		/// Passing in the regex instead of the pattern avoids problems with Regex construction.
+		/// See associated comments above for the C() method.
+		/// </summary>
+		/// <param name="input">input text</param>
+		/// <param name="regex">regex</param>
+		/// <returns>matches</returns>
 		public static List<string> Scan(string input, Regex regex)
 		{
 			return regex.Matches(input)

--- a/src/DotLiquid/Util/R.cs
+++ b/src/DotLiquid/Util/R.cs
@@ -62,6 +62,19 @@ namespace DotLiquid.Util
 		}
 
 		/// <summary>
+		/// Deprecated for performance reasons. New code should not use this.
+		/// See comments for Scan(string, Regex) above.
+		/// </summary>
+		/// <param name="input">input text</param>
+		/// <param name="pattern">regex pattern</param>
+		/// <returns>matches</returns>
+		[Obsolete("Use Scan(string, Regex) instead.")]
+		public static List<string> Scan(string input, string pattern)
+		{
+			return Scan(input, new Regex(pattern));
+		}
+
+		/// <summary>
 		/// Overload that only works when the pattern contains two groups. The callback
 		/// is called for each match, passing the two group values.
 		/// </summary>

--- a/src/DotLiquid/Variable.cs
+++ b/src/DotLiquid/Variable.cs
@@ -21,7 +21,11 @@ namespace DotLiquid
 	/// </summary>
 	public class Variable : IRenderable
 	{
-		public static readonly string FilterParser = string.Format(R.Q(@"(?:{0}|(?:\s*(?!(?:{0}))(?:{1}|\S+)\s*)+)"), Liquid.FilterSeparator, Liquid.QuotedFragment);
+		private static readonly Regex FilterParserRegex = R.B(R.Q(@"(?:{0}|(?:\s*(?!(?:{0}))(?:{1}|\S+)\s*)+)"), Liquid.FilterSeparator, Liquid.QuotedFragment);
+		private static readonly Regex FilterArgRegex = R.B(R.Q(@"(?:{0}|{1})\s*({2})"), Liquid.FilterArgumentSeparator, Liquid.ArgumentSeparator, Liquid.QuotedFragment);
+		private static readonly Regex QuotedAssignFragmentRegex = R.B(R.Q(@"\s*({0})(.*)"), Liquid.QuotedAssignFragment);
+		private static readonly Regex FilterSeparatorRegex = R.B(R.Q(@"{0}\s*(.*)"), Liquid.FilterSeparator);
+		private static readonly Regex FilterNameRegex = R.B(R.Q(@"\s*(\w+)"));
 
 		public List<Filter> Filters { get; set; }
 		public string Name { get; set; }
@@ -35,20 +39,20 @@ namespace DotLiquid
 			Name = null;
 			Filters = new List<Filter>();
 
-			Match match = Regex.Match(markup, string.Format(R.Q(@"\s*({0})(.*)"), Liquid.QuotedAssignFragment));
+			Match match = QuotedAssignFragmentRegex.Match(markup);
 			if (match.Success)
 			{
 				Name = match.Groups[1].Value;
-				Match filterMatch = Regex.Match(match.Groups[2].Value, string.Format(R.Q(@"{0}\s*(.*)"), Liquid.FilterSeparator));
+				Match filterMatch = FilterSeparatorRegex.Match(match.Groups[2].Value);
 				if (filterMatch.Success)
 				{
-					foreach (string f in R.Scan(filterMatch.Value, FilterParser))
+					foreach (string f in R.Scan(filterMatch.Value, FilterParserRegex))
 					{
-						Match filterNameMatch = Regex.Match(f, R.Q(@"\s*(\w+)"));
+						Match filterNameMatch = FilterNameRegex.Match(f);
 						if (filterNameMatch.Success)
 						{
 							string filterName = filterNameMatch.Groups[1].Value;
-							List<string> filterArgs = R.Scan(f, string.Format(R.Q(@"(?:{0}|{1})\s*({2})"), Liquid.FilterArgumentSeparator, Liquid.ArgumentSeparator, Liquid.QuotedFragment));
+							List<string> filterArgs = R.Scan(f, FilterArgRegex);
 							Filters.Add(new Filter(filterName, filterArgs.ToArray()));
 						}
 					}
@@ -65,10 +69,10 @@ namespace DotLiquid
 
 			if (output != null)
 			{
-                var transformer = Template.GetValueTypeTransformer(output.GetType());
-                
-                if(transformer != null)
-                    output = transformer(output);
+				var transformer = Template.GetValueTypeTransformer(output.GetType());
+				
+				if(transformer != null)
+					output = transformer(output);
 
 				string outputString;
 				if (output is IEnumerable)
@@ -106,8 +110,8 @@ namespace DotLiquid
 				}
 			});
 
-            if (output is IValueTypeConvertible)
-                output = ((IValueTypeConvertible) output).ConvertToValueType();
+			if (output is IValueTypeConvertible)
+				output = ((IValueTypeConvertible) output).ConvertToValueType();
 
 			return output;
 		}


### PR DESCRIPTION
Hi!  My team at Microsoft is using DotLiquid in a high scale service where hundreds of threads may be rendering templates at any given moment.  While I was running perf tests, profiling showed severe lock contention occurring in the Regex constructor, causing CPU usage to be pegged at 100% with a ton of request timeouts.  (The cause is explained in the comments of Util\R.cs.)  Here's a pull request with the fix I made.  

I searched through your Issues log and noticed that someone had asked for something similar many years time ago, but a change didn't seem necessary at the time.  I may be able to share some specific perf numbers from my tests with you if you need hard data on why we made this change, but briefly, it has reduced the CPU usage spent in lock contention from nearly 70% to less than 1%.

Let me know if you have any questions or comments!