### PR TITLE
Added default liquidize support for enum types

### DIFF
--- a/src/DotLiquid/Condition.cs
+++ b/src/DotLiquid/Condition.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using DotLiquid.Util;
 
 namespace DotLiquid
@@ -113,6 +114,13 @@ namespace DotLiquid
 
             if (left != null && right != null && left.GetType() != right.GetType())
             {
+                //Try comparing a "Value" property
+                var valueProperty = left.GetType().GetTypeInfo().GetDeclaredProperty("Value");
+                if (valueProperty != null)
+                {
+                    return EqualVariables(valueProperty.GetValue(left), right);
+                }
+
                 try
                 {
                     right = Convert.ChangeType(right, left.GetType());

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -614,6 +614,11 @@ namespace DotLiquid
             {
                 return obj;
             }
+
+            if (obj is Uri)
+            {
+                return obj;
+            }
             if (TypeUtility.IsAnonymousType(obj.GetType()))
             {
                 return obj;

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -614,7 +614,6 @@ namespace DotLiquid
             {
                 return obj;
             }
-
             if (obj is Uri)
             {
                 return obj;

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -641,7 +641,12 @@ namespace DotLiquid
             {
                 return obj;
             }
-            
+
+            if (Template.UnsafeTypeTransformer != null)
+            {
+                return Template.UnsafeTypeTransformer(obj);
+            }
+
             throw new SyntaxException(Liquid.ResourceManager.GetString("ContextObjectInvalidException"), obj.ToString());
         }
 

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -637,6 +637,11 @@ namespace DotLiquid
                 return obj;
             }
 
+            if (obj.GetType().GetTypeInfo().IsEnum)
+            {
+                return obj;
+            }
+            
             throw new SyntaxException(Liquid.ResourceManager.GetString("ContextObjectInvalidException"), obj.ToString());
         }
 

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -435,9 +435,15 @@ namespace DotLiquid
                 if (partResolved)
                     part = Resolve(partSquareBracketedMatch.Groups[1].Value);
 
+                // If object has a namespace part transformer we call that
+                if (Template.HasNamespacePartTransformer(@object?.GetType(), out var transformer))
+                {
+                    @object = transformer(@object, part);
+                }
+
                 // If object is a KeyValuePair, we treat it a bit differently - we might be rendering
                 // an included template.
-                if (IsKeyValuePair(@object) && (part.Equals(0) || part.Equals("Key")))
+                else if (IsKeyValuePair(@object) && (part.Equals(0) || part.Equals("Key")))
                 {
                     object res = @object.GetType().GetRuntimeProperty("Key").GetValue(@object);
                     @object = Liquidize(res);
@@ -461,8 +467,7 @@ namespace DotLiquid
                         object res = ((KeyValuePair<string, object>)@object).Value;
                         @object = Liquidize(res);
                     }
-
-
+                    
                     // If object is a hash- or array-like object we look for the
                     // presence of the key and if its available we return it
                     else if (IsHashOrArrayLikeObject(@object, part))
@@ -502,7 +507,7 @@ namespace DotLiquid
 
             return @object;
         }
-
+        
         private static bool IsHashOrArrayLikeObject(object obj, object part)
         {
             if (obj == null)
@@ -522,7 +527,7 @@ namespace DotLiquid
 
             return false;
         }
-
+        
         private object LookupAndEvaluate(object obj, object key)
         {
             object value;

--- a/src/DotLiquid/Template.cs
+++ b/src/DotLiquid/Template.cs
@@ -50,6 +50,12 @@ namespace DotLiquid
         /// </summary>
         public static TimeSpan RegexTimeOut { get; set; }
 
+        /// <summary>
+        /// Fallback functaion that converts all types not listed in "RegisterSafeType"
+        /// into a Liquid Drop-compatible object (eg, implements ILiquidizable)
+        /// </summary>
+        public static Func<object, object> UnsafeTypeTransformer { get; set; }
+
         private static readonly Dictionary<Type, Func<object, object>> SafeTypeTransformers;
         private static readonly Dictionary<Type, Func<object, object>> ValueTypeTransformers;
 


### PR DESCRIPTION
Enum types now be liquidized normally without registering them all as safe types.
This works fine "out of the box" as the enum value will get printed using ToString().