### PR TITLE
Fix issue preventing filters with multiple method signatures and injected context argument from being invoked

### DIFF
--- a/src/DotLiquid.Tests/FilterTests.cs
+++ b/src/DotLiquid.Tests/FilterTests.cs
@@ -61,6 +61,32 @@ namespace DotLiquid.Tests
             }
         }
 
+        private static class FiltersWithMulitpleMethodSignatures
+        {
+            public static string Concat(string one, string two)
+            {
+                return string.Concat(one, two);
+            }
+
+            public static string Concat(string one, string two, string three)
+            {
+                return string.Concat(one, two, three);
+            }
+        }
+
+        private static class FiltersWithMultipleMethodSignaturesAndContextParam
+        {
+            public static string ConcatWithContext(Context context, string one, string two)
+            {
+                return string.Concat(one, two);
+            }
+
+            public static string ConcatWithContext(Context context, string one, string two, string three)
+            {
+                return string.Concat(one, two, three);
+            }
+        }
+
         private static class ContextFilters
         {
             public static string BankStatement(Context context, object input)
@@ -132,6 +158,24 @@ namespace DotLiquid.Tests
             _context["var"] = 1000;
             _context.AddFilters(typeof(FiltersWithArguments));
             Assert.AreEqual("[1150]", new Variable("var | add_sub: 200, 50").Render(_context));
+        }
+
+        [Test]
+        public void TestFilterWithMultipleMethodSignatures()
+        {
+            Template.RegisterFilter(typeof(FiltersWithMulitpleMethodSignatures));
+
+            Assert.AreEqual("AB", Template.Parse("{{'A' | concat : 'B'}}").Render());
+            Assert.AreEqual("ABC", Template.Parse("{{'A' | concat : 'B', 'C'}}").Render());
+        }
+
+        [Test]
+        public void TestFilterWithMultipleMethodSignaturesAndContextParam()
+        {
+            Template.RegisterFilter(typeof(FiltersWithMultipleMethodSignaturesAndContextParam));
+
+            Assert.AreEqual("AB", Template.Parse("{{'A' | concat_with_context : 'B'}}").Render());
+            Assert.AreEqual("ABC", Template.Parse("{{'A' | concat_with_context : 'B', 'C'}}").Render());
         }
 
         /*/// <summary>

--- a/src/DotLiquid/Strainer.cs
+++ b/src/DotLiquid/Strainer.cs
@@ -109,8 +109,9 @@ namespace DotLiquid
 
         public object Invoke(string method, List<object> args)
         {
-            // First, try to find a method with the same number of arguments.
-            var methodInfo = _methods[method].FirstOrDefault(m => m.Item2.GetParameters().Length == args.Count);
+            // First, try to find a method with the same number of arguments minus context which we set automatically further down.
+            var methodInfo = _methods[method].FirstOrDefault(m => 
+                m.Item2.GetParameters().Where(p => p.ParameterType != typeof(Context)).Count() == args.Count);
 
             // If we failed to do so, try one with max numbers of arguments, hoping
             // that those not explicitly specified will be taken care of


### PR DESCRIPTION
When looking for a filter the Strainer.Invoke method was counting all filter params on the Liquid side against all params on the C# side. This was not accounting for the auto injected and optional Context object, which caused the correct filter to be missed.

The reason this wasn't a bigger issue is because the strainer then goes on to find the closest match starting with the one with the most parameters, it then set the context object and all was well.

The issue arrises when you have multiple method signatures on that same method, where it attempts to invoke the wrong method (as the included tests show). So this code fixes that, and should result in the Invoke method finding the correct filter straight off more often rather than working on a fallback scenario.