### PR TITLE
Ensure that it is possible to use an explicit culture everywhere

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ after_build:
   - cmd: nuget pack src/DotLiquid/DotLiquid.nuspec -Symbols -Version "%APPVEYOR_BUILD_VERSION%" -OutputDirectory build\pkg
 
 test_script:
-  - opencover.console -target:"C:\Tools\NUnit3\nunit3-console.exe" -targetargs:"src\DotLiquid.Tests\bin\Release\net451\DotLiquid.Tests.dll --where=cat!=windows --result=TestsResults.xml;format=AppVeyor" -output:TestsCoverage.xml -filter:"+[DotLiquid]*" -register:user -returntargetcode
+  - opencover.console -target:"C:\Tools\NUnit3\nunit3-console.exe" -targetargs:"src\DotLiquid.Tests\bin\Release\net461\DotLiquid.Tests.dll --where=cat!=windows --result=TestsResults.xml;format=AppVeyor" -output:TestsCoverage.xml -filter:"+[DotLiquid]*" -register:user -returntargetcode
   - codecov -f TestsCoverage.xml
 
 artifacts:

--- a/src/DotLiquid.Tests/ConditionTests.cs
+++ b/src/DotLiquid.Tests/ConditionTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+using System.Globalization;
+using System.Text.RegularExpressions;
 using DotLiquid.Exceptions;
 using DotLiquid.NamingConventions;
 using NUnit.Framework;
@@ -13,8 +14,8 @@ namespace DotLiquid.Tests
         [Test]
         public void TestBasicCondition()
         {
-            Assert.AreEqual(false, new Condition("1", "==", "2").Evaluate(null));
-            Assert.AreEqual(true, new Condition("1", "==", "1").Evaluate(null));
+            Assert.AreEqual(false, new Condition("1", "==", "2").Evaluate(null, CultureInfo.InvariantCulture));
+            Assert.AreEqual(true, new Condition("1", "==", "1").Evaluate(null, CultureInfo.InvariantCulture));
         }
 
         [Test]
@@ -62,7 +63,7 @@ namespace DotLiquid.Tests
         [Test]
         public void TestContainsWorksOnArrays()
         {
-            _context = new Context();
+            _context = new Context(CultureInfo.InvariantCulture);
             _context["array"] = new[] { 1, 2, 3, 4, 5 };
 
             AssertEvaluatesFalse("array", "contains", "0");
@@ -99,7 +100,7 @@ namespace DotLiquid.Tests
         [Test]
         public void TestStartsWithWorksOnArrays()
         {
-            _context = new Context();
+            _context = new Context(CultureInfo.InvariantCulture);
             _context["array"] = new[] { 1, 2, 3, 4, 5 };
 
             AssertEvaluatesFalse("array", "startswith", "0");
@@ -129,7 +130,7 @@ namespace DotLiquid.Tests
         [Test]
         public void TestEndsWithWorksOnArrays()
         {
-            _context = new Context();
+            _context = new Context(CultureInfo.InvariantCulture);
             _context["array"] = new[] { 1, 2, 3, 4, 5 };
 
             AssertEvaluatesFalse("array", "endswith", "0");
@@ -146,7 +147,7 @@ namespace DotLiquid.Tests
         [Test]
         public void TestDictionaryHasKey()
         {
-            _context = new Context();
+            _context = new Context(CultureInfo.InvariantCulture);
             System.Collections.Generic.Dictionary<string, string> testDictionary = new System.Collections.Generic.Dictionary<string, string>
             {
                 { "dave", "0" },
@@ -161,7 +162,7 @@ namespace DotLiquid.Tests
         [Test]
         public void TestDictionaryHasValue()
         {
-            _context = new Context();
+            _context = new Context(CultureInfo.InvariantCulture);
             System.Collections.Generic.Dictionary<string, string> testDictionary = new System.Collections.Generic.Dictionary<string, string>
             {
                 { "dave", "0" },
@@ -177,26 +178,26 @@ namespace DotLiquid.Tests
         public void TestOrCondition()
         {
             Condition condition = new Condition("1", "==", "2");
-            Assert.IsFalse(condition.Evaluate(null));
+            Assert.IsFalse(condition.Evaluate(null,CultureInfo.InvariantCulture));
 
             condition.Or(new Condition("2", "==", "1"));
-            Assert.IsFalse(condition.Evaluate(null));
+            Assert.IsFalse(condition.Evaluate(null,CultureInfo.InvariantCulture));
 
             condition.Or(new Condition("1", "==", "1"));
-            Assert.IsTrue(condition.Evaluate(null));
+            Assert.IsTrue(condition.Evaluate(null,CultureInfo.InvariantCulture));
         }
 
         [Test]
         public void TestAndCondition()
         {
             Condition condition = new Condition("1", "==", "1");
-            Assert.IsTrue(condition.Evaluate(null));
+            Assert.IsTrue(condition.Evaluate(null,CultureInfo.InvariantCulture));
 
             condition.And(new Condition("2", "==", "2"));
-            Assert.IsTrue(condition.Evaluate(null));
+            Assert.IsTrue(condition.Evaluate(null,CultureInfo.InvariantCulture));
 
             condition.And(new Condition("2", "==", "1"));
-            Assert.IsFalse(condition.Evaluate(null));
+            Assert.IsFalse(condition.Evaluate(null,CultureInfo.InvariantCulture));
         }
 
         [Test]
@@ -314,7 +315,7 @@ namespace DotLiquid.Tests
 
             var current = "MyID is {% if MyID == 1 %}1{%endif%}";
             var parse = DotLiquid.Template.Parse(current);
-            var parsedOutput = parse.Render(new RenderParameters() { LocalVariables = Hash.FromDictionary(row) });
+            var parsedOutput = parse.Render(new RenderParameters(CultureInfo.InvariantCulture) { LocalVariables = Hash.FromDictionary(row) });
             Assert.AreEqual("MyID is 1", parsedOutput);
         }
 
@@ -388,19 +389,19 @@ namespace DotLiquid.Tests
 
         private void AssertEvaluatesTrue(string left, string op, string right)
         {
-            Assert.IsTrue(new Condition(left, op, right).Evaluate(_context ?? new Context()),
+            Assert.IsTrue(new Condition(left, op, right).Evaluate(_context ?? new Context(CultureInfo.InvariantCulture), CultureInfo.InvariantCulture),
                 "Evaluated false: {0} {1} {2}", left, op, right);
         }
 
         private void AssertEvaluatesFalse(string left, string op, string right)
         {
-            Assert.IsFalse(new Condition(left, op, right).Evaluate(_context ?? new Context()),
+            Assert.IsFalse(new Condition(left, op, right).Evaluate(_context ?? new Context(CultureInfo.InvariantCulture), CultureInfo.InvariantCulture),
                 "Evaluated true: {0} {1} {2}", left, op, right);
         }
 
         private void AssertError(string left, string op, string right, System.Type errorType)
         {
-            Assert.Throws(errorType, () => new Condition(left, op, right).Evaluate(_context ?? new Context()));
+            Assert.Throws(errorType, () => new Condition(left, op, right).Evaluate(_context ?? new Context(CultureInfo.InvariantCulture), CultureInfo.InvariantCulture));
         }
 
         #endregion

--- a/src/DotLiquid.Tests/ContextTests.cs
+++ b/src/DotLiquid.Tests/ContextTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Dynamic;
+using System.Globalization;
 using System.Linq;
 using DotLiquid.Exceptions;
 using NUnit.Framework;
@@ -141,7 +142,7 @@ namespace DotLiquid.Tests
         [OneTimeSetUp]
         public void SetUp()
         {
-            _context = new Context();
+            _context = new Context(CultureInfo.InvariantCulture);
         }
 
         [Test]
@@ -223,7 +224,7 @@ namespace DotLiquid.Tests
         [Test]
         public void TestVariableNotFoundException()
         {
-            Assert.DoesNotThrow(() => Template.Parse("{{ does_not_exist }}").Render(new RenderParameters
+            Assert.DoesNotThrow(() => Template.Parse("{{ does_not_exist }}").Render(new RenderParameters(CultureInfo.InvariantCulture)
             {
                 RethrowErrors = true
             }));
@@ -304,11 +305,11 @@ namespace DotLiquid.Tests
         [Test]
         public void TestAddFilter()
         {
-            Context context = new Context();
+            Context context = new Context(CultureInfo.InvariantCulture);
             context.AddFilters(new[] { typeof(TestFilters) });
             Assert.AreEqual("hi? hi!", context.Invoke("hi", new List<object> { "hi?" }));
 
-            context = new Context();
+            context = new Context(CultureInfo.InvariantCulture);
             Assert.AreEqual("hi?", context.Invoke("hi", new List<object> { "hi?" }));
 
             context.AddFilters(new[] { typeof(TestFilters) });
@@ -318,13 +319,13 @@ namespace DotLiquid.Tests
         [Test]
         public void TestAddContextFilter()
         {
-            Context context = new Context();
+            Context context = new Context(CultureInfo.InvariantCulture);
             context["name"] = "King Kong";
 
             context.AddFilters(new[] { typeof(TestContextFilters) });
             Assert.AreEqual("hi? hi from King Kong!", context.Invoke("hi", new List<object> { "hi?" }));
 
-            context = new Context();
+            context = new Context(CultureInfo.InvariantCulture);
             Assert.AreEqual("hi?", context.Invoke("hi", new List<object> { "hi?" }));
         }
 
@@ -333,13 +334,13 @@ namespace DotLiquid.Tests
         {
             Template.RegisterFilter(typeof(GlobalFilters));
             Assert.AreEqual("Global test", Template.Parse("{{'test' | notice }}").Render());
-            Assert.AreEqual("Local test", Template.Parse("{{'test' | notice }}").Render(new RenderParameters { Filters = new[] { typeof(LocalFilters) } }));
+            Assert.AreEqual("Local test", Template.Parse("{{'test' | notice }}").Render(new RenderParameters(CultureInfo.InvariantCulture) { Filters = new[] { typeof(LocalFilters) } }));
         }
 
         [Test]
         public void TestOnlyIntendedFiltersMakeItThere()
         {
-            Context context = new Context();
+            Context context = new Context(CultureInfo.InvariantCulture);
             var methodsBefore = context.Strainer.Methods.Select(mi => mi.Name).ToList();
             context.AddFilters(new[] { typeof(TestFilters) });
             var methodsAfter = context.Strainer.Methods.Select(mi => mi.Name).ToList();

--- a/src/DotLiquid.Tests/DotLiquid.Tests.csproj
+++ b/src/DotLiquid.Tests/DotLiquid.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp1.0</TargetFrameworks>
     <AssemblyName>DotLiquid.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../Formosatek-OpenSource.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/src/DotLiquid.Tests/DropTests.cs
+++ b/src/DotLiquid.Tests/DropTests.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using DotLiquid.NamingConventions;
 using NUnit.Framework;
@@ -166,7 +167,7 @@ namespace DotLiquid.Tests
         public void TestDropWithFilters()
         {
             string output = Template.Parse(" {{ product | product_text }} ")
-                .Render(new RenderParameters
+                .Render(new RenderParameters(CultureInfo.InvariantCulture)
                 {
                     LocalVariables = Hash.FromAnonymousObject(new { product = new ProductDrop() }),
                     Filters = new[] { typeof(ProductFilter) }

--- a/src/DotLiquid.Tests/ExceptionHandlingTests.cs
+++ b/src/DotLiquid.Tests/ExceptionHandlingTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using DotLiquid.Exceptions;
 using NUnit.Framework;
 
@@ -82,7 +83,7 @@ namespace DotLiquid.Tests
             var template = Template.Parse(" {% for i in (1..100000) %} {{ i }} {% endfor %} ");
             Assert.Throws<MaximumIterationsExceededException>(() =>
             {
-                template.Render(new RenderParameters
+                template.Render(new RenderParameters(CultureInfo.InvariantCulture)
                 {
                     MaxIterations = 50
                 });
@@ -95,7 +96,7 @@ namespace DotLiquid.Tests
             var template = Template.Parse(" {% for i in (1..1000000) %} {{ i }} {% endfor %} ");
             Assert.Throws<System.TimeoutException>(() =>
             {
-                template.Render(new RenderParameters
+                template.Render(new RenderParameters(CultureInfo.InvariantCulture)
                 {
                     Timeout = 100 //ms
                 });
@@ -110,7 +111,7 @@ namespace DotLiquid.Tests
 
             Assert.Throws<SyntaxException>(() =>
             {
-                var output = template.Render(new RenderParameters
+                var output = template.Render(new RenderParameters(CultureInfo.InvariantCulture)
                 {
                     LocalVariables = assigns,
                     ErrorsOutputMode = ErrorsOutputMode.Rethrow
@@ -124,7 +125,7 @@ namespace DotLiquid.Tests
             var template = Template.Parse("{{test}}");
             Hash assigns = new Hash((h, k) => { throw new SyntaxException("Unknown variable '" + k + "'"); });
 
-            var output = template.Render(new RenderParameters
+            var output = template.Render(new RenderParameters(CultureInfo.InvariantCulture)
             {
                 LocalVariables = assigns,
                 ErrorsOutputMode = ErrorsOutputMode.Suppress
@@ -138,7 +139,7 @@ namespace DotLiquid.Tests
             var template = Template.Parse("{{test}}");
             Hash assigns = new Hash((h, k) => { throw new SyntaxException("Unknown variable '" + k + "'"); });
 
-            var output = template.Render(new RenderParameters
+            var output = template.Render(new RenderParameters(CultureInfo.InvariantCulture)
             {
                 LocalVariables = assigns,
                 ErrorsOutputMode = ErrorsOutputMode.Display

--- a/src/DotLiquid.Tests/FileSystemTests.cs
+++ b/src/DotLiquid.Tests/FileSystemTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using DotLiquid.Exceptions;
 using DotLiquid.FileSystems;
 using NUnit.Framework;
@@ -12,7 +13,7 @@ namespace DotLiquid.Tests
         [Test]
         public void TestDefault()
         {
-            Assert.Throws<FileSystemException>(() => new BlankFileSystem().ReadTemplateFile(new Context(), "dummy"));
+            Assert.Throws<FileSystemException>(() => new BlankFileSystem().ReadTemplateFile(new Context(CultureInfo.InvariantCulture), "dummy"));
         }
         
 

--- a/src/DotLiquid.Tests/FilterTests.cs
+++ b/src/DotLiquid.Tests/FilterTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+using System.Collections;
+using System.Globalization;
 using DotLiquid.Exceptions;
 using NUnit.Framework;
 
@@ -84,7 +85,7 @@ namespace DotLiquid.Tests
         [OneTimeSetUp]
         public void SetUp()
         {
-            _context = new Context();
+            _context = new Context(CultureInfo.InvariantCulture);
         }
 
         /*[Test]
@@ -248,8 +249,8 @@ namespace DotLiquid.Tests
             Template.RegisterFilter(typeof(MoneyFilter));
 
             Assert.AreEqual(" 1000$ ", Template.Parse("{{1000 | money}}").Render());
-            Assert.AreEqual(" 1000$ CAD ", Template.Parse("{{1000 | money}}").Render(new RenderParameters { Filters = new[] { typeof(CanadianMoneyFilter) } }));
-            Assert.AreEqual(" 1000$ CAD ", Template.Parse("{{1000 | money}}").Render(new RenderParameters { Filters = new[] { typeof(CanadianMoneyFilter) } }));
+            Assert.AreEqual(" 1000$ CAD ", Template.Parse("{{1000 | money}}").Render(new RenderParameters(CultureInfo.InvariantCulture) { Filters = new[] { typeof(CanadianMoneyFilter) } }));
+            Assert.AreEqual(" 1000$ CAD ", Template.Parse("{{1000 | money}}").Render(new RenderParameters(CultureInfo.InvariantCulture) { Filters = new[] { typeof(CanadianMoneyFilter) } }));
         }
 
         [Test]

--- a/src/DotLiquid.Tests/FunctionFilterTests.cs
+++ b/src/DotLiquid.Tests/FunctionFilterTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using NUnit.Framework;
 
@@ -11,7 +11,7 @@ namespace DotLiquid.Tests
         [SetUp]
         public void Setup()
         {
-            _context = new Context();
+            _context = new Context(CultureInfo.InvariantCulture);
         }
 
         [Test]

--- a/src/DotLiquid.Tests/Tags/IncludeTagTests.cs
+++ b/src/DotLiquid.Tests/Tags/IncludeTagTests.cs
@@ -3,6 +3,7 @@ using DotLiquid.Exceptions;
 using DotLiquid.FileSystems;
 using NUnit.Framework;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace DotLiquid.Tests.Tags
 {
@@ -105,13 +106,13 @@ namespace DotLiquid.Tests.Tags
         public void TestIncludeTagMustNotBeConsideredError()
         {
             Assert.AreEqual(0, Template.Parse("{% include 'product_template' %}").Errors.Count);
-            Assert.DoesNotThrow(() => Template.Parse("{% include 'product_template' %}").Render(new RenderParameters { RethrowErrors = true }));
+            Assert.DoesNotThrow(() => Template.Parse("{% include 'product_template' %}").Render(new RenderParameters(CultureInfo.InvariantCulture) { RethrowErrors = true }));
         }
 
         [Test]
         public void TestIncludeTagLooksForFileSystemInRegistersFirst()
         {
-            Assert.AreEqual("from OtherFileSystem", Template.Parse("{% include 'pick_a_source' %}").Render(new RenderParameters { Registers = Hash.FromAnonymousObject(new { file_system = new OtherFileSystem() }) }));
+            Assert.AreEqual("from OtherFileSystem", Template.Parse("{% include 'pick_a_source' %}").Render(new RenderParameters(CultureInfo.InvariantCulture) { Registers = Hash.FromAnonymousObject(new { file_system = new OtherFileSystem() }) }));
         }
 
         [Test]
@@ -174,7 +175,7 @@ namespace DotLiquid.Tests.Tags
         {
             Template.FileSystem = new InfiniteFileSystem();
 
-            Assert.Throws<StackLevelException>(() => Template.Parse("{% include 'loop' %}").Render(new RenderParameters { RethrowErrors = true }));
+            Assert.Throws<StackLevelException>(() => Template.Parse("{% include 'loop' %}").Render(new RenderParameters(CultureInfo.InvariantCulture) { RethrowErrors = true }));
         }
 
         [Test]
@@ -196,7 +197,7 @@ namespace DotLiquid.Tests.Tags
         public void TestUndefinedTemplateVariableWithLocalFileSystem()
         {
             Template.FileSystem = new LocalFileSystem(string.Empty);
-            Assert.Throws<FileSystemException>(() => Template.Parse(" hello {% include notthere %} world ").Render(new RenderParameters
+            Assert.Throws<FileSystemException>(() => Template.Parse(" hello {% include notthere %} world ").Render(new RenderParameters(CultureInfo.InvariantCulture)
             {
                 RethrowErrors = true
             }));
@@ -206,7 +207,7 @@ namespace DotLiquid.Tests.Tags
         public void TestMissingTemplateWithLocalFileSystem()
         {
             Template.FileSystem = new LocalFileSystem(string.Empty);
-            Assert.Throws<FileSystemException>(() => Template.Parse(" hello {% include 'doesnotexist' %} world ").Render(new RenderParameters
+            Assert.Throws<FileSystemException>(() => Template.Parse(" hello {% include 'doesnotexist' %} world ").Render(new RenderParameters(CultureInfo.InvariantCulture)
             {
                 RethrowErrors = true
             }));

--- a/src/DotLiquid.Tests/Tags/StandardTagTests.cs
+++ b/src/DotLiquid.Tests/Tags/StandardTagTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using DotLiquid.Exceptions;
 using NUnit.Framework;
 
@@ -13,7 +14,7 @@ namespace DotLiquid.Tests.Tags
             Tag tag = new Tag();
             tag.Initialize("tag", null, null);
             Assert.AreEqual("tag", tag.Name);
-            Assert.AreEqual(string.Empty, tag.Render(new Context()));
+            Assert.AreEqual(string.Empty, tag.Render(new Context(CultureInfo.InvariantCulture)));
         }
 
         [Test]

--- a/src/DotLiquid.Tests/TemplateTests.cs
+++ b/src/DotLiquid.Tests/TemplateTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Web;
@@ -153,9 +154,9 @@ namespace DotLiquid.Tests
         {
             Template template = Template.Parse("{{test}}");
 
-            using (TextWriter writer = new StringWriter())
+            using (TextWriter writer = new StringWriter(CultureInfo.InvariantCulture))
             {
-                template.Render(writer, new RenderParameters { LocalVariables = Hash.FromAnonymousObject(new { test = "worked" }) });
+                template.Render(writer, new RenderParameters(CultureInfo.InvariantCulture) { LocalVariables = Hash.FromAnonymousObject(new { test = "worked" }) });
 
                 Assert.AreEqual("worked", writer.ToString());
             }
@@ -167,7 +168,7 @@ namespace DotLiquid.Tests
             Template template = Template.Parse("{{test}}");
 
             var output = new MemoryStream();
-            template.Render(output, new RenderParameters { LocalVariables = Hash.FromAnonymousObject(new { test = "worked" }) });
+            template.Render(output, new RenderParameters(CultureInfo.InvariantCulture) { LocalVariables = Hash.FromAnonymousObject(new { test = "worked" }) });
 
             output.Seek(0, SeekOrigin.Begin);
 

--- a/src/DotLiquid.Tests/VariableResolutionTests.cs
+++ b/src/DotLiquid.Tests/VariableResolutionTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using NUnit.Framework;
 
 namespace DotLiquid.Tests
@@ -73,13 +74,13 @@ namespace DotLiquid.Tests
             Template template = Template.Parse("Hello {{ test }}");
             Hash assigns = new Hash((h, k) => { throw new Exception("Unknown variable '" + k + "'"); });
             assigns["test"] = "Tobi";
-            Assert.AreEqual("Hello Tobi", template.Render(new RenderParameters
+            Assert.AreEqual("Hello Tobi", template.Render(new RenderParameters(CultureInfo.InvariantCulture)
             {
                 LocalVariables = assigns,
                 RethrowErrors = true
             }));
             assigns.Remove("test");
-            Exception ex = Assert.Throws<Exception>(() => template.Render(new RenderParameters
+            Exception ex = Assert.Throws<Exception>(() => template.Render(new RenderParameters(CultureInfo.InvariantCulture)
             {
                 LocalVariables = assigns,
                 RethrowErrors = true

--- a/src/DotLiquid.sln
+++ b/src/DotLiquid.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26403.7
+VisualStudioVersion = 15.0.26730.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{2CF66DE5-5452-415E-B932-AC63BBD5648A}"
 	ProjectSection(SolutionItems) = preProject
@@ -43,6 +43,9 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {56644150-2CBE-4639-A6BC-E1946E82971D}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0

--- a/src/DotLiquid/Condition.cs
+++ b/src/DotLiquid/Condition.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -60,17 +60,17 @@ namespace DotLiquid
         {
         }
 
-        public virtual bool Evaluate(Context context)
+        public virtual bool Evaluate(Context context, IFormatProvider formatProvider)
         {
-            context = context ?? new Context();
+            context = context ?? new Context(formatProvider);
             bool result = InterpretCondition(Left, Right, Operator, context);
 
             switch (_childRelation)
             {
                 case "or":
-                    return result || _childCondition.Evaluate(context);
+                    return result || _childCondition.Evaluate(context, formatProvider);
                 case "and":
-                    return result && _childCondition.Evaluate(context);
+                    return result && _childCondition.Evaluate(context, formatProvider);
                 default:
                     return result;
             }
@@ -159,7 +159,7 @@ namespace DotLiquid
             get { return true; }
         }
 
-        public override bool Evaluate(Context context)
+        public override bool Evaluate(Context context, IFormatProvider formatProvider)
         {
             return true;
         }

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -62,7 +62,14 @@ namespace DotLiquid
         /// <param name="outerScope"></param>
         /// <param name="registers"></param>
         /// <param name="errorsOutputMode"></param>
-        public Context(List<Hash> environments, Hash outerScope, Hash registers, ErrorsOutputMode errorsOutputMode, int maxIterations, int timeout)
+        public Context
+            (List<Hash> environments
+             , Hash outerScope
+             , Hash registers
+             , ErrorsOutputMode errorsOutputMode
+             , int maxIterations
+             , int timeout
+             , IFormatProvider formatProvider)
         {
             Environments = environments;
 
@@ -76,6 +83,7 @@ namespace DotLiquid
             _errorsOutputMode = errorsOutputMode;
             _maxIterations = maxIterations;
             _timeout = timeout;
+            FormatProvider = formatProvider;
 
             RestartTimeout();
 
@@ -85,8 +93,8 @@ namespace DotLiquid
         /// <summary>
         /// Creates a new rendering context
         /// </summary>
-        public Context()
-            : this(new List<Hash>(), new Hash(), new Hash(), ErrorsOutputMode.Display, 0, 0)
+        public Context(IFormatProvider formatProvider)
+            : this(new List<Hash>(), new Hash(), new Hash(), ErrorsOutputMode.Display, 0, 0, formatProvider )
         {
         }
 
@@ -343,7 +351,7 @@ namespace DotLiquid
                 // For cultures with "," as the decimal separator, allow
                 // both "," and "." to be used as the separator.
                 // First try to parse using current culture.
-                if (float.TryParse(match.Groups[1].Value, out float result))
+                if (float.TryParse(match.Groups[1].Value, NumberStyles.Number, FormatProvider, out float result))
                     return result;
 
                 // If that fails, try to parse using invariant culture.
@@ -352,6 +360,8 @@ namespace DotLiquid
 
             return Variable(key, notifyNotFound);
         }
+
+        public IFormatProvider FormatProvider { get; }
 
         /// <summary>
         /// Fetches an object starting at the local scope and then moving up

--- a/src/DotLiquid/DotLiquid.csproj
+++ b/src/DotLiquid/DotLiquid.csproj
@@ -37,6 +37,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Reference Include="System.Threading.Thread">
+      <HintPath>..\..\..\..\.nuget\packages\system.threading.thread\4.3.0\ref\netstandard1.3\System.Threading.Thread.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="LICENSE.txt">
       <Pack>true</Pack>
     </None>

--- a/src/DotLiquid/RenderParameters.cs
+++ b/src/DotLiquid/RenderParameters.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace DotLiquid
 {
@@ -68,6 +69,12 @@ namespace DotLiquid
         }
 
         private int _timeout = 0;
+        public IFormatProvider FormatProvider { get; }
+
+        public RenderParameters(IFormatProvider formatProvider)
+        {
+            FormatProvider = formatProvider ?? throw new ArgumentNullException( nameof(formatProvider) );
+        }
 
         /// <summary>
         /// Rendering timeout in ms
@@ -94,12 +101,12 @@ namespace DotLiquid
                 environments.Add(LocalVariables);
             if (template.IsThreadSafe)
             {
-                context = new Context(environments, new Hash(), new Hash(), ErrorsOutputMode, MaxIterations, Timeout);
+                context = new Context(environments, new Hash(), new Hash(), ErrorsOutputMode, MaxIterations, Timeout, FormatProvider);
             }
             else
             {
                 environments.Add(template.Assigns);
-                context = new Context(environments, template.InstanceAssigns, template.Registers, ErrorsOutputMode, MaxIterations, Timeout);
+                context = new Context(environments, template.InstanceAssigns, template.Registers, ErrorsOutputMode, MaxIterations, Timeout, FormatProvider);
             }
             registers = Registers;
             filters = Filters;
@@ -109,10 +116,13 @@ namespace DotLiquid
         /// Creates a RenderParameters from a context
         /// </summary>
         /// <param name="context"></param>
+        /// <param name="formatProvider"></param>
         /// <returns></returns>
-        public static RenderParameters FromContext(Context context)
+        public static RenderParameters FromContext(Context context, IFormatProvider formatProvider)
         {
-            return new RenderParameters { Context = context };
+            if (context == null)
+                throw new ArgumentNullException( nameof(context) );
+            return new RenderParameters(formatProvider) { Context = context };
         }
     }
 }

--- a/src/DotLiquid/Tag.cs
+++ b/src/DotLiquid/Tag.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 
 namespace DotLiquid
@@ -82,7 +82,7 @@ namespace DotLiquid
         /// <returns></returns>
         internal string Render(Context context)
         {
-            using (TextWriter result = new StringWriter())
+            using (TextWriter result = new StringWriter(context.FormatProvider))
             {
                 Render(context, result);
                 return result.ToString();

--- a/src/DotLiquid/Tags/Capture.cs
+++ b/src/DotLiquid/Tags/Capture.cs
@@ -39,7 +39,7 @@ namespace DotLiquid.Tags
 
         public override void Render(Context context, TextWriter result)
         {
-            using (TextWriter temp = new StringWriter())
+            using (TextWriter temp = new StringWriter(result.FormatProvider))
             {
                 base.Render(context, temp);
                 context.Scopes.Last()[_to] = temp.ToString();

--- a/src/DotLiquid/Tags/Case.cs
+++ b/src/DotLiquid/Tags/Case.cs
@@ -59,7 +59,7 @@ namespace DotLiquid.Tags
                             return;
                         }
                     }
-                    else if (block.Evaluate(context))
+                    else if (block.Evaluate(context, result.FormatProvider))
                     {
                         executeElseBlock = false;
                         RenderAll(block.Attachment, context, result);

--- a/src/DotLiquid/Tags/Extends.cs
+++ b/src/DotLiquid/Tags/Extends.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -58,6 +59,7 @@ namespace DotLiquid.Tags
     /// </example>
     public class Extends : DotLiquid.Block
     {
+
         private static readonly Regex Syntax = R.B(@"^({0})", Liquid.QuotedFragment);
 
         private string _templateName;
@@ -139,7 +141,7 @@ namespace DotLiquid.Tags
                         ((List<Block>)context.Scopes[0]["extends"]).Add(block);
                     }
                 }
-                template.Render(result, RenderParameters.FromContext(context));
+                template.Render(result, RenderParameters.FromContext(context, result.FormatProvider));
             });
         }
 

--- a/src/DotLiquid/Tags/Html/TableRow.cs
+++ b/src/DotLiquid/Tags/Html/TableRow.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -102,7 +102,7 @@ namespace DotLiquid.Tags.Html
 
                 ++col;
 
-                using (TextWriter temp = new StringWriter())
+                using (TextWriter temp = new StringWriter(result.FormatProvider))
                 {
                     RenderAll(NodeList, context, temp);
                     result.Write("<td class=\"col{0}\">{1}</td>", col, temp.ToString());

--- a/src/DotLiquid/Tags/If.cs
+++ b/src/DotLiquid/Tags/If.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
 using DotLiquid.Exceptions;
@@ -50,7 +50,7 @@ namespace DotLiquid.Tags
             {
                 foreach (Condition block in Blocks)
                 {
-                    if (block.Evaluate(context))
+                    if (block.Evaluate(context, result.FormatProvider))
                     {
                         RenderAll(block.Attachment, context, result);
                         return;

--- a/src/DotLiquid/Tags/IfChanged.cs
+++ b/src/DotLiquid/Tags/IfChanged.cs
@@ -9,7 +9,7 @@ namespace DotLiquid.Tags
             context.Stack(() =>
             {
                 string tempString;
-                using (TextWriter temp = new StringWriter())
+                using (TextWriter temp = new StringWriter(result.FormatProvider))
                 {
                     RenderAll(NodeList, context, temp);
                     tempString = temp.ToString();

--- a/src/DotLiquid/Tags/Include.cs
+++ b/src/DotLiquid/Tags/Include.cs
@@ -66,13 +66,13 @@ namespace DotLiquid.Tags
                     ((IEnumerable) variable).Cast<object>().ToList().ForEach(v =>
                     {
                         context[shortenedTemplateName] = v;
-                        partial.Render(result, RenderParameters.FromContext(context));
+                        partial.Render(result, RenderParameters.FromContext(context, result.FormatProvider));
                     });
                     return;
                 }
 
                 context[shortenedTemplateName] = variable;
-                partial.Render(result, RenderParameters.FromContext(context));
+                partial.Render(result, RenderParameters.FromContext(context, result.FormatProvider));
             });
         }
     }

--- a/src/DotLiquid/Tags/Unless.cs
+++ b/src/DotLiquid/Tags/Unless.cs
@@ -16,7 +16,7 @@ namespace DotLiquid.Tags
             {
                 // First condition is interpreted backwards (if not)
                 Condition block = Blocks.First();
-                if (!block.Evaluate(context))
+                if (!block.Evaluate(context, result.FormatProvider))
                 {
                     RenderAll(block.Attachment, context, result);
                     return;
@@ -24,7 +24,7 @@ namespace DotLiquid.Tags
 
                 // After the first condition unless works just like if
                 foreach (Condition forEachBlock in Blocks.Skip(1))
-                    if (forEachBlock.Evaluate(context))
+                    if (forEachBlock.Evaluate(context, result.FormatProvider))
                     {
                         RenderAll(forEachBlock.Attachment, context, result);
                         return;

--- a/src/DotLiquid/Template.cs
+++ b/src/DotLiquid/Template.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -295,12 +296,13 @@ namespace DotLiquid
         }
 
         /// <summary>
-        /// Renders the template using default parameters and returns a string containing the result.
+        /// Renders the template using default parameters and the current culture and returns a string containing the result.
         /// </summary>
         /// <returns></returns>
         public string Render(IFormatProvider formatProvider = null)
         {
-            return Render(new RenderParameters(), formatProvider);
+            formatProvider = formatProvider ?? CultureInfo.CurrentCulture;
+            return Render(new RenderParameters(formatProvider));
         }
 
         /// <summary>
@@ -311,35 +313,50 @@ namespace DotLiquid
         /// <returns></returns>
         public string Render(Hash localVariables, IFormatProvider formatProvider=null)
         {
-            return Render(new RenderParameters
+            formatProvider = formatProvider ?? CultureInfo.CurrentCulture;
+            using (var writer = new StringWriter( formatProvider ))
+            {
+                formatProvider = writer.FormatProvider;
+
+                var parameters = new RenderParameters(formatProvider)
                 {
                     LocalVariables = localVariables
-                }, formatProvider);
+                };
+
+                return Render( writer, parameters );
+            }
         }
+
 
         /// <summary>
         /// Renders the template using the specified parameters and returns a string containing the result.
         /// </summary>
         /// <param name="parameters"></param>
-        /// <param name="formatProvider"></param>
         /// <returns></returns>
-        public string Render(RenderParameters parameters, IFormatProvider formatProvider = null)
+        public string Render(RenderParameters parameters)
         {
-            using (TextWriter writer = formatProvider == null ? new StringWriter() : new StringWriter(formatProvider))
+            using (var writer =  new StringWriter(parameters.FormatProvider))
             {
-                Render(writer, parameters);
-                return writer.ToString();
+                return Render( writer, parameters );
             }
         }
 
-        /// <summary>
-        /// Renders the template into the specified StreamWriter.
-        /// </summary>
-        /// <param name="result"></param>
-        /// <param name="parameters"></param>
-        public void Render(TextWriter result, RenderParameters parameters)
+        public string Render(TextWriter writer, RenderParameters parameters)
         {
-            RenderInternal(result, parameters);
+            if (writer == null)
+                throw new ArgumentNullException( nameof(writer) );
+            if (parameters == null)
+                throw new ArgumentNullException( nameof(parameters) );
+            RenderInternal( writer, parameters );
+            return writer.ToString();
+        }
+
+        /// <inheritdoc />
+        private class StreamWriterWithFormatProvider : StreamWriter
+        {
+            public StreamWriterWithFormatProvider(Stream stream, IFormatProvider formatProvider) : base( stream ) => FormatProvider = formatProvider;
+
+            public override IFormatProvider FormatProvider { get; }
         }
 
         /// <summary>
@@ -351,7 +368,7 @@ namespace DotLiquid
         {
             // Can't dispose this new StreamWriter, because it would close the
             // passed-in stream, which isn't up to us.
-            StreamWriter streamWriter = new StreamWriter(stream);
+            StreamWriter streamWriter = new StreamWriterWithFormatProvider( stream, parameters.FormatProvider );
             RenderInternal(streamWriter, parameters);
             streamWriter.Flush();
         }


### PR DESCRIPTION
We found that the following test would fail on the users computer if they had their culture set different to what we expect. Our code should run independant of the culture of the current computer.

        private class ActionDisposable : IDisposable
        {
            private readonly Action _Action;

            public ActionDisposable(Action action) => _Action = action;

            public void Dispose() => _Action();
        }
        IDisposable SetCulture(CultureInfo ci)
        {
            var old = CultureInfo.CurrentCulture;
            CultureInfo.CurrentCulture = ci;
            return new ActionDisposable( ()=>CultureInfo.CurrentCulture = old );
        }



        [Test]
        public void ParsingWithCommaDecimalSeparatorShouldWorkWhenPassedCultureIsDifferentToCurrentCulture()
        {
            var ci = new CultureInfo(CultureInfo.CurrentCulture.Name)
            {
                NumberFormat =
                      {
                          NumberDecimalSeparator = ","
                          , NumberGroupSeparator = "."
                      }
            };
            using (SetCulture( ci ))
            {
                var t = Template.Parse( "{{2.5}}" );
                var result = t.Render( new Hash(), CultureInfo.InvariantCulture );

                Assert.AreEqual( result, "2.5" );
            }
        }

Before fixes the result would be 25 even though the invariantculture was being passed to render. It turns out that there were other places in the code that pulled the default culture. This fix changes that. The majority of the changes are just passing the culture from the outerscope through to where calls like

    float.TryParse

are actually used. Messy but necessary.

I have commit rights but I'd appreciate if somebody could review and give feedback if this is acceptable.