### PR TITLE
filter functions do not work with templates & drops

### DIFF
--- a/src/DotLiquid.Tests/FunctionFilterTests.cs
+++ b/src/DotLiquid.Tests/FunctionFilterTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using NUnit.Framework;
+using DotLiquid.NamingConventions;
 
 namespace DotLiquid.Tests
 {
@@ -20,6 +21,22 @@ namespace DotLiquid.Tests
             _context["var"] = 2;
             _context.AddFilter<int, string>("AddTwo", i => (i + 2).ToString(CultureInfo.InvariantCulture));
             Assert.That(new Variable("var | add_two").Render(_context), Is.EqualTo("4"));
+        }
+
+        [Test]
+        public void AddingFunctions_Using_templates()
+        {
+            var template = Template.Parse("{{ var | add_two }}");
+
+            var data = new TestDrop { var = 2 };
+            _context.AddFilter<int, string>("AddTwo", i => (i + 2).ToString(CultureInfo.InvariantCulture));
+
+            var renderParams = new RenderParameters(CultureInfo.InvariantCulture)
+            {
+                LocalVariables = Hash.FromAnonymousObject(data),
+                Context = _context
+            };
+            Assert.That(template.Render(renderParams), Is.EqualTo("4"));
         }
 
         [Test]
@@ -44,5 +61,11 @@ namespace DotLiquid.Tests
             _context.AddFilter<int, string>("AddTwo", i => (i + 2).ToString(CultureInfo.InvariantCulture));
             Assert.That(new Variable("var | add_two").Render(_context), Is.EqualTo("4"));
         }
+
+        public class TestDrop : Drop
+        {
+            public int var { get; set; }
+        }
+
     }
 }

--- a/src/DotLiquid/RenderParameters.cs
+++ b/src/DotLiquid/RenderParameters.cs
@@ -90,7 +90,7 @@ namespace DotLiquid
             if (Context != null)
             {
                 context = Context;
-                registers = null;
+                registers = LocalVariables;
                 filters = null;
                 context.RestartTimeout();
                 return;

--- a/src/DotLiquid/Template.cs
+++ b/src/DotLiquid/Template.cs
@@ -395,7 +395,10 @@ namespace DotLiquid
             if (!IsThreadSafe)
             {
                 if (registers != null)
+                {
                     Registers.Merge(registers);
+                    context.Merge(Registers);
+                }
 
                 if (filters != null)
                     context.AddFilters(filters);


### PR DESCRIPTION
Hello.

I'm not expecting this PR to be accepted as, honestly, I haven't really taken the time to properly understand the code base.

Hopefully you can see from the Test what my issue is - that I cannot get filter functions to work when using a Template with a Drop (All the filter function tests use a context and variable directly).

I have made some changes to make the test pass, and all other tests pass. However, I am not sure if what I have done is the correct thing to do.

see issue #295
