### PR TITLE
Fix culture-specific TestTimes test

### DIFF
--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.Threading;
 using NUnit.Framework;
@@ -365,12 +365,15 @@ namespace DotLiquid.Tests
         [Test]
         public void TestTimes()
         {
-            Helper.AssertTemplateResult("12", "{{ 3 | times:4 }}");
-            Helper.AssertTemplateResult("125", "{{ 10 | times:12.5 }}");
-            Helper.AssertTemplateResult("125", "{{ 10.0 | times:12.5 }}");
-            Helper.AssertTemplateResult("125", "{{ 12.5 | times:10 }}");
-            Helper.AssertTemplateResult("125", "{{ 12.5 | times:10.0 }}");
-            Helper.AssertTemplateResult("foofoofoofoo", "{{ 'foo' | times:4 }}");
+            using (CultureHelper.SetCulture("en-GB"))
+            { 
+                Helper.AssertTemplateResult("12", "{{ 3 | times:4 }}");
+                Helper.AssertTemplateResult("125", "{{ 10 | times:12.5 }}");
+                Helper.AssertTemplateResult("125", "{{ 10.0 | times:12.5 }}");
+                Helper.AssertTemplateResult("125", "{{ 12.5 | times:10 }}");
+                Helper.AssertTemplateResult("125", "{{ 12.5 | times:10.0 }}");
+                Helper.AssertTemplateResult("foofoofoofoo", "{{ 'foo' | times:4 }}");
+            }
         }
 
         [Test]


### PR DESCRIPTION
The `TestTimes` test failed on my machine (Dutch culture). This PR makes the culture explicit to have the test succeed.