### PR TITLE
add generic interface support for GetSafeTypeTransformer and GetValueTypeTransformer

### DIFF
--- a/src/DotLiquid.Tests/TemplateTests.cs
+++ b/src/DotLiquid.Tests/TemplateTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Net;
 using System.Web;
@@ -335,6 +336,27 @@ namespace DotLiquid.Tests
             var output = template.Render(Hash.FromAnonymousObject(new { context = new MySimpleType2 { Name = "worked" } }));
 
             Assert.AreEqual("", output);
+        }
+
+        public interface MyGenericInterface<T>
+        {
+            T Value { get; set; }
+        }
+
+        public class MyGenericImpl<T> : MyGenericInterface<T>
+        {
+            public T Value { get; set; }
+        }
+
+        [Test]
+        public void TestRegisterGenericInterface()
+        {
+            Template.RegisterSafeType(typeof(MyGenericInterface<>), new[] { "Value" });
+            Template template = Template.Parse("{{context.Value}}");
+
+            var output = template.Render(Hash.FromAnonymousObject(new { context = new MyGenericImpl<string> { Value = "worked" } }));
+
+            Assert.AreEqual("worked", output);
         }
     }
 }

--- a/src/DotLiquid/Template.cs
+++ b/src/DotLiquid/Template.cs
@@ -130,32 +130,40 @@ namespace DotLiquid
         public static Func<object, object> GetValueTypeTransformer(Type type)
         {
             // Check for concrete types
-            if (ValueTypeTransformers.ContainsKey(type))
-                return ValueTypeTransformers[type];
+            Func<object, object> transformer;
+            if (ValueTypeTransformers.TryGetValue(type, out transformer))
+                return transformer;
 
             // Check for interfaces
-            foreach (var interfaceType in ValueTypeTransformers.Where(x => x.Key.GetTypeInfo().IsInterface))
+            var interfaces = type.GetTypeInfo().ImplementedInterfaces;
+            foreach (var interfaceType in interfaces)
             {
-                if (type.GetTypeInfo().ImplementedInterfaces.Contains(interfaceType.Key))
-                    return interfaceType.Value;
+                if (ValueTypeTransformers.TryGetValue(interfaceType, out transformer))
+                    return transformer;
+                if (interfaceType.GetTypeInfo().IsGenericType && ValueTypeTransformers.TryGetValue(
+                    interfaceType.GetGenericTypeDefinition(), out transformer))
+                    return transformer;
             }
-
             return null;
         }
 
         public static Func<object, object> GetSafeTypeTransformer(Type type)
         {
             // Check for concrete types
-            if (SafeTypeTransformers.ContainsKey(type))
-                return SafeTypeTransformers[type];
+            Func<object, object> transformer;
+            if (SafeTypeTransformers.TryGetValue(type, out transformer))
+                return transformer;
 
             // Check for interfaces
-            foreach (var interfaceType in SafeTypeTransformers.Where(x => x.Key.GetTypeInfo().IsInterface))
+            var interfaces = type.GetTypeInfo().ImplementedInterfaces;
+            foreach (var interfaceType in interfaces)
             {
-                if (type.GetTypeInfo().ImplementedInterfaces.Contains(interfaceType.Key))
-                    return interfaceType.Value;
+                if (SafeTypeTransformers.TryGetValue(interfaceType, out transformer))
+                    return transformer;
+                if (interfaceType.GetTypeInfo().IsGenericType && SafeTypeTransformers.TryGetValue(
+                    interfaceType.GetGenericTypeDefinition(), out transformer))
+                    return transformer;
             }
-
             return null;
         }
 


### PR DESCRIPTION
This commit add generic interface support for GetSafeTypeTransformer and GetValueTypeTransformer.
It make code like this work:
Template.RegisterSafeType(typeof(ITreeNode<>), new[] { "Value", "Parent", "Childs" });

Also improve some performance.
