### PR TITLE
Fix object extension methods to take into account Drops...

### DIFF
--- a/src/DotLiquid/MIISdotliquid.csproj
+++ b/src/DotLiquid/MIISdotliquid.csproj
@@ -6,7 +6,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <Authors>Tim Jones;Alessandro Petrelli</Authors>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
-    <AssemblyName>DotLiquid</AssemblyName>
+    <AssemblyName>MIISdotliquid</AssemblyName>
     <AssemblyOriginatorKeyFile>../Formosatek-OpenSource.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
@@ -30,6 +30,7 @@
     <DebugType>full</DebugType>
     <DebugSymbols>True</DebugSymbols>
       <DocumentationFile>bin\Debug\$(TargetFramework)\DotLiquid.xml</DocumentationFile>
+      <RootNamespace>DotLiquid</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DotLiquid/Properties/AssemblyInfo.cs
+++ b/src/DotLiquid/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -6,8 +6,8 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 
-[assembly: AssemblyTitle("DotLiquid")]
-[assembly: AssemblyDescription("DotLiquid is a templating system ported to the .NET framework from Ruby’s Liquid Markup.")]
+[assembly: AssemblyTitle("MIISDotLiquid")]
+[assembly: AssemblyDescription("Fixed version for MIIS - DotLiquid is a templating system ported to the .NET framework from Ruby’s Liquid Markup.")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Formosatek Ltd")]
 [assembly: AssemblyProduct("DotLiquid")]
@@ -25,8 +25,8 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("75d1dc49-0097-4f60-b5fd-0e43d213b38b")]
 
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2.0.315.0")]
+[assembly: AssemblyFileVersion("2.0.315.0")]
+[assembly: AssemblyInformationalVersion("2.0.315.0")]
 
 [assembly: InternalsVisibleTo("DotLiquid.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010093ae26e2c87851b659e9847a0a9c6088a4ad1988df9b176d56c3996e33458273df5c2138b5bf13b2352a99152f10ef1bc2564069179d5344ba723a875ea048b80fcb34c1c5ff7e3d131cb208140265e5144183570d1e0433c1a37959720e0d8d83a7ee870d5e0dd904afc62663103eb2e2105e1eddeadfe876c9ccc90a31cfbf")]

--- a/src/DotLiquid/Util/ObjectExtensionMethods.cs
+++ b/src/DotLiquid/Util/ObjectExtensionMethods.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Reflection;
 
@@ -10,6 +10,9 @@ namespace DotLiquid.Util
         {
             if (value == null)
                 throw new ArgumentNullException("value");
+
+            if (value is DropBase)
+                return (value as DropBase).ContainsKey(member);
 
             Type type = value.GetType();
 
@@ -28,6 +31,13 @@ namespace DotLiquid.Util
         {
             if (value == null)
                 throw new ArgumentNullException("value");
+
+            if (value is DropBase)
+            {
+                DropBase valAsDB = value as DropBase;
+                if (valAsDB.ContainsKey(member))
+                    return valAsDB[member];
+            }
 
             Type type = value.GetType();
 


### PR DESCRIPTION
… that overwrite the indexer to get their values.

With the current implementation of the `RespondTo` and `Send` methods in `DotLiquid.Util.ObjectExtensionMethods`, if you have a `Drop` derived class that overrides the indexer in `DropBase` so that it can return arbitrary properties (such as those defined in the Front-Matter of a file), the current methods aren't able to deal with them. **This prevents being able to sort using those arbitrary properties with the sort filter**.

Fortunately, the solution is pretty straight forward: just 2 and 6 lines of code respectively, as you can see in the PR.

In the following block, below, I've pasted a simple console program that you can use to test how this works with the original code and with the fixed one. It tries to sort bu name or length the Markdown files inside a folder. In a real situation the fields would be taken from the Front-Matter.

Hope you can accept the PR, generate a new version and update the NuGet package. 

Thanks for your great work on this library!!

-----
**Sample code below**:

```csharp
using System;
using System.Linq;
using System.IO;
using DotLiquid;

namespace TestSort
{
    class Program
    {
        static void Main(string[] args)
        {
            DirectoryInfo di = new DirectoryInfo(@"C:\TestFiles\");
            var allFiles = (from file in di.EnumerateFiles("*.md", SearchOption.TopDirectoryOnly)
                            select new MarkdownFile(file.Name, file.Length)
                           );
            Template parser = Template.Parse(@"
{% assign sorted = allFiles | sort: 'length' %}
{% for file in sorted %}
- {{file.Name}}
{% endfor %}");
            Hash context = new Hash(allFiles);
            string res = parser.Render(context);
            Console.WriteLine(res);
            Console.ReadLine();
        }
    }

    //A sample Drop overriding the indexer from the base class
    public class MarkdownFile : Drop
    {
        private string fullName;
        private long length;

        public MarkdownFile(string fullName, long length)
        {
            this.fullName = fullName;
            this.length = length;
        }

        public override object this[object fieldName]
        {
            get
            {
                //Tries to return a real property form the object if present
                object res = base[fieldName];
                if (res == null)
                {
                    switch (fieldName.ToString().ToLowerInvariant())
                    {
                        case "name":
                            res = fullName.ToLowerInvariant();
                            break;
                        case "length":
                            res = length;
                            break;
                        default:
                            res = "";
                            break;
                    }
                }

                return res;
            }
        }
    }
}
```