### PR TITLE
fix for handling doubles in assign

### DIFF
--- a/src/DotLiquid.Tests/Tags/AssignTests.cs
+++ b/src/DotLiquid.Tests/Tags/AssignTests.cs
@@ -25,6 +25,13 @@ namespace DotLiquid.Tests.Tags
         }
 
         [Test]
+        public void TestAssignDoubleWithoutVariable()
+        {
+            Helper.AssertTemplateResult(string.Format("1{0}2345678912345", CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator),
+                "{% assign foo = 1.2345678912345 %}{{ foo }}");
+        }
+
+        [Test]
         public void TestAssignDecimalInlineWithEnglishDecimalSeparator()
         {
             using (CultureHelper.SetCulture("en-GB"))

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -20,7 +20,7 @@ namespace DotLiquid
         private static readonly Regex DoubleQuotedRegex = R.C(R.Q(@"^""(.*)""$"));
         private static readonly Regex IntegerRegex = R.C(R.Q(@"^([+-]?\d+)$"));
         private static readonly Regex RangeRegex = R.C(R.Q(@"^\((\S+)\.\.(\S+)\)$"));
-        private static readonly Regex FloatRegex = R.C(R.Q(@"^([+-]?\d[\d\.|\,]+)$"));
+        private static readonly Regex NumericRegex = R.C(R.Q(@"^([+-]?\d[\d\.|\,]+)$"));
         private static readonly Regex SquareBracketedRegex = R.C(R.Q(@"^\[(.*)\]$"));
         private static readonly Regex VariableParserRegex = R.C(Liquid.VariableParser);
 
@@ -344,18 +344,18 @@ namespace DotLiquid
                 return Range.Inclusive(Convert.ToInt32(Resolve(match.Groups[1].Value)),
                     Convert.ToInt32(Resolve(match.Groups[2].Value)));
 
-            // Floats.
-            match = FloatRegex.Match(key);
+            // Floating point numbers.
+            match = NumericRegex.Match(key);
             if (match.Success)
             {
                 // For cultures with "," as the decimal separator, allow
                 // both "," and "." to be used as the separator.
                 // First try to parse using current culture.
-                if (float.TryParse(match.Groups[1].Value, NumberStyles.Number, FormatProvider, out float result))
+                if (double.TryParse(match.Groups[1].Value, NumberStyles.Number, FormatProvider, out double result))
                     return result;
 
                 // If that fails, try to parse using invariant culture.
-                return float.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
+                return double.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
             }
 
             return Variable(key, notifyNotFound);


### PR DESCRIPTION
I found an issue when trying to render a `double`.

Steps to reproduce:
```
{% assign double = 1.1234567891234 %}
{{ double }}
```

**Expected**
`1.1234567891234`

**Actual**
`1.123457`

I've added a test to the PR and checked other tests. The change doesn't seem to be that big, but please let me know if should add something to the PR.