### PR TITLE
Support to %s dateformat

### DIFF
--- a/src/DotLiquid.Tests/Util/StrFTimeTests.cs
+++ b/src/DotLiquid.Tests/Util/StrFTimeTests.cs
@@ -23,6 +23,7 @@ namespace DotLiquid.Tests.Util
         [TestCase("%m", ExpectedResult = "01")]
         [TestCase("%M", ExpectedResult = "32")]
         [TestCase("%p", ExpectedResult = "PM")]
+		[TestCase("%s", ExpectedResult = "1326033134")]
         [TestCase("%S", ExpectedResult = "14")]
         [TestCase("%U", ExpectedResult = "02")]
         [TestCase("%W", ExpectedResult = "01")]

--- a/src/DotLiquid/Util/StrFTime.cs
+++ b/src/DotLiquid/Util/StrFTime.cs
@@ -15,7 +15,7 @@ namespace DotLiquid.Util
             { "b", (dateTime) => dateTime.ToString("MMM", CultureInfo.CurrentCulture) },
             { "B", (dateTime) => dateTime.ToString("MMMM", CultureInfo.CurrentCulture) },
             { "c", (dateTime) => dateTime.ToString("ddd MMM dd HH:mm:ss yyyy", CultureInfo.CurrentCulture) },
-            { "d", (dateTime) => dateTime.ToString("dd", CultureInfo.CurrentCulture) }, 
+            { "d", (dateTime) => dateTime.ToString("dd", CultureInfo.CurrentCulture) },
             { "e", (dateTime) => dateTime.ToString("%d", CultureInfo.CurrentCulture).PadLeft(2, ' ') },
             { "H", (dateTime) => dateTime.ToString("HH", CultureInfo.CurrentCulture) },
             { "I", (dateTime) => dateTime.ToString("hh", CultureInfo.CurrentCulture) },

--- a/src/DotLiquid/Util/StrFTime.cs
+++ b/src/DotLiquid/Util/StrFTime.cs
@@ -23,6 +23,7 @@ namespace DotLiquid.Util
             { "m", (dateTime) => dateTime.ToString("MM", CultureInfo.CurrentCulture) },
             { "M", (dateTime) => dateTime.Minute.ToString().PadLeft(2, '0') },
             { "p", (dateTime) => dateTime.ToString("tt", CultureInfo.CurrentCulture).ToUpper() },
+			{ "s", (dateTime) => ((int)(dateTime - new DateTime(1970, 1, 1)).TotalSeconds).ToString() },
             { "S", (dateTime) => dateTime.ToString("ss", CultureInfo.CurrentCulture) },
             { "U", (dateTime) => CultureInfo.CurrentCulture.Calendar.GetWeekOfYear(dateTime, CultureInfo.CurrentCulture.DateTimeFormat.CalendarWeekRule, DayOfWeek.Sunday).ToString().PadLeft(2, '0') },
             { "W", (dateTime) => CultureInfo.CurrentCulture.Calendar.GetWeekOfYear(dateTime, CultureInfo.CurrentCulture.DateTimeFormat.CalendarWeekRule, DayOfWeek.Monday).ToString().PadLeft(2, '0') },

--- a/src/DotLiquid/Util/StrFTime.cs
+++ b/src/DotLiquid/Util/StrFTime.cs
@@ -15,7 +15,7 @@ namespace DotLiquid.Util
             { "b", (dateTime) => dateTime.ToString("MMM", CultureInfo.CurrentCulture) },
             { "B", (dateTime) => dateTime.ToString("MMMM", CultureInfo.CurrentCulture) },
             { "c", (dateTime) => dateTime.ToString("ddd MMM dd HH:mm:ss yyyy", CultureInfo.CurrentCulture) },
-            { "d", (dateTime) => dateTime.ToString("dd", CultureInfo.CurrentCulture) },
+            { "d", (dateTime) => dateTime.ToString("dd", CultureInfo.CurrentCulture) }, 
             { "e", (dateTime) => dateTime.ToString("%d", CultureInfo.CurrentCulture).PadLeft(2, ' ') },
             { "H", (dateTime) => dateTime.ToString("HH", CultureInfo.CurrentCulture) },
             { "I", (dateTime) => dateTime.ToString("hh", CultureInfo.CurrentCulture) },


### PR DESCRIPTION
Added support to %s Ruby dateformat.
%s - Number of seconds since 1970-01-01 00:00:00 UTC.