### PR TITLE
Wrap rethrown exception to preserve stack trace

### DIFF
--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -169,7 +169,7 @@ namespace DotLiquid
                 return string.Empty;
 
             if (_errorsOutputMode == ErrorsOutputMode.Rethrow)
-                throw ex;
+                throw new Exception("Could not render the Liquid template.", ex);
 
             if (ex is SyntaxException)
             {


### PR DESCRIPTION
Throwing a catched exception with `throw ex` here will rewrite the stack trace and I no longer see the stack trace where the exception actually happened. Wrapping it in another exception with inner exception will preserve the original stack trace in the inner exception. 

I have a strange issue (seems to be a concurrency problem) and the only way to debug is to check the stack trace - but at the moment there is no way to get the original stack trace.