### PR TITLE
Feature/fix numeric promotion performance

### DIFF
--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -459,6 +459,19 @@ namespace DotLiquid.Tests
         }
 
         [Test]
+        public void TestInt32DividedByInt64 ()
+        {
+            int a = 20;
+            long b = 5;
+            var c = a / b;
+            Assert.AreEqual( c, (long)4 );
+
+
+            Hash assigns = Hash.FromAnonymousObject(new { a = a, b = b});
+            Helper.AssertTemplateResult("4", "{{ a | divided_by:b }}", assigns);
+        }
+
+        [Test]
         public void TestModulo()
         {
             Helper.AssertTemplateResult("1", "{{ 3 | modulo:2 }}");

--- a/src/DotLiquid/DotLiquid.csproj
+++ b/src/DotLiquid/DotLiquid.csproj
@@ -34,6 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="SonarAnalyzer.CSharp" Version="5.11.0.1761" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DotLiquid/StandardFilters.cs
+++ b/src/DotLiquid/StandardFilters.cs
@@ -644,7 +644,9 @@ namespace DotLiquid
             }
 
             return ExpressionUtility.CreateExpression
-                                    (operation, input.GetType(), operand.GetType(), input.GetType(), true)
+                                    ( body: operation
+                                      , leftType: input.GetType()
+                                      , rightType: operand.GetType() )
                                     .DynamicInvoke(input, operand);
         }
     }

--- a/src/DotLiquid/Util/ExpressionUtility.cs
+++ b/src/DotLiquid/Util/ExpressionUtility.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
+using DotLiquid.Exceptions;
 
 namespace DotLiquid.Util
 {
@@ -9,45 +12,101 @@ namespace DotLiquid.Util
     /// </summary>
     public static class ExpressionUtility
     {
+        private static readonly Dictionary<Type, Type[]> NumericTypePromotions;
+
+        static ExpressionUtility()
+        {
+            NumericTypePromotions = new Dictionary<Type, Type[]>();
+
+            void Add(Type key, params Type[] types) => NumericTypePromotions[key] = types;
+            // Using the promotion table at
+            // https://docs.microsoft.com/en-us/dotnet/standard/base-types/conversion-tables
+
+            Add(typeof(Byte), typeof(UInt16), typeof(Int16), typeof(UInt32), typeof(Int32), typeof(UInt64), typeof(Int64), typeof(Single), typeof(Double), typeof(Decimal));
+            Add(typeof(SByte), typeof(Int16), typeof(Int32), typeof(Int64), typeof(Single), typeof(Double), typeof(Decimal));
+            Add(typeof(Int16), typeof(Int32), typeof(Int64), typeof(Single), typeof(Double), typeof(Decimal));
+            Add(typeof(UInt16), typeof(UInt32), typeof(Int32), typeof(UInt64), typeof(Int64), typeof(Single), typeof(Double), typeof(Decimal));
+            Add(typeof(Char), typeof(UInt16), typeof(UInt32), typeof(Int32), typeof(UInt64), typeof(Int64), typeof(Single), typeof(Double), typeof(Decimal));
+            Add(typeof(Int32), typeof(Int64), typeof(Double), typeof(Decimal), typeof(Single));
+            Add(typeof(UInt32), typeof(Int64), typeof(UInt64), typeof(Double), typeof(Decimal), typeof(Single));
+            Add(typeof(Int64), typeof(Decimal), typeof(Single), typeof(double));
+            Add(typeof(UInt64), typeof(Decimal), typeof(Single), typeof(double));
+            Add(typeof(Single), typeof(Double));
+            Add(typeof(Decimal), typeof(Single), typeof(Double));
+            Add(typeof(Double));
+
+        }
+
+        /// <summary>
+        /// Perform the implicit conversions as set out in the C# spec docs at
+        /// https://docs.microsoft.com/en-us/dotnet/standard/base-types/conversion-tables
+        /// </summary>
+        /// <param name="left"></param>
+        /// <param name="right"></param>
+        /// <returns></returns>
+        static Type BinaryNumericResultType(Type left, Type right)
+        {
+            if (left == right)
+                return left;
+
+            if (!NumericTypePromotions.ContainsKey(left))
+                throw new System.ArgumentException("Argument is not numeric", nameof(left));
+            if (!NumericTypePromotions.ContainsKey(right))
+                throw new System.ArgumentException("Argument is not numeric", nameof(right));
+
+            // Test left to right promotion
+            if (NumericTypePromotions[right].Contains(left))
+                return right;
+            if (NumericTypePromotions[left].Contains(right))
+                return left;
+
+            throw new Exception("Should not get here in code");
+        }
+
+        private static (Expression left, Expression right) Cast(Expression lhs, Expression rhs,Type leftType, Type rightType, Type resultType)
+        {
+            var castLhs = leftType == resultType ? lhs : (Expression)Expression.Convert(lhs, resultType);
+            var castRhs = rightType == resultType ? rhs : (Expression)Expression.Convert(rhs, resultType);
+            return (castLhs, castRhs);
+        }
+
         /// <summary>
         /// Create a function delegate representing a binary operation
         /// </summary>
         /// <param name="body">Body factory</param>
         /// <param name="leftType"></param>
         /// <param name="rightType"></param>
-        /// <param name="resultType"></param>
-        /// <param name="castArgsToResultOnFailure">
-        /// If no matching operation is possible, attempt to convert
-        /// TArg1 and TArg2 to TResult for a match? For example, there is no
-        /// "decimal operator /(decimal, int)", but by converting TArg2 (int) to
-        /// TResult (decimal) a match is found.
-        /// </param>
+        /// <exception cref="System.ArgumentException"></exception>
         /// <returns>Compiled function delegate</returns>
-        public static Delegate CreateExpression(Func<Expression, Expression, BinaryExpression> body,
-            Type leftType, Type rightType, Type resultType, bool castArgsToResultOnFailure)
+        public static Delegate CreateExpression
+            (Func<Expression, Expression, BinaryExpression> body
+             , Type leftType
+             , Type rightType)
         {
-            ParameterExpression lhs = Expression.Parameter(leftType, "lhs");
-            ParameterExpression rhs = Expression.Parameter(rightType, "rhs");
+            var lhs = Expression.Parameter(leftType, "lhs");
+            var rhs = Expression.Parameter(rightType, "rhs");
             try
             {
                 try
                 {
-                    return Expression.Lambda(body(lhs, rhs), lhs, rhs).Compile();
+                    var resultType = BinaryNumericResultType( leftType, rightType );
+                    var (castLhs, castRhs) = Cast( lhs, rhs, leftType, rightType, resultType );
+                    return Expression.Lambda(body(castLhs, castRhs), lhs, rhs).Compile();
                 }
                 catch (InvalidOperationException)
                 {
-                    if (castArgsToResultOnFailure && !( // if we show retry
-                        leftType == resultType && // and the args aren't
-                            rightType == resultType))
+                    try
                     {
-                        // already "TValue, TValue, TValue"...
-                        // convert both lhs and rhs to TResult (as appropriate)
-                        Expression castLhs = leftType == resultType ? lhs : (Expression) Expression.Convert(lhs, resultType);
-                        Expression castRhs = rightType == resultType ? rhs : (Expression) Expression.Convert(rhs, resultType);
-
-                        return Expression.Lambda(body(castLhs, castRhs), lhs, rhs).Compile();
+                        var resultType = leftType;
+                        var (castLhs, castRhs) = Cast( lhs, rhs, leftType, rightType, resultType );
+                        return Expression.Lambda( body( castLhs, castRhs ), lhs, rhs ).Compile();
                     }
-                    throw;
+                    catch (InvalidOperationException)
+                    {
+                        var resultType = rightType;
+                        var (castLhs, castRhs) = Cast( lhs, rhs, leftType, rightType, resultType );
+                        return Expression.Lambda( body( castLhs, castRhs ), lhs, rhs ).Compile();
+                    }
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
We noticed that the performance for binary numeric operators such as 

        [Test]
        public void TestInt32DividedByInt64 ()
        {
            int a = 20;
            long b = 5;
            Hash assigns = Hash.FromAnonymousObject(new { a = a, b = b});
            Helper.AssertTemplateResult("4", "{{ a | divided_by:b }}", assigns);
        }
        
resulted in very poor performance. This was because the code that implemented
the numeric conversion used exceptions for flow control. Basically it tried
to compile the expression as is and if there was an exception it then retried
compiling with some type conversions thrown in.

It is possible to do better by encoding the allowed numeric conversions
in a lookup table and then preemptively performing those conversions. 

This doesn't change the API or results at all. It only affects the
performance.
