### PR TITLE
Remove unnecessary cast to string on IIndexable check

### DIFF
--- a/src/DotLiquid.Tests/CustomIndexableTests.cs
+++ b/src/DotLiquid.Tests/CustomIndexableTests.cs
@@ -1,0 +1,100 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace DotLiquid.Tests
+{
+    [TestFixture]
+    public class CustomIndexableTests
+    {
+        #region Test classes
+        internal class VirtualList : IIndexable, IEnumerable
+        {
+            internal VirtualList(params object[] items)
+            {
+                this.items = items;
+            }
+
+            private readonly object[] items;
+
+            public object this[object key]
+            {
+                get
+                {
+                    int? index = key as int?;
+                    if (!index.HasValue || index.Value < 0 || index.Value >= items.Length) {
+                        throw new KeyNotFoundException();
+                    }
+                    return items[index.Value];
+                }
+            }
+
+            public bool ContainsKey(object key)
+            {
+                int? index = key as int?;
+                return index.HasValue && index.Value >= 0 && index.Value < items.Length;
+            }
+
+            public IEnumerator GetEnumerator()
+            {
+                return items.GetEnumerator();
+            }
+        }
+
+        internal class CustomIndexable : IIndexable, ILiquidizable
+        {
+            public object this[object key]
+            {
+                get
+                {
+                    if (key == null) {
+                        return "null";
+                    }
+                    return key.GetType() + " " + key.ToString();
+                }
+            }
+
+            public bool ContainsKey(object key)
+            {
+                return true;
+            }
+
+            public object ToLiquid()
+            {
+                return this;
+            }
+        }
+        #endregion
+
+        [Test]
+        public void TestVirtualListLoop()
+        {
+            string output = Template.Parse("{%for item in list%}{{ item }} {%endfor%}")
+                .Render(Hash.FromAnonymousObject(new {list = new VirtualList(1, "Second", 3)}));
+            Assert.AreEqual("1 Second 3 ", output);
+        }
+
+        [Test]
+        public void TestVirtualListIndex()
+        {
+            string output = Template.Parse("1: {{ list[0] }}, 2: {{ list[1] }}, 3: {{ list[2] }}")
+                .Render(Hash.FromAnonymousObject(new {list = new VirtualList(1, "Second", 3)}));
+            Assert.AreEqual("1: 1, 2: Second, 3: 3", output);
+        }
+
+        [Test]
+        public void TestCustomIndexableIntKeys()
+        {
+            string output = Template.Parse("1: {{container[0]}}, 2: {{container[1]}}")
+                .Render(Hash.FromAnonymousObject(new {container = new CustomIndexable()}));
+            Assert.AreEqual("1: System.Int32 0, 2: System.Int32 1", output);
+        }
+
+        [Test]
+        public void TestCustomIndexableStringKeys() {
+            string output = Template.Parse("abc: {{container.abc}}")
+                .Render(Hash.FromAnonymousObject(new {container = new CustomIndexable()}));
+            Assert.AreEqual("abc: System.String abc", output);
+        }
+    }
+}

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -486,7 +486,7 @@ namespace DotLiquid
             if (TypeUtility.IsAnonymousType(obj.GetType()) && obj.GetType().GetRuntimeProperty((string)part) != null)
                 return true;
 
-            if ((obj is IIndexable) && ((IIndexable)obj).ContainsKey((string)part))
+            if ((obj is IIndexable) && ((IIndexable)obj).ContainsKey(part))
                 return true;
 
             return false;


### PR DESCRIPTION
I would like to remove the cast in the call to `IIndexable.ContainsKey`, as I believe that it brings no value, and inhibits at least the following cases:

 * A list-like object that does not desire to implement the whole `IList` interface
 * An object that uses `IIndexable` to support both integer and string indices