### PR TITLE
Jyeohamilton/listshiftfix

### DIFF
--- a/src/DotLiquid.Tests/DotLiquid.Tests.csproj
+++ b/src/DotLiquid.Tests/DotLiquid.Tests.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Tags\UnlessElseTests.cs" />
     <Compile Include="Tags\StandardTagTests.cs" />
     <Compile Include="TemplateTests.cs" />
+    <Compile Include="Util\ListExtensionMethodsTests.cs" />
     <Compile Include="Util\StrFTimeTests.cs" />
     <Compile Include="VariableResolutionTests.cs" />
     <Compile Include="VariableTests.cs" />

--- a/src/DotLiquid.Tests/Util/ListExtensionMethodsTests.cs
+++ b/src/DotLiquid.Tests/Util/ListExtensionMethodsTests.cs
@@ -11,11 +11,11 @@ namespace DotLiquid.Tests.Util
         [Test]
         public void TestGetAtIndexForNullList()
         {
-            var list = (List<object>)null;
+            var list = (List<string>)null;
 
             Assert.IsNull(list.TryGetAtIndex(0));
             Assert.IsNull(list.TryGetAtIndex(-1));
-            Assert.IsNull(list.TryGetAtIndex(100));
+            Assert.IsNull(list.TryGetAtIndex(1));
         }
 
         [Test]
@@ -25,19 +25,53 @@ namespace DotLiquid.Tests.Util
 
             Assert.IsNull(list.TryGetAtIndex(1));
             Assert.IsNull(list.TryGetAtIndex(-1));
-            Assert.IsNull(list.TryGetAtIndex(100));
+            Assert.IsNull(list.TryGetAtIndex(1));
         }
 
         [Test]
         public void TestGetAtIndexForNonNullList()
         {
-            const string item = "foo";
-            var list = new List<string> { item };
+            const string item0 = "foo";
+            const string item1 = "bar";
+            var list = new List<string> { item0, item1 };
 
-            Assert.AreEqual(item, list.TryGetAtIndex(0));
-            Assert.IsNull(list.TryGetAtIndex(1));
+            Assert.AreEqual(item0, list.TryGetAtIndex(0));
+            Assert.AreEqual(item1, list.TryGetAtIndex(1));
+            Assert.IsNull(list.TryGetAtIndex(2));
             Assert.IsNull(list.TryGetAtIndex(-1));
-            Assert.IsNull(list.TryGetAtIndex(100));
+        }
+
+        [Test]
+        public void TestGetAtIndexReverseForNullList()
+        {
+            var list = (List<string>)null;
+
+            Assert.IsNull(list.TryGetAtIndexReverse(0));
+            Assert.IsNull(list.TryGetAtIndexReverse(-1));
+            Assert.IsNull(list.TryGetAtIndexReverse(1));
+        }
+
+        [Test]
+        public void TestGetAtIndexReverseForEmptyList()
+        {
+            var list = new List<string>();
+
+            Assert.IsNull(list.TryGetAtIndexReverse(1));
+            Assert.IsNull(list.TryGetAtIndexReverse(-1));
+            Assert.IsNull(list.TryGetAtIndexReverse(1));
+        }
+
+        [Test]
+        public void TestGetAtIndexReverseForNonNullList()
+        {
+            const string item0 = "foo";
+            const string item1 = "bar";
+            var list = new List<string> { item0, item1 };
+
+            Assert.AreEqual(item1, list.TryGetAtIndexReverse(0));
+            Assert.AreEqual(item0, list.TryGetAtIndexReverse(1));
+            Assert.IsNull(list.TryGetAtIndexReverse(2));
+            Assert.IsNull(list.TryGetAtIndexReverse(-1));
         }
     }
 }

--- a/src/DotLiquid.Tests/Util/ListExtensionMethodsTests.cs
+++ b/src/DotLiquid.Tests/Util/ListExtensionMethodsTests.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+
+using DotLiquid.Util;
+using NUnit.Framework;
+
+namespace DotLiquid.Tests.Util
+{
+    [TestFixture]
+    public class ListExtensionMethodsTests
+    {
+        [Test]
+        public void TestGetAtIndexForNullList()
+        {
+            var list = (List<object>)null;
+
+            Assert.IsNull(list.TryGetAtIndex(0));
+            Assert.IsNull(list.TryGetAtIndex(-1));
+            Assert.IsNull(list.TryGetAtIndex(100));
+        }
+
+        [Test]
+        public void TestGetAtIndexForEmptyList()
+        {
+            var list = new List<string>();
+
+            Assert.IsNull(list.TryGetAtIndex(1));
+            Assert.IsNull(list.TryGetAtIndex(-1));
+            Assert.IsNull(list.TryGetAtIndex(100));
+        }
+
+        [Test]
+        public void TestGetAtIndexForNonNullList()
+        {
+            const string item = "foo";
+            var list = new List<string> { item };
+
+            Assert.AreEqual(item, list.TryGetAtIndex(0));
+            Assert.IsNull(list.TryGetAtIndex(1));
+            Assert.IsNull(list.TryGetAtIndex(-1));
+            Assert.IsNull(list.TryGetAtIndex(100));
+        }
+    }
+}

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -291,7 +291,9 @@ namespace DotLiquid
         {
             List<string> parts = R.Scan(markup, VariableParserRegex);
 
-            string firstPart = parts.Shift();
+            // first item in list, if any
+            string firstPart = parts.TryGetAtIndex(0);
+
             Match firstPartSquareBracketedMatch = SquareBracketedRegex.Match(firstPart);
             if (firstPartSquareBracketedMatch.Success)
                 firstPart = Resolve(firstPartSquareBracketedMatch.Groups[1].Value).ToString();
@@ -299,8 +301,10 @@ namespace DotLiquid
             object @object;
             if ((@object = FindVariable(firstPart)) != null)
             {
-                foreach (string forEachPart in parts)
+                // try to resolve the rest of the parts (starting from the second item in the list)
+                for (int i = 1; i < parts.Count; ++i)
                 {
+                    var forEachPart = parts[i];
                     Match partSquareBracketedMatch = SquareBracketedRegex.Match(forEachPart);
                     bool partResolved = partSquareBracketedMatch.Success;
 

--- a/src/DotLiquid/Tags/If.cs
+++ b/src/DotLiquid/Tags/If.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text.RegularExpressions;
 using DotLiquid.Exceptions;
 using DotLiquid.Util;
@@ -56,7 +55,6 @@ namespace DotLiquid.Tags
                         return;
                     }
                 }
-                ;
             });
         }
 
@@ -70,8 +68,10 @@ namespace DotLiquid.Tags
             else
             {
                 List<string> expressions = R.Scan(markup, ExpressionsAndOperatorsRegex);
-                expressions.Reverse();
-                string syntax = expressions.Shift();
+
+                // last item in list
+                string syntax = expressions.TryGetAtIndex(expressions.Count - 1);
+
                 if (string.IsNullOrEmpty(syntax))
                     throw new SyntaxException(SyntaxHelp);
                 Match syntaxMatch = Syntax.Match(syntax);
@@ -81,11 +81,12 @@ namespace DotLiquid.Tags
                 Condition condition = new Condition(syntaxMatch.Groups[1].Value,
                     syntaxMatch.Groups[2].Value, syntaxMatch.Groups[3].Value);
 
-                while (expressions.Any())
+                // read pairs of item, starting from second-last item in list, backwards to the beginning of the list
+                for (int i = expressions.Count - 2; i >= 0; i = i - 2)
                 {
-                    string @operator = expressions.Shift().Trim();
+                    string @operator = expressions.TryGetAtIndex(i).Trim();
 
-                    Match expressionMatch = Syntax.Match(expressions.Shift());
+                    Match expressionMatch = Syntax.Match(expressions.TryGetAtIndex(i - 1));
                     if (!expressionMatch.Success)
                         throw new SyntaxException(SyntaxHelp);
 

--- a/src/DotLiquid/Tags/If.cs
+++ b/src/DotLiquid/Tags/If.cs
@@ -70,7 +70,7 @@ namespace DotLiquid.Tags
                 List<string> expressions = R.Scan(markup, ExpressionsAndOperatorsRegex);
 
                 // last item in list
-                string syntax = expressions.TryGetAtIndex(expressions.Count - 1);
+                string syntax = expressions.TryGetAtIndexReverse(0);
 
                 if (string.IsNullOrEmpty(syntax))
                     throw new SyntaxException(SyntaxHelp);
@@ -81,12 +81,12 @@ namespace DotLiquid.Tags
                 Condition condition = new Condition(syntaxMatch.Groups[1].Value,
                     syntaxMatch.Groups[2].Value, syntaxMatch.Groups[3].Value);
 
-                // read pairs of item, starting from second-last item in list, backwards to the beginning of the list
-                for (int i = expressions.Count - 2; i >= 0; i = i - 2)
+                // continue to process remaining items in the list backwards, in pairs
+                for (int i = 1; i < expressions.Count; i = i + 2)
                 {
-                    string @operator = expressions.TryGetAtIndex(i).Trim();
+                    string @operator = expressions.TryGetAtIndexReverse(i).Trim();
 
-                    Match expressionMatch = Syntax.Match(expressions.TryGetAtIndex(i - 1));
+                    Match expressionMatch = Syntax.Match(expressions.TryGetAtIndexReverse(i + 1));
                     if (!expressionMatch.Success)
                         throw new SyntaxException(SyntaxHelp);
 

--- a/src/DotLiquid/Util/ListExtensionMethods.cs
+++ b/src/DotLiquid/Util/ListExtensionMethods.cs
@@ -5,12 +5,13 @@ namespace DotLiquid.Util
     public static class ListExtensionMethods
     {
         /// <summary>
-        /// Returns the element at a certain position in the list, or null if there is no such element.
+        /// Returns the element at a certain position in the list.
+        /// Returns null if there is no such element.
         /// The list is not modified.
         /// </summary>
         /// <typeparam name="T">type</typeparam>
         /// <param name="list">list</param>
-        /// <param name="index">reverse index</param>
+        /// <param name="index">index (0 is the first element in the list)</param>
         /// <returns>element</returns>
         public static T TryGetAtIndex<T>(this List<T> list, int index)
             where T : class
@@ -24,10 +25,30 @@ namespace DotLiquid.Util
         }
 
         /// <summary>
+        /// Returns the element at a certain position in the list, but in reverse.
+        /// Returns null if there is no such element.
+        /// The list is not modified.
+        /// </summary>
+        /// <typeparam name="T">type</typeparam>
+        /// <param name="list">list</param>
+        /// <param name="rindex">reverse index (0 is the last element in the list)</param>
+        /// <returns>element</returns>
+        public static T TryGetAtIndexReverse<T>(this List<T> list, int rindex)
+            where T : class
+        {
+            if (list != null && list.Count > rindex && rindex >= 0)
+            {
+                return list[list.Count - 1 - rindex];
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Removes the first element from the list and returns it,
         /// or null if the list is empty.
         /// WARNING: The RemoveAt() operation is O(N). 
-        /// If the element does not actually need to be removed from the list, use TryGetAtIndex() instead.ed
+        /// If the element does not actually need to be removed from the list, use TryGetAtIndex() instead.
         /// </summary>
         /// <param name="list"></param>
         /// <returns></returns>

--- a/src/DotLiquid/Util/ListExtensionMethods.cs
+++ b/src/DotLiquid/Util/ListExtensionMethods.cs
@@ -5,8 +5,29 @@ namespace DotLiquid.Util
     public static class ListExtensionMethods
     {
         /// <summary>
+        /// Returns the element at a certain position in the list, or null if there is no such element.
+        /// The list is not modified.
+        /// </summary>
+        /// <typeparam name="T">type</typeparam>
+        /// <param name="list">list</param>
+        /// <param name="index">reverse index</param>
+        /// <returns>element</returns>
+        public static T TryGetAtIndex<T>(this List<T> list, int index)
+            where T : class
+        {
+            if (list != null && list.Count > index && index >= 0)
+            {
+                return list[index];
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Removes the first element from the list and returns it,
         /// or null if the list is empty.
+        /// WARNING: The RemoveAt() operation is O(N). 
+        /// If the element does not actually need to be removed from the list, use TryGetAtIndex() instead.ed
         /// </summary>
         /// <param name="list"></param>
         /// <returns></returns>


### PR DESCRIPTION
Minor perf fix.  There are a couple of places in the variable resolution inner loop where List methods are used that modify the list (Shift, Reverse). However, the list does not really need to be modified (in these cases), so this is an unnecessary O(N) expense. This PR proposes reading the data in-place instead.
 