### PR TITLE
Slice filter resilient to negative start index out of bounds

### DIFF
--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -108,6 +108,20 @@ namespace DotLiquid.Tests
         }
 
         [Test]
+        public void TestSlice()
+        {
+            Assert.AreEqual(null, StandardFilters.Slice(null, 1));
+            Assert.AreEqual(null, StandardFilters.Slice("", 10));
+            Assert.AreEqual("abc", StandardFilters.Slice("abcdefg", 0, 3));
+            Assert.AreEqual("bcd", StandardFilters.Slice("abcdefg", 1, 3));
+            Assert.AreEqual("efg", StandardFilters.Slice("abcdefg", -3, 3));
+            Assert.AreEqual("efg", StandardFilters.Slice("abcdefg", -3, 30));
+            Assert.AreEqual("efg", StandardFilters.Slice("abcdefg", 4, 30));
+            Assert.AreEqual("a", StandardFilters.Slice("abc", -4, 2));
+            Assert.AreEqual("", StandardFilters.Slice("abcdefg", -10, 1));
+        }
+        
+        [Test]
         public void TestJoin()
         {
             Assert.AreEqual(null, StandardFilters.Join(null));

--- a/src/DotLiquid/StandardFilters.cs
+++ b/src/DotLiquid/StandardFilters.cs
@@ -49,6 +49,11 @@ namespace DotLiquid
             if (start < 0)
             { 
                 start += input.Length;
+                if (start < 0)
+                {
+                    len = Math.Max(0, len + start);
+                    start = 0;
+                }
             }
             if (start + len > input.Length)
             { 


### PR DESCRIPTION
Example: If the input string is of length 2, start is -4 and len = 3, then the result should be just the first letter of the input string. Now an exception "Index out of range" is thrown.