### PR TITLE
#278: Wildcard global member allowance

### DIFF
--- a/src/DotLiquid.Tests/LiquidTypeAttributeTests.cs
+++ b/src/DotLiquid.Tests/LiquidTypeAttributeTests.cs
@@ -17,6 +17,26 @@ namespace DotLiquid.Tests
             public string Name { get; set; }
         }
 
+        [LiquidType("*")]
+        public class MyLiquidTypeWithGlobalMemberAllowance
+        {
+            public string Name { get; set; }
+        }
+
+        [LiquidType("*")]
+        public class MyLiquidTypeWithGlobalMemberAllowanceAndHiddenChild
+        {
+            public string Name { get; set; }
+            public MyLiquidTypeWithNoAllowedMembers Child { get; set; }
+        }
+
+        [LiquidType("*")]
+        public class MyLiquidTypeWithGlobalMemberAllowanceAndExposedChild
+        {
+            public string Name { get; set; }
+            public MyLiquidTypeWithAllowedMember Child { get; set; }
+        }
+
         [Test]
         public void TestLiquidTypeAttributeWithNoAllowedMembers()
         {
@@ -31,6 +51,30 @@ namespace DotLiquid.Tests
             Template template = Template.Parse("{{context.Name}}");
             var output = template.Render(Hash.FromAnonymousObject(new { context = new MyLiquidTypeWithAllowedMember() { Name = "worked" } }));
             Assert.AreEqual("worked", output);
+        }
+
+        [Test]
+        public void TestLiquidTypeAttributeWithGlobalMemberAllowance()
+        {
+            Template template = Template.Parse("{{context.Name}}");
+            var output = template.Render(Hash.FromAnonymousObject(new { context = new MyLiquidTypeWithGlobalMemberAllowance() { Name = "worked" } }));
+            Assert.AreEqual("worked", output);
+        }
+
+        [Test]
+        public void TestLiquidTypeAttributeWithGlobalMemberAllowanceDoesNotExposeHiddenChildMembers()
+        {
+            Template template = Template.Parse("|{{context.Name}}|{{context.Child.Name}}|");
+            var output = template.Render(Hash.FromAnonymousObject(new { context = new MyLiquidTypeWithGlobalMemberAllowanceAndHiddenChild() { Name = "worked_parent", Child = new MyLiquidTypeWithNoAllowedMembers() { Name = "worked_child" } } }));
+            Assert.AreEqual("|worked_parent||", output);
+        }
+
+        [Test]
+        public void TestLiquidTypeAttributeWithGlobalMemberAllowanceDoesExposeValidChildMembers()
+        {
+            Template template = Template.Parse("|{{context.Name}}|{{context.Child.Name}}|");
+            var output = template.Render(Hash.FromAnonymousObject(new { context = new MyLiquidTypeWithGlobalMemberAllowanceAndExposedChild() { Name = "worked_parent", Child = new MyLiquidTypeWithAllowedMember() { Name = "worked_child" } } }));
+            Assert.AreEqual("|worked_parent|worked_child|", output);
         }
     }
 }

--- a/src/DotLiquid/Drop.cs
+++ b/src/DotLiquid/Drop.cs
@@ -243,6 +243,7 @@ namespace DotLiquid
         private readonly string[] _allowedMembers;
         private readonly object _proxiedObject;
         private readonly Func<object, object> _value;
+        private readonly bool _allowAllMembers;
 
         /// <summary>
         /// Create a new DropProxy object
@@ -253,16 +254,23 @@ namespace DotLiquid
         {
             _proxiedObject = obj;
             _allowedMembers = allowedMembers;
+            // Allow all member if the list of allowed members is size 1 and is a wild card
+            _allowAllMembers = _allowedMembers?.Length == 1 && _allowedMembers[0] == "*";
         }
 
+        /// <summary>
+        /// Create a new DropProxy object
+        /// </summary>
+        /// <param name="obj">The object to create a proxy for</param>
+        /// <param name="allowedMembers">An array of property and method names that are allowed to be called on the object.</param>
+        /// <param name="value">Function that converts the specified type into a Liquid Drop-compatible object (eg, implements ILiquidizable)</param>
         public DropProxy(object obj, string[] allowedMembers, Func<object, object> value)
+            : this(obj, allowedMembers)
         {
-            _proxiedObject = obj;
-            _allowedMembers = allowedMembers;
             _value = value;
         }
 
-#region IValueTypeConvertible
+        #region IValueTypeConvertible
 
         public virtual object ConvertToValueType()
         {
@@ -272,10 +280,10 @@ namespace DotLiquid
             return _value(_proxiedObject);
         }
 
-#endregion IValueTypeConvertible
+        #endregion IValueTypeConvertible
 
         internal override object GetObject() { return _proxiedObject; }
 
-        internal override TypeResolution CreateTypeResolution(Type type) { return new TypeResolution(type, mi => _allowedMembers.Contains(mi.Name)); }
+        internal override TypeResolution CreateTypeResolution(Type type) { return new TypeResolution(type, mi => _allowAllMembers || _allowedMembers.Contains(mi.Name)); }
     }
 }


### PR DESCRIPTION
#278 (Wildcard global member allowance):

- Modified Drop to allow all members if the filter is ["*"]
- Added unit tests to verify correct behavior