### PR TITLE
Allow DotLiquid to be fully capable of using IFormatProvider

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
 build:
   verbosity: minimal # quiet|minimal|normal|detailed
   project: src/DotLiquid.sln
-  publish_nuget: true
+  publish_nuget: false
   publish_nuget_symbols: true
 
 after_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ build:
   verbosity: minimal # quiet|minimal|normal|detailed
   project: src/DotLiquid.sln
   publish_nuget: false
-  publish_nuget_symbols: true
+  publish_nuget_symbols: false
 
 after_build:
   - cmd: md build\pkg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,13 +45,6 @@ artifacts:
 nuget:
   project_feed: true
 
-deploy:
-- provider: NuGet
-  api_key:
-    secure: LrIeQprS+E5FzLkdKGYIYHXy/86Kt8YVhTa4J/VhLzGUO+yXnqI+GxDR+K5Wj/VL
-  skip_symbols: false
-  artifact: /.*\.nupkg/
-
 notifications:
   - provider: Email
     to:

--- a/src/DotLiquid.Tests/OutputTests.cs
+++ b/src/DotLiquid.Tests/OutputTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 using System.IO;
 using NUnit.Framework;
 
@@ -77,23 +78,18 @@ namespace DotLiquid.Tests
             Assert.AreEqual(" bmw ", Template.Parse(" {{best_cars}} ").Render(_assigns));
         }
 
-        
-         string Render(CultureInfo culture)
- 	    {
- 
-             var renderParams = new RenderParameters()
-             {
-                 LocalVariables = _assigns 
-             };
- 	        using (var writer = new StringWriter(culture))
- 	        {
- 	            Template.Parse("{{number}}").Render(writer, renderParams);
- 	            return writer.ToString();
- 	        }
- 	        
- 	    }
- 
- 	    [Test]
+
+        string Render(CultureInfo culture)
+        {
+
+            var renderParams = new RenderParameters
+                               {
+                                   LocalVariables = _assigns 
+                               };
+            return Template.Parse("{{number}}").Render(renderParams, culture);
+        }
+
+        [Test]
  	    public void TestSeperator_Comma()
         {
 

--- a/src/DotLiquid.Tests/OutputTests.cs
+++ b/src/DotLiquid.Tests/OutputTests.cs
@@ -1,3 +1,5 @@
+﻿using System.Globalization;
+using System.IO;
 using NUnit.Framework;
 
 namespace DotLiquid.Tests
@@ -64,7 +66,8 @@ namespace DotLiquid.Tests
             _assigns = Hash.FromAnonymousObject(new
             {
                 best_cars = "bmw",
-                car = Hash.FromAnonymousObject(new { bmw = "good", gm = "bad" })
+                car = Hash.FromAnonymousObject(new { bmw = "good", gm = "bad" }),
+                number = 3.145
             });
         }
 
@@ -73,6 +76,49 @@ namespace DotLiquid.Tests
         {
             Assert.AreEqual(" bmw ", Template.Parse(" {{best_cars}} ").Render(_assigns));
         }
+
+        
+         string Render(CultureInfo culture)
+ 	    {
+ 
+             var renderParams = new RenderParameters()
+             {
+                 LocalVariables = _assigns 
+             };
+ 	        using (var writer = new StringWriter(culture))
+ 	        {
+ 	            Template.Parse("{{number}}").Render(writer, renderParams);
+ 	            return writer.ToString();
+ 	        }
+ 	        
+ 	    }
+ 
+ 	    [Test]
+ 	    public void TestSeperator_Comma()
+        {
+
+            NumberFormatInfo nfi = new NumberFormatInfo();
+            nfi.NumberDecimalSeparator = ",";
+            var c = new CultureInfo("en-US")
+            {
+                NumberFormat = nfi
+            };
+            Assert.AreEqual("3,145", Render(c) );
+
+        }
+ 	    [Test]
+ 	    public void TestSeperator_Decimal()
+        {
+            NumberFormatInfo nfi = new NumberFormatInfo();
+            nfi.NumberDecimalSeparator = ".";
+            var c = new CultureInfo("en-US")
+            {
+                NumberFormat = nfi
+            };
+            Assert.AreEqual("3.145",Render(c) );
+
+        }
+
 
         [Test]
         public void TestVariableTraversing()

--- a/src/DotLiquid/Template.cs
+++ b/src/DotLiquid/Template.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -223,32 +223,34 @@ namespace DotLiquid
         /// Renders the template using default parameters and returns a string containing the result.
         /// </summary>
         /// <returns></returns>
-        public string Render()
+        public string Render(IFormatProvider formatProvider = null)
         {
-            return Render(new RenderParameters());
+            return Render(new RenderParameters(), formatProvider);
         }
 
         /// <summary>
         /// Renders the template using the specified local variables and returns a string containing the result.
         /// </summary>
         /// <param name="localVariables"></param>
+        /// <param name="formatProvider"></param>
         /// <returns></returns>
-        public string Render(Hash localVariables)
+        public string Render(Hash localVariables, IFormatProvider formatProvider=null)
         {
             return Render(new RenderParameters
                 {
                     LocalVariables = localVariables
-                });
+                }, formatProvider);
         }
 
         /// <summary>
         /// Renders the template using the specified parameters and returns a string containing the result.
         /// </summary>
         /// <param name="parameters"></param>
+        /// <param name="formatProvider"></param>
         /// <returns></returns>
-        public string Render(RenderParameters parameters)
+        public string Render(RenderParameters parameters, IFormatProvider formatProvider = null)
         {
-            using (TextWriter writer = new StringWriter())
+            using (TextWriter writer = formatProvider == null ? new StringWriter() : new StringWriter(formatProvider))
             {
                 Render(writer, parameters);
                 return writer.ToString();

--- a/src/DotLiquid/Variable.cs
+++ b/src/DotLiquid/Variable.cs
@@ -1,3 +1,4 @@
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -62,6 +63,8 @@ namespace DotLiquid
 
         public void Render(Context context, TextWriter result)
         {
+            string ToFormattedString(object o, IFormatProvider ifp) => o is IFormattable ifo ? ifo.ToString( null, ifp ) : o.ToString();
+
             object output = RenderInternal(context);
 
             if (output is ILiquidizable)
@@ -79,15 +82,12 @@ namespace DotLiquid
 
                 if (outputString != null) {}
                 else if (output is IEnumerable)
-#if NET35
-                    outputString = string.Join(string.Empty, ((IEnumerable)output).Cast<object>().Select(o => o.ToString()).ToArray());
-#else
-                    outputString = string.Join(string.Empty, ((IEnumerable)output).Cast<object>());
-#endif
+                    outputString = string.Join(string.Empty, ((IEnumerable)output).Cast<object>().Select(o => ToFormattedString(o,result.FormatProvider)).ToArray());
                 else if (output is bool)
                     outputString = output.ToString().ToLower();
                 else
-                    outputString = output.ToString();
+                    outputString = ToFormattedString(output,result.FormatProvider);
+
                 result.Write(outputString);
             }
         }


### PR DESCRIPTION
Previously the following two tests **might** fail

        [Test]
 	    public void TestSeperator_Comma()
        {

            NumberFormatInfo nfi = new NumberFormatInfo();
            nfi.NumberDecimalSeparator = ",";
            var c = new CultureInfo("en-US")
            {
                NumberFormat = nfi
            };
            Assert.AreEqual("3,145", Render(c) );

        }
 	    [Test]
 	    public void TestSeperator_Decimal()
        {
            NumberFormatInfo nfi = new NumberFormatInfo();
            nfi.NumberDecimalSeparator = ".";
            var c = new CultureInfo("en-US")
            {
                NumberFormat = nfi
            };
            Assert.AreEqual("3.145",Render(c) );

        }


depending on the current culture. This was because a raw ``ToString`` was being called on parsed objects. This would use the current culture rather than the culture of the TextWriter or Stream.

This pull request ensures that the culture of the textwriter or stream is used.