### PR TITLE
max iterations error, error output modes

### DIFF
--- a/src/DotLiquid.Tests/ExceptionHandlingTests.cs
+++ b/src/DotLiquid.Tests/ExceptionHandlingTests.cs
@@ -90,6 +90,19 @@ namespace DotLiquid.Tests
         }
 
         [Test]
+        public void TestTimeoutError()
+        {
+            var template = Template.Parse(" {% for i in (1..1000000) %} {{ i }} {% endfor %} ");
+            Assert.Throws<System.TimeoutException>(() =>
+            {
+                template.Render(new RenderParameters
+                {
+                    Timeout = 100 //ms
+                });
+            });
+        }
+
+        [Test]
         public void TestErrorsOutputModeRethrow()
         {
             var template = Template.Parse("{{test}}");

--- a/src/DotLiquid.Tests/ExceptionHandlingTests.cs
+++ b/src/DotLiquid.Tests/ExceptionHandlingTests.cs
@@ -1,4 +1,4 @@
-using DotLiquid.Exceptions;
+﻿using DotLiquid.Exceptions;
 using NUnit.Framework;
 
 namespace DotLiquid.Tests
@@ -70,10 +70,67 @@ namespace DotLiquid.Tests
         {
             Template template = null;
             Assert.DoesNotThrow(() => { template = Template.Parse(" {{ errors.interrupt_exception }} "); });
-            var localVariables = Hash.FromAnonymousObject(new {errors = new ExceptionDrop()});
+            var localVariables = Hash.FromAnonymousObject(new { errors = new ExceptionDrop() });
             var exception = Assert.Throws<InterruptException>(() => template.Render(localVariables));
 
             Assert.AreEqual("interrupted", exception.Message);
+        }
+
+        [Test]
+        public void TestMaximumIterationsExceededError()
+        {
+            var template = Template.Parse(" {% for i in (1..100000) %} {{ i }} {% endfor %} ");
+            Assert.Throws<MaximumIterationsExceededException>(() =>
+            {
+                template.Render(new RenderParameters
+                {
+                    MaxIterations = 50
+                });
+            });
+        }
+
+        [Test]
+        public void TestErrorsOutputModeRethrow()
+        {
+            var template = Template.Parse("{{test}}");
+            Hash assigns = new Hash((h, k) => { throw new SyntaxException("Unknown variable '" + k + "'"); });
+
+            Assert.Throws<SyntaxException>(() =>
+            {
+                var output = template.Render(new RenderParameters
+                {
+                    LocalVariables = assigns,
+                    ErrorsOutputMode = RenderParameters.ErrorsOutputModeEnum.Rethrow
+                });
+            });
+        }
+
+        [Test]
+        public void TestErrorsOutputModeSuppress()
+        {
+            var template = Template.Parse("{{test}}");
+            Hash assigns = new Hash((h, k) => { throw new SyntaxException("Unknown variable '" + k + "'"); });
+
+            var output = template.Render(new RenderParameters
+            {
+                LocalVariables = assigns,
+                ErrorsOutputMode = RenderParameters.ErrorsOutputModeEnum.Suppress
+            });
+            Assert.AreEqual("", output);
+        }
+
+        [Test]
+        public void TestErrorsOutputModeDisplay()
+        {
+            var template = Template.Parse("{{test}}");
+            Hash assigns = new Hash((h, k) => { throw new SyntaxException("Unknown variable '" + k + "'"); });
+
+            var output = template.Render(new RenderParameters
+            {
+                LocalVariables = assigns,
+                ErrorsOutputMode = RenderParameters.ErrorsOutputModeEnum.Display
+            });
+            Assert.IsNotEmpty(output);
         }
     }
 }

--- a/src/DotLiquid/Block.cs
+++ b/src/DotLiquid/Block.cs
@@ -170,6 +170,8 @@ namespace DotLiquid
         {
             foreach (var token in list)
             {
+                context.CheckTimeout();
+
                 try
                 {
                     if (token is IRenderable renderableToken)

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using DotLiquid.Exceptions;
 using DotLiquid.Util;
+using System.Diagnostics;
 
 namespace DotLiquid
 {
@@ -61,7 +62,7 @@ namespace DotLiquid
         /// <param name="outerScope"></param>
         /// <param name="registers"></param>
         /// <param name="errorsOutputMode"></param>
-        public Context(List<Hash> environments, Hash outerScope, Hash registers, RenderParameters.ErrorsOutputModeEnum errorsOutputMode, int maxIterations)
+        public Context(List<Hash> environments, Hash outerScope, Hash registers, RenderParameters.ErrorsOutputModeEnum errorsOutputMode, int maxIterations, int timeout)
         {
             Environments = environments;
 
@@ -81,7 +82,7 @@ namespace DotLiquid
         /// Creates a new rendering context
         /// </summary>
         public Context()
-            : this(new List<Hash>(), new Hash(), new Hash(), RenderParameters.ErrorsOutputModeEnum.Display, 0)
+            : this(new List<Hash>(), new Hash(), new Hash(), RenderParameters.ErrorsOutputModeEnum.Display, 0, 0)
         {
         }
 
@@ -617,6 +618,23 @@ namespace DotLiquid
 
             foreach (string k in tempAssigns.Keys)
                 lastScope[k] = tempAssigns[k];
+        }
+
+        private readonly int _timeout;
+        private Stopwatch _stopwatch = new Stopwatch();
+
+        public void ResetTimeout()
+        {
+            _stopwatch.Restart();
+        }
+
+        public void CheckTimeout()
+        {
+            if (_timeout <= 0)
+                return;
+
+            if (_stopwatch.ElapsedMilliseconds > _timeout)
+                throw new TimeoutException();
         }
     }
 }

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -75,6 +75,10 @@ namespace DotLiquid
             Errors = new List<Exception>();
             _errorsOutputMode = errorsOutputMode;
             _maxIterations = maxIterations;
+            _timeout = timeout;
+
+            RestartTimeout();
+
             SquashInstanceAssignsWithEnvironments();
         }
 
@@ -623,7 +627,7 @@ namespace DotLiquid
         private readonly int _timeout;
         private Stopwatch _stopwatch = new Stopwatch();
 
-        public void ResetTimeout()
+        public void RestartTimeout()
         {
             _stopwatch.Restart();
         }

--- a/src/DotLiquid/Exceptions/MaximumIterationsExceededException.cs
+++ b/src/DotLiquid/Exceptions/MaximumIterationsExceededException.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DotLiquid.Exceptions
+{
+    class MaximumIterationsExceededException : RenderException
+    {
+        public MaximumIterationsExceededException(string message, params string[] args)
+            : base(string.Format(message, args))
+        {
+        }
+
+        public MaximumIterationsExceededException()
+        {
+        }
+    }
+}

--- a/src/DotLiquid/Exceptions/RenderException.cs
+++ b/src/DotLiquid/Exceptions/RenderException.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace DotLiquid.Exceptions
+{
+#if !CORE
+    [Serializable]
+#endif
+    public abstract class RenderException :
+#if CORE
+        Exception
+#else
+        ApplicationException
+#endif
+    {
+        protected RenderException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        protected RenderException(string message)
+            : base(message)
+        {
+        }
+
+        protected RenderException()
+        {
+        }
+    }
+}

--- a/src/DotLiquid/Properties/Resources.it.resx
+++ b/src/DotLiquid/Properties/Resources.it.resx
@@ -228,4 +228,7 @@
   <data name="IfTagTooMuchConditionsException" xml:space="preserve">
     <value>Errore di sintassi nel tag 'if' - sono consentite fino 500 condizioni</value>
   </data>
+  <data name="ForTagMaxIterationsExceededException" xml:space="preserve">
+    <value>Render Error - Maximum number of iterations {0} exceeded</value>
+  </data>
 </root>

--- a/src/DotLiquid/Properties/Resources.resx
+++ b/src/DotLiquid/Properties/Resources.resx
@@ -228,4 +228,7 @@
   <data name="IfTagTooMuchConditionsException" xml:space="preserve">
     <value>Syntax Error in 'if' tag - max 500 conditions are allowed</value>
   </data>
+  <data name="ForTagMaximumIterationsExceededException" xml:space="preserve">
+    <value>Render Error - Maximum number of iterations {0} exceeded</value>
+  </data>
 </root>

--- a/src/DotLiquid/RenderParameters.cs
+++ b/src/DotLiquid/RenderParameters.cs
@@ -19,7 +19,50 @@ namespace DotLiquid
         /// <summary>
         /// Gets or sets a value that controls whether errors are thrown as exceptions.
         /// </summary>
-        public bool RethrowErrors { get; set; }
+        [Obsolete]
+        public bool RethrowErrors
+        {
+            get { return (ErrorsOutputMode == ErrorsOutputModeEnum.Rethrow); }
+            set { ErrorsOutputMode = (value ? ErrorsOutputModeEnum.Rethrow : ErrorsOutputModeEnum.Display); }
+        }
+
+        public enum ErrorsOutputModeEnum
+        {
+            Rethrow,
+            Suppress,
+            Display
+        }
+
+        private ErrorsOutputModeEnum _erorsOutputMode = ErrorsOutputModeEnum.Display;
+
+        public ErrorsOutputModeEnum ErrorsOutputMode
+        {
+            get
+            {
+                return _erorsOutputMode;
+            }
+
+            set
+            {
+                _erorsOutputMode = value;
+            }
+        }
+
+        private int _maxIterations = 0;
+
+        public int MaxIterations
+        {
+            get { return _maxIterations; }
+            set { _maxIterations = value; }
+        }
+
+        private int _timeout = 0;
+
+        public int Timeout
+        {
+            get { return _timeout; }
+            set { _timeout = value; }
+        }
 
         internal void Evaluate(Template template, out Context context, out Hash registers, out IEnumerable<Type> filters)
         {
@@ -36,12 +79,12 @@ namespace DotLiquid
                 environments.Add(LocalVariables);
             if (template.IsThreadSafe)
             {
-                context = new Context(environments, new Hash(), new Hash(), RethrowErrors);
+                context = new Context(environments, new Hash(), new Hash(), ErrorsOutputMode, MaxIterations);
             }
             else
             {
                 environments.Add(template.Assigns);
-                context = new Context(environments, template.InstanceAssigns, template.Registers, RethrowErrors);
+                context = new Context(environments, template.InstanceAssigns, template.Registers, ErrorsOutputMode, MaxIterations);
             }
             registers = Registers;
             filters = Filters;

--- a/src/DotLiquid/RenderParameters.cs
+++ b/src/DotLiquid/RenderParameters.cs
@@ -71,6 +71,7 @@ namespace DotLiquid
                 context = Context;
                 registers = null;
                 filters = null;
+                context.ResetTimeout();
                 return;
             }
 
@@ -79,12 +80,12 @@ namespace DotLiquid
                 environments.Add(LocalVariables);
             if (template.IsThreadSafe)
             {
-                context = new Context(environments, new Hash(), new Hash(), ErrorsOutputMode, MaxIterations);
+                context = new Context(environments, new Hash(), new Hash(), ErrorsOutputMode, MaxIterations, Timeout);
             }
             else
             {
                 environments.Add(template.Assigns);
-                context = new Context(environments, template.InstanceAssigns, template.Registers, ErrorsOutputMode, MaxIterations);
+                context = new Context(environments, template.InstanceAssigns, template.Registers, ErrorsOutputMode, MaxIterations, Timeout);
             }
             registers = Registers;
             filters = Filters;

--- a/src/DotLiquid/RenderParameters.cs
+++ b/src/DotLiquid/RenderParameters.cs
@@ -71,7 +71,7 @@ namespace DotLiquid
                 context = Context;
                 registers = null;
                 filters = null;
-                context.ResetTimeout();
+                context.RestartTimeout();
                 return;
             }
 

--- a/src/DotLiquid/Tags/For.cs
+++ b/src/DotLiquid/Tags/For.cs
@@ -127,6 +127,8 @@ namespace DotLiquid.Tags
             {
                 for (var index = 0; index < segment.Count; index++)
                 {
+                    context.CheckTimeout();
+
                     var item = segment[index];
                     if (item is KeyValuePair<string,object>)
                     {
@@ -170,6 +172,8 @@ namespace DotLiquid.Tags
             int index = 0;
             foreach (object item in collection)
             {
+                context.CheckTimeout();
+
                 if (to != null && to.Value <= index)
                     break;
 


### PR DESCRIPTION
This code can be a problem:

```
{% for i in (1..100000) %}
  {{ i }}
{% endfor %}
```

It is also not always convenient to write exceptions to the output. I added an additional exception handling mode.

Thanks

