### PR TITLE
Fix nested dictionary check

### DIFF
--- a/src/DotLiquid.Tests/ContextTests.cs
+++ b/src/DotLiquid.Tests/ContextTests.cs
@@ -614,6 +614,22 @@ namespace DotLiquid.Tests
         }
 
         [Test]
+        public void TestDictionaryAsVariable()
+        {
+            _context["dynamic"] = Hash.FromDictionary(new Dictionary<string, object> { ["lambda"] = "Hello" });
+
+            Assert.AreEqual("Hello", _context["dynamic.lambda"]);
+        }
+
+        [Test]
+        public void TestNestedDictionaryAsVariable()
+        {
+            _context["dynamic"] = Hash.FromDictionary(new Dictionary<string, object> { ["lambda"] = new Dictionary<string, object> { ["name"] = "Hello" } });
+
+            Assert.AreEqual("Hello", _context["dynamic.lambda.name"]);
+        }
+
+        [Test]
         public void TestProcAsVariable()
         {
             _context["dynamic"] = (Proc) delegate { return "Hello"; };

--- a/src/DotLiquid/Hash.cs
+++ b/src/DotLiquid/Hash.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -109,7 +109,7 @@ namespace DotLiquid
 
             foreach (var keyValue in dictionary)
             {
-                    if (keyValue.Value is Dictionary<string, object>)
+                    if (keyValue.Value is IDictionary<string, object>)
                     {
                         result.Add(keyValue.Key, FromDictionary((IDictionary<string, object>) keyValue.Value));
                     }


### PR DESCRIPTION
The `Hash.FromDictionary` method takes an `IDictionary<string, object>` parameter. Within the method, there is a nested dictionary check, but that check then requires a `Dictionary<string, object>` (which is the concrete implementation, not the interface). This PR fixes that and also adds two unit tests for the dictionary as variable use case.