### PR TITLE
Notify unknown variables in the Error collection

### DIFF
--- a/src/DotLiquid.Tests/ContextTests.cs
+++ b/src/DotLiquid.Tests/ContextTests.cs
@@ -195,6 +195,37 @@ namespace DotLiquid.Tests
         {
             Assert.AreEqual(null, _context["does_not_exist"]);
         }
+        [Test]
+        public void TestVariableNotFoundErrors()
+        {
+            Template template = Template.Parse("{{ does_not_exist }}");
+            string rendered = template.Render();
+ 
+            Assert.AreEqual("", rendered);
+            Assert.AreEqual(1, template.Errors.Count);
+            Assert.AreEqual(string.Format(Liquid.ResourceManager.GetString("VariableNotFoundException"), "does_not_exist"), template.Errors[0].Message);
+        }
+ 
+        [Test]
+        public void TestVariableNotFoundFromAnonymousObject()
+        {
+            Template template = Template.Parse("{{ first.test }}{{ second.test }}");
+            string rendered = template.Render(Hash.FromAnonymousObject(new { second = new { foo = "hi!" } }));
+ 
+            Assert.AreEqual("", rendered);
+            Assert.AreEqual(2, template.Errors.Count);
+            Assert.AreEqual(string.Format(Liquid.ResourceManager.GetString("VariableNotFoundException"), "first.test"), template.Errors[0].Message);
+            Assert.AreEqual(string.Format(Liquid.ResourceManager.GetString("VariableNotFoundException"), "second.test"), template.Errors[1].Message);
+        }
+ 
+        [Test]
+        public void TestVariableNotFoundException()
+        {
+            Assert.DoesNotThrow(() => Template.Parse("{{ does_not_exist }}").Render(new RenderParameters
+            {
+                RethrowErrors = true
+            }));
+        }
 
         [Test]
         public void TestScoping()

--- a/src/DotLiquid.Tests/ContextTests.cs
+++ b/src/DotLiquid.Tests/ContextTests.cs
@@ -195,6 +195,7 @@ namespace DotLiquid.Tests
         {
             Assert.AreEqual(null, _context["does_not_exist"]);
         }
+
         [Test]
         public void TestVariableNotFoundErrors()
         {

--- a/src/DotLiquid.Tests/ContextTests.cs
+++ b/src/DotLiquid.Tests/ContextTests.cs
@@ -229,6 +229,26 @@ namespace DotLiquid.Tests
         }
 
         [Test]
+        public void TestVariableNotFoundExceptionIgnoredForIfStatement()
+        {
+            Template template = Template.Parse("{% if does_not_exist %}abc{% endif %}");
+            string rendered = template.Render();
+
+            Assert.AreEqual("", rendered);
+            Assert.AreEqual(0, template.Errors.Count);
+        }
+
+        [Test]
+        public void TestVariableNotFoundExceptionIgnoredForUnlessStatement()
+        {
+            Template template = Template.Parse("{% unless does_not_exist %}abc{% endunless %}");
+            string rendered = template.Render();
+
+            Assert.AreEqual("abc", rendered);
+            Assert.AreEqual(0, template.Errors.Count);
+        }
+
+        [Test]
         public void TestScoping()
         {
             Assert.DoesNotThrow(() =>

--- a/src/DotLiquid.Tests/Tags/IncludeTagTests.cs
+++ b/src/DotLiquid.Tests/Tags/IncludeTagTests.cs
@@ -68,6 +68,13 @@ namespace DotLiquid.Tests.Tags
         }
 
         [Test]
+        public void TestIncludeTagMustNotBeConsideredError()
+        {
+            Assert.AreEqual(0, Template.Parse("{% include 'product_template' %}").Errors.Count);
+            Assert.DoesNotThrow(() => Template.Parse("{% include 'product_template' %}").Render(new RenderParameters { RethrowErrors = true }));
+        }
+
+        [Test]
         public void TestIncludeTagLooksForFileSystemInRegistersFirst()
         {
             Assert.AreEqual("from OtherFileSystem", Template.Parse("{% include 'pick_a_source' %}").Render(new RenderParameters { Registers = Hash.FromAnonymousObject(new { file_system = new OtherFileSystem() }) }));

--- a/src/DotLiquid/Condition.cs
+++ b/src/DotLiquid/Condition.cs
@@ -130,7 +130,7 @@ namespace DotLiquid
             // return this as the result.
             if (string.IsNullOrEmpty(op))
             {
-                object result = context[left];
+                object result = context[left, false];
                 return (result != null && (!(result is bool) || (bool) result));
             }
 

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -183,13 +183,13 @@ namespace DotLiquid
         /// <returns></returns>
         public object this [string key]
         {
-            get { return Resolve(key); }
+            get { return Resolve(key, true); }
             set { Scopes[0][key] = value; }
         }
 
         public bool HasKey(string key)
         {
-            return Resolve(key) != null;
+            return Resolve(key, false) != null;
         }
 
         /// <summary>
@@ -203,8 +203,9 @@ namespace DotLiquid
         /// products == empty #=> products.empty?
         /// </summary>
         /// <param name="key"></param>
+        /// <param name="notifyVariableNotFound"></param>
         /// <returns></returns>
-        private object Resolve(string key)
+        private object Resolve(string key, bool notifyVariableNotFound = true)
         {
             switch (key)
             {
@@ -259,7 +260,10 @@ namespace DotLiquid
                 return float.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
             }
 
-            return Variable(key);
+            object variable = Variable(key);
+            if (variable == null && notifyVariableNotFound == true)
+                Errors.Add(new VariableNotFoundException(string.Format(Liquid.ResourceManager.GetString("VariableNotFoundException"), key)));
+            return variable;
         }
 
         /// <summary>

--- a/src/DotLiquid/Exceptions/VariableNotFoundException.cs
+++ b/src/DotLiquid/Exceptions/VariableNotFoundException.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace DotLiquid.Exceptions
+{
+#if !CORE
+    [Serializable]
+#endif
+    public class VariableNotFoundException : LiquidException
+    {
+        public VariableNotFoundException(string message, params string[] args)
+            : base(string.Format(message, args))
+        {
+        }
+
+        public VariableNotFoundException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/DotLiquid/Properties/Resources.Designer.cs
+++ b/src/DotLiquid/Properties/Resources.Designer.cs
@@ -366,7 +366,16 @@ namespace DotLiquid.Properties {
                 return ResourceManager.GetString("VariableFilterNotFoundException", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Error - Variable &apos;{0}&apos; could not be found..
+        /// </summary>
+        internal static string VariableNotFoundException {
+            get {
+                return ResourceManager.GetString("VariableNotFoundException", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to key could not be found.
         /// </summary>

--- a/src/DotLiquid/Properties/Resources.it.resx
+++ b/src/DotLiquid/Properties/Resources.it.resx
@@ -219,6 +219,9 @@
   <data name="VariableFilterNotFoundException" xml:space="preserve">
     <value>Errore - Il filtro '{0}' in '{1}' non è stato trovato</value>
   </data>
+  <data name="VariableNotFoundException" xml:space="preserve">
+    <value>Errore - La variabile '{0}' non è stata trovata</value>
+  </data>
   <data name="WeakTableKeyNotFoundException" xml:space="preserve">
     <value>la chiave non è stata trovata</value>
   </data>

--- a/src/DotLiquid/Properties/Resources.resx
+++ b/src/DotLiquid/Properties/Resources.resx
@@ -219,6 +219,9 @@
   <data name="VariableFilterNotFoundException" xml:space="preserve">
     <value>Error - Filter '{0}' in '{1}' could not be found.</value>
   </data>
+  <data name="VariableNotFoundException" xml:space="preserve">
+    <value>Error - Variabile '{0}' could not be found</value>
+  </data>
   <data name="WeakTableKeyNotFoundException" xml:space="preserve">
     <value>key could not be found</value>
   </data>

--- a/src/DotLiquid/Properties/Resources.resx
+++ b/src/DotLiquid/Properties/Resources.resx
@@ -220,7 +220,7 @@
     <value>Error - Filter '{0}' in '{1}' could not be found.</value>
   </data>
   <data name="VariableNotFoundException" xml:space="preserve">
-    <value>Error - Variabile '{0}' could not be found</value>
+    <value>Error - Variable '{0}' could not be found</value>
   </data>
   <data name="WeakTableKeyNotFoundException" xml:space="preserve">
     <value>key could not be found</value>

--- a/src/DotLiquid/Tags/Include.cs
+++ b/src/DotLiquid/Tags/Include.cs
@@ -45,7 +45,7 @@ namespace DotLiquid.Tags
             Template partial = Template.Parse(source);
 
             string shortenedTemplateName = _templateName.Substring(1, _templateName.Length - 2);
-            object variable = context[_variableName ?? shortenedTemplateName];
+            object variable = context[_variableName ?? shortenedTemplateName, _variableName != null];
 
             context.Stack(() =>
             {


### PR DESCRIPTION
Request to re-open PR #156. When a variable used in the template cannot be resolved, an new VariableNotFoundException is added to the Error list so that it is possible to show to the end user which variables are evaluated to null because they do not exists.