### PR TITLE
Add ITemplateFileSystem that allow return Template instance for better performance 

### DIFF
--- a/src/DotLiquid.Tests/Tags/IncludeTagTests.cs
+++ b/src/DotLiquid.Tests/Tags/IncludeTagTests.cs
@@ -47,11 +47,22 @@ namespace DotLiquid.Tests.Tags
             }
         }
 
-        private class TestTemplateFileSystem : TestFileSystem, ITemplateFileSystem
+        internal class TestTemplateFileSystem : ITemplateFileSystem
         {
             private IDictionary<string, Template> _templateCache = new Dictionary<string, Template>();
+            private IFileSystem _baseFileSystem = null;
             private int _cacheHitTimes;
             public int CacheHitTimes { get { return _cacheHitTimes; } }
+
+            public TestTemplateFileSystem(IFileSystem baseFileSystem)
+            {
+                _baseFileSystem = baseFileSystem;
+            }
+
+            public string ReadTemplateFile(Context context, string templateName)
+            {
+                return _baseFileSystem.ReadTemplateFile(context, templateName);
+            }
 
             public Template GetTemplate(Context context, string templateName)
             {
@@ -204,7 +215,7 @@ namespace DotLiquid.Tests.Tags
         [Test]
         public void TestIncludeFromTemplateFileSystem()
         {
-            var fileSystem = new TestTemplateFileSystem();
+            var fileSystem = new TestTemplateFileSystem(new TestFileSystem());
             Template.FileSystem = fileSystem;
             for (int i = 0; i < 2; ++i)
             {

--- a/src/DotLiquid.Tests/Tags/IncludeTagTests.cs
+++ b/src/DotLiquid.Tests/Tags/IncludeTagTests.cs
@@ -1,6 +1,8 @@
+using System;
 using DotLiquid.Exceptions;
 using DotLiquid.FileSystems;
 using NUnit.Framework;
+using System.Collections.Generic;
 
 namespace DotLiquid.Tests.Tags
 {
@@ -42,6 +44,27 @@ namespace DotLiquid.Tests.Tags
                     default:
                         return templatePath;
                 }
+            }
+        }
+
+        private class TestTemplateFileSystem : TestFileSystem, ITemplateFileSystem
+        {
+            private IDictionary<string, Template> _templateCache = new Dictionary<string, Template>();
+            private int _cacheHitTimes;
+            public int CacheHitTimes { get { return _cacheHitTimes; } }
+
+            public Template ReadTemplateInstance(Context context, string templateName)
+            {
+                Template template;
+                if (_templateCache.TryGetValue(templateName, out template))
+                {
+                    ++_cacheHitTimes;
+                    return template;
+                }
+                var result = ReadTemplateFile(context, templateName);
+                template = Template.Parse(result);
+                _templateCache[templateName] = template;
+                return template;
             }
         }
 
@@ -176,6 +199,18 @@ namespace DotLiquid.Tests.Tags
             {
                 RethrowErrors = true
             }));
+        }
+
+        [Test]
+        public void TestIncludeFromTemplateFileSystem()
+        {
+            var fileSystem = new TestTemplateFileSystem();
+            Template.FileSystem = fileSystem;
+            for (int i = 0; i < 2; ++i)
+            {
+                Assert.AreEqual("Product: Draft 151cm ", Template.Parse("{% include 'product' with products[0] %}").Render(Hash.FromAnonymousObject(new { products = new[] { Hash.FromAnonymousObject(new { title = "Draft 151cm" }), Hash.FromAnonymousObject(new { title = "Element 155cm" }) } })));
+            }
+            Assert.AreEqual(fileSystem.CacheHitTimes, 1);
         }
     }
 }

--- a/src/DotLiquid.Tests/Tags/IncludeTagTests.cs
+++ b/src/DotLiquid.Tests/Tags/IncludeTagTests.cs
@@ -53,7 +53,7 @@ namespace DotLiquid.Tests.Tags
             private int _cacheHitTimes;
             public int CacheHitTimes { get { return _cacheHitTimes; } }
 
-            public Template ReadTemplateInstance(Context context, string templateName)
+            public Template GetTemplate(Context context, string templateName)
             {
                 Template template;
                 if (_templateCache.TryGetValue(templateName, out template))

--- a/src/DotLiquid.Tests/Tags/InheritanceTests.cs
+++ b/src/DotLiquid.Tests/Tags/InheritanceTests.cs
@@ -161,5 +161,22 @@ namespace DotLiquid.Tests.Tags
             Assert.AreEqual ("!ABCYZ", template.Render ());
             Assert.AreEqual ("!ABCYZ", template.Render ());
         }
+
+        [Test]
+        public void TestExtendFromTemplateFileSystem()
+        {
+            var fileSystem = new IncludeTagTests.TestTemplateFileSystem(new TestFileSystem());
+            Template.FileSystem = fileSystem;
+            for (int i = 0; i < 2; ++i)
+            {
+                Template template = Template.Parse(
+                                    @"{% extends 'simple' %}
+                    {% block thing %}
+                        yeah
+                    {% endblock %}");
+                StringAssert.Contains("test", template.Render());
+            }
+            Assert.AreEqual(fileSystem.CacheHitTimes, 1);
+        }
     }
 }

--- a/src/DotLiquid/FileSystems/ITemplateFileSystem.cs
+++ b/src/DotLiquid/FileSystems/ITemplateFileSystem.cs
@@ -1,0 +1,17 @@
+﻿namespace DotLiquid.FileSystems
+{
+    /// <summary>
+    /// This interface allow you return a Template instance,
+    /// it can reduce the template parsing time in some cases.
+    /// Please also provide the implementation of ReadTemplateFile for fallback purpose.
+    /// </summary>
+    public interface ITemplateFileSystem : IFileSystem
+    {
+        /// <summary>
+        /// Called by Liquid to retrieve a template instance
+        /// </summary>
+        /// <param name="templatePath"></param>
+        /// <returns></returns>
+        Template ReadTemplateInstance(Context context, string templateName);
+    }
+}

--- a/src/DotLiquid/FileSystems/ITemplateFileSystem.cs
+++ b/src/DotLiquid/FileSystems/ITemplateFileSystem.cs
@@ -12,6 +12,6 @@
         /// </summary>
         /// <param name="templatePath"></param>
         /// <returns></returns>
-        Template ReadTemplateInstance(Context context, string templateName);
+        Template GetTemplate(Context context, string templateName);
     }
 }

--- a/src/DotLiquid/Tags/Extends.cs
+++ b/src/DotLiquid/Tags/Extends.cs
@@ -103,9 +103,16 @@ namespace DotLiquid.Tags
         {
             // Get the template or template content and then either copy it (since it will be modified) or parse it
             IFileSystem fileSystem = context.Registers["file_system"] as IFileSystem ?? Template.FileSystem;
-            object file = fileSystem.ReadTemplateFile(context, _templateName);
-            Template template = file as Template;
-            template = template ?? Template.Parse(file == null ? null : file.ToString());
+            Template template = null;
+            if (fileSystem is ITemplateFileSystem)
+            {
+                template = ((ITemplateFileSystem)fileSystem).ReadTemplateInstance(context, _templateName);
+            }
+            if (template == null)
+            {
+                string source = fileSystem.ReadTemplateFile(context, _templateName);
+                template = Template.Parse(source);
+            }
 
             List<Block> parentBlocks = FindBlocks(template.Root, null);
             List<Block> orphanedBlocks = ((List<Block>)context.Scopes[0]["extends"]) ?? new List<Block>();

--- a/src/DotLiquid/Tags/Extends.cs
+++ b/src/DotLiquid/Tags/Extends.cs
@@ -103,10 +103,11 @@ namespace DotLiquid.Tags
         {
             // Get the template or template content and then either copy it (since it will be modified) or parse it
             IFileSystem fileSystem = context.Registers["file_system"] as IFileSystem ?? Template.FileSystem;
+            ITemplateFileSystem templateFileSystem = fileSystem as ITemplateFileSystem;
             Template template = null;
-            if (fileSystem is ITemplateFileSystem)
+            if (templateFileSystem != null)
             {
-                template = ((ITemplateFileSystem)fileSystem).ReadTemplateInstance(context, _templateName);
+                template = templateFileSystem.GetTemplate(context, _templateName);
             }
             if (template == null)
             {

--- a/src/DotLiquid/Tags/Include.cs
+++ b/src/DotLiquid/Tags/Include.cs
@@ -41,8 +41,16 @@ namespace DotLiquid.Tags
         public override void Render(Context context, TextWriter result)
         {
             IFileSystem fileSystem = context.Registers["file_system"] as IFileSystem ?? Template.FileSystem;
-            string source = fileSystem.ReadTemplateFile(context, _templateName);
-            Template partial = Template.Parse(source);
+            Template partial = null;
+            if (fileSystem is ITemplateFileSystem)
+            {
+                partial = ((ITemplateFileSystem)fileSystem).ReadTemplateInstance(context, _templateName);
+            }
+            if (partial == null)
+            {
+                string source = fileSystem.ReadTemplateFile(context, _templateName);
+                partial = Template.Parse(source);
+            }
 
             string shortenedTemplateName = _templateName.Substring(1, _templateName.Length - 2);
             object variable = context[_variableName ?? shortenedTemplateName, _variableName != null];

--- a/src/DotLiquid/Tags/Include.cs
+++ b/src/DotLiquid/Tags/Include.cs
@@ -41,10 +41,11 @@ namespace DotLiquid.Tags
         public override void Render(Context context, TextWriter result)
         {
             IFileSystem fileSystem = context.Registers["file_system"] as IFileSystem ?? Template.FileSystem;
+            ITemplateFileSystem templateFileSystem = fileSystem as ITemplateFileSystem;
             Template partial = null;
-            if (fileSystem is ITemplateFileSystem)
+            if (templateFileSystem != null)
             {
-                partial = ((ITemplateFileSystem)fileSystem).ReadTemplateInstance(context, _templateName);
+                partial = templateFileSystem.GetTemplate(context, _templateName);
             }
             if (partial == null)
             {


### PR DESCRIPTION
Refer to #209 
This implementation won't break exists code, it allow user to switch a new interface if they intend to return a cached template instance.
The definition of ITemplateFileSystem is 

``` c#
public interface ITemplateFileSystem : IFileSystem
{
    Template ReadTemplateInstance(Context context, string templateName);
}
```

Then I modified Include and Extend tag, If file system object is also ITemplateFileSystem, it will call ITemplateFileSystem.ReadTemplateInstance before IFileSystem.ReadTemplateFile.