### PR TITLE
Add now/today inputs to date filter

### DIFF
--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -127,6 +127,11 @@ namespace DotLiquid.Tests
 
             Assert.AreEqual("hi", StandardFilters.Date("hi", "MMMM"));
 
+            Assert.AreEqual(DateTime.Now.ToString("MM/dd/yyyy"), StandardFilters.Date("now", "MM/dd/yyyy"));
+            Assert.AreEqual(DateTime.Now.ToString("MM/dd/yyyy"), StandardFilters.Date("today", "MM/dd/yyyy"));
+            Assert.AreEqual(DateTime.Now.ToString("MM/dd/yyyy"), StandardFilters.Date("Now", "MM/dd/yyyy"));
+            Assert.AreEqual(DateTime.Now.ToString("MM/dd/yyyy"), StandardFilters.Date("Today", "MM/dd/yyyy"));
+
             Template template = Template.Parse(@"{{ hi | date:""MMMM"" }}");
             Assert.AreEqual("hi", template.Render(Hash.FromAnonymousObject(new { hi = "hi" })));
         }

--- a/src/DotLiquid/StandardFilters.cs
+++ b/src/DotLiquid/StandardFilters.cs
@@ -504,17 +504,28 @@ namespace DotLiquid
         /// <returns></returns>
         public static string Date(object input, string format)
         {
+            string value;
+
             if (input == null)
                 return null;
 
+            value = input.ToString();
+
             if (format.IsNullOrWhiteSpace())
-                return input.ToString();
+                return value;
 
             DateTime date;
 
-            return DateTime.TryParse(input.ToString(), out date)
-                ? Liquid.UseRubyDateFormat ? date.ToStrFTime(format) : date.ToString(format)
-                : input.ToString();
+            if (string.Equals(value, "now", StringComparison.OrdinalIgnoreCase) || string.Equals(value, "today", StringComparison.OrdinalIgnoreCase))
+            {
+                date = DateTime.Now;
+            }
+            else if (!DateTime.TryParse(value, out date))
+            {
+                return value;
+            }
+
+            return Liquid.UseRubyDateFormat ? date.ToStrFTime(format) : date.ToString(format);
         }
 
         /// <summary>


### PR DESCRIPTION
Hello,

The documentation for the [date](https://shopify.github.io/liquid/filters/date/) filter states that you can use the `now` and `today` words to substitute for the current date. As Dotliquid doesn't support this, this PR adds support for that. Although the docs don't say either way, [499 for liquid](https://github.com/Shopify/liquid/pull/499) does fix a regression where case insensitivity was broken, so I have made this implementation case insensitive as well.

I also adjusted `StandardFilterTests.TestDate` to include basic checking of the keywords.

I haven't actually used .NET Core yet, and although I was under the expression my 2015 dev environment was up to date (except for NCrunch), neither NCrunch, nor Resharper, not VSTest would actually find or run any tests (except for the DotLiquid.Website.Tests which wasn't very helpfull). So after making my changes, I would compile then run `dotnet-test-nunit.exe DotLiquid.Tests.dll` from the `Debug\net451\win7-x64` folder.

This indicated my adjusted test passed, but always claimed that `DotLiquid.Tests.Util.StrFTimeTests.TestFormat` failed - even if I reverted my original changes. So they don't appear to be related but I thought I'd mention it here regardless.

````
1) Failed : DotLiquid.Tests.Util.StrFTimeTests.TestFormat("%W")
  String lengths are both 2. Strings differ at index 1.
  Expected: "01"
  But was:  "02"
````

As I said, I haven't worked with Core before so it's very possible I may well have missed something - please let me know if this PR is lacking.

Thanks;
Richard Moss