### PR TITLE
make template instance thread safe (provide extra option)

### DIFF
--- a/src/DotLiquid.Tests/ParallelTest.cs
+++ b/src/DotLiquid.Tests/ParallelTest.cs
@@ -1,0 +1,21 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DotLiquid.Tests {
+    [TestFixture]
+    public class ParallelTest {
+        [Test]
+        public void TestCachedTemplateRender() {
+            Template template = Template.Parse(@"{% assign foo = 'from instance assigns' %}{{foo}}");
+            template.MakeThreadSafe();
+
+            var parallelOptions = new ParallelOptions { MaxDegreeOfParallelism = 30 };
+
+            Parallel.For(0, 10000, parallelOptions, (x) => Assert.AreEqual("from instance assigns", template.Render()));
+        }
+    }
+}

--- a/src/DotLiquid.Tests/TemplateTests.cs
+++ b/src/DotLiquid.Tests/TemplateTests.cs
@@ -43,11 +43,29 @@ namespace DotLiquid.Tests
         }
 
         [Test]
+        public void TestThreadSafeInstanceAssignsNotPersistOnSameTemplateObjectBetweenParses()
+        {
+            Template t = new Template();
+            t.MakeThreadSafe();
+            Assert.AreEqual("from instance assigns", t.ParseInternal("{% assign foo = 'from instance assigns' %}{{ foo }}").Render());
+            Assert.AreEqual("", t.ParseInternal("{{ foo }}").Render());
+        }
+
+        [Test]
         public void TestInstanceAssignsPersistOnSameTemplateParsingBetweenRenders()
         {
             Template t = Template.Parse("{{ foo }}{% assign foo = 'foo' %}{{ foo }}");
             Assert.AreEqual("foo", t.Render());
             Assert.AreEqual("foofoo", t.Render());
+        }
+
+        [Test]
+        public void TestThreadSafeInstanceAssignsNotPersistOnSameTemplateParsingBetweenRenders()
+        {
+            Template t = Template.Parse("{{ foo }}{% assign foo = 'foo' %}{{ foo }}");
+            t.MakeThreadSafe();
+            Assert.AreEqual("foo", t.Render());
+            Assert.AreEqual("foo", t.Render());
         }
 
         [Test]

--- a/src/DotLiquid/RenderParameters.cs
+++ b/src/DotLiquid/RenderParameters.cs
@@ -32,8 +32,15 @@ namespace DotLiquid
             List<Hash> environments = new List<Hash>();
             if (LocalVariables != null)
                 environments.Add(LocalVariables);
-            environments.Add(template.Assigns);
-            context = new Context(environments, template.InstanceAssigns, template.Registers, RethrowErrors);
+            if (template.IsThreadSafe)
+            {
+                context = new Context(environments, new Hash(), new Hash(), RethrowErrors);
+            }
+            else
+            {
+                environments.Add(template.Assigns);
+                context = new Context(environments, template.InstanceAssigns, template.Registers, RethrowErrors);
+            }
             registers = Registers;
             filters = Filters;
         }


### PR DESCRIPTION
Hello, this PR provide an option that can make Template instance thread safe.
After calling Template.MakeThreadSafe, user can't assign values to template instance anymore.

Example
``` csharp
Template t = Template.Parse("{{ foo }}{% assign foo = 'foo' %}{{ foo }}");
 t.MakeThreadSafe();
Assert.AreEqual("foo", t.Render());
Assert.AreEqual("foo", t.Render());
```

Because it's an extra option, this modification won't affect existing code.
Also I added a global option Template.DefaultIsThreadSafe can make all Template instances thread safe by default.