### PR TITLE
Update LocalFileSystem.cs

### DIFF
--- a/src/DotLiquid/FileSystems/LocalFileSystem.cs
+++ b/src/DotLiquid/FileSystems/LocalFileSystem.cs
@@ -44,7 +44,8 @@ namespace DotLiquid.FileSystems
                 ? Path.Combine(Path.Combine(Root, Path.GetDirectoryName(templatePath)), string.Format("_{0}.liquid", Path.GetFileName(templatePath)))
                 : Path.Combine(Root, string.Format("_{0}.liquid", templatePath));
 
-            string escapedPath = Root.Replace(@"\", @"\\").Replace("(", @"\(").Replace(")", @"\)");
+            //string escapedPath = Root.Replace(@"\", @"\\").Replace("(", @"\(").Replace(")", @"\)");
+            string escapedPath = Regex.Escape(Root);
             if (!Regex.IsMatch(Path.GetFullPath(fullPath), string.Format("^{0}", escapedPath)))
                 throw new FileSystemException(Liquid.ResourceManager.GetString("LocalFileSystemIllegalTemplatePathException"), Path.GetFullPath(fullPath));
 


### PR DESCRIPTION
Safer regex-escaping for root by .net. "Program Files (x86)\..." works also..