### PR TITLE
Added support for strip, lstrip and rstrip filters

### DIFF
--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -77,6 +77,36 @@ namespace DotLiquid.Tests
         }
 
         [Test]
+        public void TestStrip()
+        {
+            Assert.AreEqual("test", StandardFilters.Strip("  test  "));
+            Assert.AreEqual("test", StandardFilters.Strip("   test"));
+            Assert.AreEqual("test", StandardFilters.Strip("test   "));
+            Assert.AreEqual("test", StandardFilters.Strip("test"));
+            Assert.AreEqual(null, StandardFilters.Strip(null));
+        }
+
+        [Test]
+        public void TestLStrip()
+        {
+            Assert.AreEqual("test  ", StandardFilters.Lstrip("  test  "));
+            Assert.AreEqual("test", StandardFilters.Lstrip("   test"));
+            Assert.AreEqual("test   ", StandardFilters.Lstrip("test   "));
+            Assert.AreEqual("test", StandardFilters.Lstrip("test"));
+            Assert.AreEqual(null, StandardFilters.Lstrip(null));
+        }
+
+        [Test]
+        public void TestRStrip()
+        {
+            Assert.AreEqual("  test", StandardFilters.Rstrip("  test  "));
+            Assert.AreEqual("   test", StandardFilters.Rstrip("   test"));
+            Assert.AreEqual("test", StandardFilters.Rstrip("test   "));
+            Assert.AreEqual("test", StandardFilters.Rstrip("test"));
+            Assert.AreEqual(null, StandardFilters.Rstrip(null));
+        }
+
+        [Test]
         public void TestJoin()
         {
             Assert.AreEqual(null, StandardFilters.Join(null));

--- a/src/DotLiquid/StandardFilters.cs
+++ b/src/DotLiquid/StandardFilters.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Net;
@@ -203,6 +203,36 @@ namespace DotLiquid
             return input.IsNullOrWhiteSpace()
                 ? input
                 : Regex.Replace(input, @"<.*?>", string.Empty, RegexOptions.None, Template.RegexTimeOut);
+        }
+
+        /// <summary>
+        /// Strip all whitespace from input
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static string Strip(string input)
+        {
+            return input?.Trim();
+        }
+
+        /// <summary>
+        /// Strip all leading whitespace from input
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static string Lstrip(string input)
+        {
+            return input?.TrimStart();
+        }
+
+        /// <summary>
+        /// Strip all trailing whitespace from input
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static string Rstrip(string input)
+        {
+            return input?.TrimEnd();
         }
 
         /// <summary>


### PR DESCRIPTION
The [Liquid docs](https://github.com/Shopify/liquid/wiki/Liquid-for-Designers#standard-filters) includes strip,  lstrip and rstrip.  This PR adds those filters to the StandardFilters class.