### PR TITLE
Fix respect culture

### DIFF
--- a/src/DotLiquid.Tests/OutputTests.cs
+++ b/src/DotLiquid.Tests/OutputTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 using System.IO;
 using NUnit.Framework;
 
@@ -59,23 +60,18 @@ namespace DotLiquid.Tests
             Assert.AreEqual(" bmw ", Template.Parse(" {{best_cars}} ").Render(_assigns));
         }
 
-        
-         string Render(CultureInfo culture)
- 	    {
- 
-             var renderParams = new RenderParameters()
-             {
-                 LocalVariables = _assigns 
-             };
- 	        using (var writer = new StringWriter(culture))
- 	        {
- 	            Template.Parse("{{number}}").Render(writer, renderParams);
- 	            return writer.ToString();
- 	        }
- 	        
- 	    }
- 
- 	    [Test]
+
+        string Render(CultureInfo culture)
+        {
+
+            var renderParams = new RenderParameters
+                               {
+                                   LocalVariables = _assigns 
+                               };
+            return Template.Parse("{{number}}").Render(renderParams, culture);
+        }
+
+        [Test]
  	    public void TestSeperator_Comma()
         {
 

--- a/src/DotLiquid.Tests/OutputTests.cs
+++ b/src/DotLiquid.Tests/OutputTests.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Framework;
+﻿using System.Globalization;
+using System.IO;
+using NUnit.Framework;
 
 namespace DotLiquid.Tests
 {
@@ -46,7 +48,8 @@ namespace DotLiquid.Tests
             _assigns = Hash.FromAnonymousObject(new
             {
                 best_cars = "bmw",
-                car = Hash.FromAnonymousObject(new { bmw = "good", gm = "bad" })
+                car = Hash.FromAnonymousObject(new { bmw = "good", gm = "bad" }),
+                number = 3.145
             });
         }
 
@@ -55,6 +58,49 @@ namespace DotLiquid.Tests
         {
             Assert.AreEqual(" bmw ", Template.Parse(" {{best_cars}} ").Render(_assigns));
         }
+
+        
+         string Render(CultureInfo culture)
+ 	    {
+ 
+             var renderParams = new RenderParameters()
+             {
+                 LocalVariables = _assigns 
+             };
+ 	        using (var writer = new StringWriter(culture))
+ 	        {
+ 	            Template.Parse("{{number}}").Render(writer, renderParams);
+ 	            return writer.ToString();
+ 	        }
+ 	        
+ 	    }
+ 
+ 	    [Test]
+ 	    public void TestSeperator_Comma()
+        {
+
+            NumberFormatInfo nfi = new NumberFormatInfo();
+            nfi.NumberDecimalSeparator = ",";
+            var c = new CultureInfo("en-US")
+            {
+                NumberFormat = nfi
+            };
+            Assert.AreEqual("3,145", Render(c) );
+
+        }
+ 	    [Test]
+ 	    public void TestSeperator_Decimal()
+        {
+            NumberFormatInfo nfi = new NumberFormatInfo();
+            nfi.NumberDecimalSeparator = ".";
+            var c = new CultureInfo("en-US")
+            {
+                NumberFormat = nfi
+            };
+            Assert.AreEqual("3.145",Render(c) );
+
+        }
+
 
         [Test]
         public void TestVariableTraversing()

--- a/src/DotLiquid/Template.cs
+++ b/src/DotLiquid/Template.cs
@@ -295,32 +295,34 @@ namespace DotLiquid
         /// Renders the template using default parameters and returns a string containing the result.
         /// </summary>
         /// <returns></returns>
-        public string Render()
+        public string Render(IFormatProvider formatProvider = null)
         {
-            return Render(new RenderParameters());
+            return Render(new RenderParameters(), formatProvider);
         }
 
         /// <summary>
         /// Renders the template using the specified local variables and returns a string containing the result.
         /// </summary>
         /// <param name="localVariables"></param>
+        /// <param name="formatProvider"></param>
         /// <returns></returns>
-        public string Render(Hash localVariables)
+        public string Render(Hash localVariables, IFormatProvider formatProvider=null)
         {
             return Render(new RenderParameters
                 {
                     LocalVariables = localVariables
-                });
+                }, formatProvider);
         }
 
         /// <summary>
         /// Renders the template using the specified parameters and returns a string containing the result.
         /// </summary>
         /// <param name="parameters"></param>
+        /// <param name="formatProvider"></param>
         /// <returns></returns>
-        public string Render(RenderParameters parameters)
+        public string Render(RenderParameters parameters, IFormatProvider formatProvider = null)
         {
-            using (TextWriter writer = new StringWriter())
+            using (TextWriter writer = formatProvider == null ? new StringWriter() : new StringWriter(formatProvider))
             {
                 Render(writer, parameters);
                 return writer.ToString();

--- a/src/DotLiquid/Variable.cs
+++ b/src/DotLiquid/Variable.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -62,6 +63,8 @@ namespace DotLiquid
 
         public void Render(Context context, TextWriter result)
         {
+            string ToFormattedString(object o, IFormatProvider ifp) => o is IFormattable ifo ? ifo.ToString( null, ifp ) : o.ToString();
+
             object output = RenderInternal(context);
 
             if (output is ILiquidizable)
@@ -77,21 +80,15 @@ namespace DotLiquid
                 //treating Strings as IEnumerable, and was joining Chars in loop
                 string outputString = output as string;
 
-                if (outputString == null)
-                {
-                    if (output is IEnumerable enumerableOutput)
-                    {
-                        outputString = string.Join(string.Empty, enumerableOutput.Cast<object>());
-                    }
-                    else if (output is bool)
-                    {
-                        outputString = output.ToString().ToLower();
-                    }
-                    else
-                    {
-                        outputString = output.ToString();
-                    }
-                }
+              if (outputString != null) {}
+              else if (output is IEnumerable)
+                 outputString = string.Join(string.Empty, ((IEnumerable)output).Cast<object>().Select(o => ToFormattedString(o,result.FormatProvider)).ToArray());
+              else if (output is bool)
+                 outputString = output.ToString().ToLower();
+              else
+                 outputString = ToFormattedString(output,result.FormatProvider);
+
+            
                 result.Write(outputString);
             }
         }


### PR DESCRIPTION
Previously the following tests **might** fail depending on the current culture the test was run in.


        [Test]
 	    public void TestSeperator_Comma()
        {

            NumberFormatInfo nfi = new NumberFormatInfo();
            nfi.NumberDecimalSeparator = ",";
            var c = new CultureInfo("en-US")
            {
                NumberFormat = nfi
            };
            Assert.AreEqual("3,145", Render(c) );

        }
 	    [Test]
 	    public void TestSeperator_Decimal()
        {
            NumberFormatInfo nfi = new NumberFormatInfo();
            nfi.NumberDecimalSeparator = ".";
            var c = new CultureInfo("en-US")
            {
                NumberFormat = nfi
            };
            Assert.AreEqual("3.145",Render(c) );

        }

The pull request ensures that the Render method respects the passed in culture for all object types that support IFormattable.