### PR TITLE
Fixed Issue with For Loop Not Working in Sandbox

### DIFF
--- a/src/DotLiquid/Tags/For.cs
+++ b/src/DotLiquid/Tags/For.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -138,17 +138,17 @@ namespace DotLiquid.Tags
 
                     } else 
                         context[_variableName] = item;
-                    
-                    context["forloop"] = Hash.FromAnonymousObject(new
+
+                    context["forloop"] = Hash.FromDictionary(new Dictionary<string, object>
                     {
-                        name = _name,
-                        length = length,
-                        index = index + 1,
-                        index0 = index,
-                        rindex = length - index,
-                        rindex0 = length - index - 1,
-                        first = (index == 0),
-                        last = (index == length - 1)
+                        ["name"] = _name,
+                        ["length"] = length,
+                        ["index"] = index + 1,
+                        ["index0"] = index,
+                        ["rindex"] = length - index,
+                        ["rindex0"] = length - index - 1,
+                        ["first"] = (index == 0),
+                        ["last"] = (index == length - 1)
                     });
                     try
                     {


### PR DESCRIPTION
The For loop functionality was throwing an Exception when it was ran within a Sandbox. I started creating a unit test to reproduce this, however I started running into issues with the System.Runtime.Remoting library not being available for .NETCore, which seemed to prevent the DotLiquid.Tests project from building.  I was attempting to follow the link below to setup the test.

https://docs.microsoft.com/en-us/dotnet/framework/misc/how-to-run-partially-trusted-code-in-a-sandbox