### PR TITLE
Fix long to integer conversion issue with truncate filters

### DIFF
--- a/src/DotLiquid.Tests/FilterTests.cs
+++ b/src/DotLiquid.Tests/FilterTests.cs
@@ -262,19 +262,51 @@ namespace DotLiquid.Tests
             Assert.AreEqual(" King Kong has 1000$ ", new Variable("var | bank_statement").Render(_context));
         }
 
-
         [Test]
         public void Truncate()
         {
-            _context["var"] = "this is a longish string";
-            Assert.AreEqual("this is...", new Variable("var | truncate: 10").Render(_context));
+            var variable = new Variable("\"Ground control to Major Tom.\" | truncate: 20");
+            Assert.AreEqual("Ground control to...", variable.Render(_context));
+
+            variable = new Variable("\"Ground control to Major Tom.\" | truncate: 25, \", and so on\"");
+            Assert.AreEqual("Ground control, and so on", variable.Render(_context));
+
+            variable = new Variable("\"Ground control to Major Tom.\" | truncate: 20, \"\"");
+            Assert.AreEqual("Ground control to Ma", variable.Render(_context));
+
+            variable = new Variable("\"Ground control to Major Tom.\" | truncate: 0");
+            Assert.AreEqual("...", variable.Render(_context));
+
+            variable = new Variable("\"Ground control to Major Tom.\" | truncate: -1");
+            Assert.That(() => variable.Render(_context), Throws.Exception.TypeOf<ArgumentException>());
+
+            variable = new Variable($"\"Ground control to Major Tom.\" | truncate: {((long)int.MaxValue) + 1}");
+            Assert.That(() => variable.Render(_context), Throws.Exception.TypeOf<ArgumentException>());
+
         }
 
         [Test]
         public void TruncateWords()
         {
-            _context["var"] = "this is a longish string";
-            Assert.AreEqual("this is...", new Variable("var | truncate_words: 2").Render(_context));
+
+            var variable = new Variable("\"Ground control to Major Tom.\" | truncate_words: 3");
+            Assert.AreEqual("Ground control to...", variable.Render(_context));
+
+            variable = new Variable("\"Ground control to Major Tom.\" | truncate_words: 3, \"--\"");
+            Assert.AreEqual("Ground control to--", variable.Render(_context));
+
+            variable = new Variable("\"Ground control to Major Tom.\" | truncate_words: 3, \"\"");
+            Assert.AreEqual("Ground control to", variable.Render(_context));
+
+            variable = new Variable("\"Ground control to Major Tom.\" | truncate_words: 0");
+            Assert.AreEqual("...", variable.Render(_context));
+
+            variable = new Variable("\"Ground control to Major Tom.\" | truncate_words: -1");
+            Assert.That(() => variable.Render(_context), Throws.Exception.TypeOf<ArgumentException>());
+
+            variable = new Variable($"\"Ground control to Major Tom.\" | truncate_words: {((long)int.MaxValue) + 1}");
+            Assert.That(() => variable.Render(_context), Throws.Exception.TypeOf<ArgumentException>());
+
         }
 
     }

--- a/src/DotLiquid.Tests/FilterTests.cs
+++ b/src/DotLiquid.Tests/FilterTests.cs
@@ -261,5 +261,21 @@ namespace DotLiquid.Tests
             _context.AddFilters(typeof(ContextFilters));
             Assert.AreEqual(" King Kong has 1000$ ", new Variable("var | bank_statement").Render(_context));
         }
+
+
+        [Test]
+        public void Truncate()
+        {
+            _context["var"] = "this is a longish string";
+            Assert.AreEqual("this is...", new Variable("var | truncate: 10").Render(_context));
+        }
+
+        [Test]
+        public void TruncateWords()
+        {
+            _context["var"] = "this is a longish string";
+            Assert.AreEqual("this is...", new Variable("var | truncate_words: 2").Render(_context));
+        }
+
     }
 }

--- a/src/DotLiquid.Tests/FilterTests.cs
+++ b/src/DotLiquid.Tests/FilterTests.cs
@@ -262,52 +262,5 @@ namespace DotLiquid.Tests
             Assert.AreEqual(" King Kong has 1000$ ", new Variable("var | bank_statement").Render(_context));
         }
 
-        [Test]
-        public void Truncate()
-        {
-            var variable = new Variable("\"Ground control to Major Tom.\" | truncate: 20");
-            Assert.AreEqual("Ground control to...", variable.Render(_context));
-
-            variable = new Variable("\"Ground control to Major Tom.\" | truncate: 25, \", and so on\"");
-            Assert.AreEqual("Ground control, and so on", variable.Render(_context));
-
-            variable = new Variable("\"Ground control to Major Tom.\" | truncate: 20, \"\"");
-            Assert.AreEqual("Ground control to Ma", variable.Render(_context));
-
-            variable = new Variable("\"Ground control to Major Tom.\" | truncate: 0");
-            Assert.AreEqual("...", variable.Render(_context));
-
-            variable = new Variable("\"Ground control to Major Tom.\" | truncate: -1");
-            Assert.That(() => variable.Render(_context), Throws.Exception.TypeOf<ArgumentException>());
-
-            variable = new Variable($"\"Ground control to Major Tom.\" | truncate: {((long)int.MaxValue) + 1}");
-            Assert.That(() => variable.Render(_context), Throws.Exception.TypeOf<ArgumentException>());
-
-        }
-
-        [Test]
-        public void TruncateWords()
-        {
-
-            var variable = new Variable("\"Ground control to Major Tom.\" | truncate_words: 3");
-            Assert.AreEqual("Ground control to...", variable.Render(_context));
-
-            variable = new Variable("\"Ground control to Major Tom.\" | truncate_words: 3, \"--\"");
-            Assert.AreEqual("Ground control to--", variable.Render(_context));
-
-            variable = new Variable("\"Ground control to Major Tom.\" | truncate_words: 3, \"\"");
-            Assert.AreEqual("Ground control to", variable.Render(_context));
-
-            variable = new Variable("\"Ground control to Major Tom.\" | truncate_words: 0");
-            Assert.AreEqual("...", variable.Render(_context));
-
-            variable = new Variable("\"Ground control to Major Tom.\" | truncate_words: -1");
-            Assert.That(() => variable.Render(_context), Throws.Exception.TypeOf<ArgumentException>());
-
-            variable = new Variable($"\"Ground control to Major Tom.\" | truncate_words: {((long)int.MaxValue) + 1}");
-            Assert.That(() => variable.Render(_context), Throws.Exception.TypeOf<ArgumentException>());
-
-        }
-
     }
 }

--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -41,6 +41,14 @@ namespace DotLiquid.Tests
             Assert.AreEqual("1234567890", StandardFilters.Truncate("1234567890", 20));
             Assert.AreEqual("...", StandardFilters.Truncate("1234567890", 0));
             Assert.AreEqual("1234567890", StandardFilters.Truncate("1234567890"));
+
+            Helper.AssertTemplateResult(expected: "Ground control to...", template: "{{ 'Ground control to Major Tom.' | truncate:20 }}");
+            Helper.AssertTemplateResult(expected: "Ground control, and so on", template: "{{ 'Ground control to Major Tom.' | truncate:25, ', and so on' }}");
+            Helper.AssertTemplateResult(expected: "Ground control to Ma", template: "{{ 'Ground control to Major Tom.' | truncate:20, '' }}");
+            Helper.AssertTemplateResult(expected: "...", template: "{{ 'Ground control to Major Tom.' | truncate:0 }}");
+            Helper.AssertTemplateResult(expected: "Liquid error: length parameter of truncate filter is out of the range of valid positive integers.", template: "{{ 'Ground control to Major Tom.' | truncate:-1 }}");
+            Helper.AssertTemplateResult(expected: "Liquid error: Value was either too large or too small for an Int32.", template: "{{ 'Ground control to Major Tom.' | truncate:" + int.MaxValue + 1 + " }}");
+
         }
 
         [Test]
@@ -61,6 +69,14 @@ namespace DotLiquid.Tests
             Assert.AreEqual("one two...", StandardFilters.TruncateWords("one two three", 2));
             Assert.AreEqual("one two three", StandardFilters.TruncateWords("one two three"));
             Assert.AreEqual("Two small (13&#8221; x 5.5&#8221; x 10&#8221; high) baskets fit inside one large basket (13&#8221;...", StandardFilters.TruncateWords("Two small (13&#8221; x 5.5&#8221; x 10&#8221; high) baskets fit inside one large basket (13&#8221; x 16&#8221; x 10.5&#8221; high) with cover.", 15));
+
+            Helper.AssertTemplateResult(expected: "Ground control to...", template: "{{ 'Ground control to Major Tom.' | truncate_words:3 }}");
+            Helper.AssertTemplateResult(expected: "Ground control to--", template: "{{ 'Ground control to Major Tom.' | truncate_words:3, '--' }}");
+            Helper.AssertTemplateResult(expected: "Ground control to", template: "{{ 'Ground control to Major Tom.' | truncate_words:3, '' }}");
+            Helper.AssertTemplateResult(expected: "...", template: "{{ 'Ground control to Major Tom.' | truncate_words:0 }}");
+            Helper.AssertTemplateResult(expected: "Liquid error: words parameter of truncate-words filter is out of the range of valid positive integers.", template: "{{ 'Ground control to Major Tom.' | truncate_words:-1 }}");
+            Helper.AssertTemplateResult(expected: "Liquid error: Value was either too large or too small for an Int32.", template: "{{ 'Ground control to Major Tom.' | truncate_words:" + int.MaxValue + 1 + " }}");
+
         }
 
         [Test]

--- a/src/DotLiquid/StandardFilters.cs
+++ b/src/DotLiquid/StandardFilters.cs
@@ -166,15 +166,15 @@ namespace DotLiquid
         /// <param name="length"></param>
         /// <param name="truncateString"></param>
         /// <returns></returns>
-        public static string Truncate(string input, long length = 50, string truncateString = "...")
+        public static string Truncate(string input, int length = 50, string truncateString = "...")
         {
             if (string.IsNullOrEmpty(input))
                 return input;
 
-            if (length < 0 || length > int.MaxValue)
+            if (length < 0)
                 throw new DotLiquid.Exceptions.ArgumentException("length parameter of truncate filter is out of the range of valid positive integers.");
 
-            int lengthExcludingTruncateString = (int)length - truncateString.Length;
+            int lengthExcludingTruncateString = length - truncateString.Length;
 
             return input.Length > length
                 ? input.Substring(0, lengthExcludingTruncateString < 0 ? 0 : lengthExcludingTruncateString) + truncateString
@@ -188,19 +188,18 @@ namespace DotLiquid
         /// <param name="words"></param>
         /// <param name="truncateString"></param>
         /// <returns></returns>
-        public static string TruncateWords(string input, long words = 15, string truncateString = "...")
+        public static string TruncateWords(string input, int words = 15, string truncateString = "...")
         {
             if (string.IsNullOrEmpty(input))
                 return input;
 
-            if (words < 0 || words > int.MaxValue)
+            if (words < 0)
                 throw new DotLiquid.Exceptions.ArgumentException("words parameter of truncate-words filter is out of the range of valid positive integers.");
 
-            var wordList = input.Split(' ').ToList();
+            List<string> wordList = input.Split(' ').ToList();
 
-            int wordsAsInt = (int)words;
-            return wordList.Count > wordsAsInt
-                ? string.Join(" ", wordList.Take(wordsAsInt).ToArray()) + truncateString
+            return wordList.Count > words
+                ? string.Join(" ", wordList.Take(words).ToArray()) + truncateString
                 : input;
         }
 

--- a/src/DotLiquid/StandardFilters.cs
+++ b/src/DotLiquid/StandardFilters.cs
@@ -166,12 +166,14 @@ namespace DotLiquid
         /// <param name="length"></param>
         /// <param name="truncateString"></param>
         /// <returns></returns>
-        public static string Truncate(string input, int length = 50, string truncateString = "...")
+        public static string Truncate(string input, long length = 50, string truncateString = "...")
         {
             if (string.IsNullOrEmpty(input))
                 return input;
 
-            int l = length - truncateString.Length;
+            int lengthAsInt = length < int.MinValue ? int.MinValue : (length > int.MaxValue ? int.MaxValue : (int)length);
+
+            int l = lengthAsInt - truncateString.Length;
 
             return input.Length > length
                 ? input.Substring(0, l < 0 ? 0 : l) + truncateString
@@ -185,13 +187,15 @@ namespace DotLiquid
         /// <param name="words"></param>
         /// <param name="truncateString"></param>
         /// <returns></returns>
-        public static string TruncateWords(string input, int words = 15, string truncateString = "...")
+        public static string TruncateWords(string input, long words = 15, string truncateString = "...")
         {
             if (string.IsNullOrEmpty(input))
                 return input;
 
+            int wordsAsInt = words < int.MinValue ? int.MinValue : (words > int.MaxValue ? int.MaxValue : (int)words);
+
             var wordList = input.Split(' ').ToList();
-            int l = words < 0 ? 0 : words;
+            int l = wordsAsInt < 0 ? 0 : wordsAsInt;
 
             return wordList.Count > l
                 ? string.Join(" ", wordList.Take(l).ToArray()) + truncateString

--- a/src/DotLiquid/StandardFilters.cs
+++ b/src/DotLiquid/StandardFilters.cs
@@ -171,12 +171,13 @@ namespace DotLiquid
             if (string.IsNullOrEmpty(input))
                 return input;
 
-            int lengthAsInt = length < int.MinValue ? int.MinValue : (length > int.MaxValue ? int.MaxValue : (int)length);
+            if (length < 0 || length > int.MaxValue)
+                throw new DotLiquid.Exceptions.ArgumentException("length parameter of truncate filter is out of the range of valid positive integers.");
 
-            int l = lengthAsInt - truncateString.Length;
+            int lengthExcludingTruncateString = (int)length - truncateString.Length;
 
             return input.Length > length
-                ? input.Substring(0, l < 0 ? 0 : l) + truncateString
+                ? input.Substring(0, lengthExcludingTruncateString < 0 ? 0 : lengthExcludingTruncateString) + truncateString
                 : input;
         }
 
@@ -192,13 +193,14 @@ namespace DotLiquid
             if (string.IsNullOrEmpty(input))
                 return input;
 
-            int wordsAsInt = words < int.MinValue ? int.MinValue : (words > int.MaxValue ? int.MaxValue : (int)words);
+            if (words < 0 || words > int.MaxValue)
+                throw new DotLiquid.Exceptions.ArgumentException("words parameter of truncate-words filter is out of the range of valid positive integers.");
 
             var wordList = input.Split(' ').ToList();
-            int l = wordsAsInt < 0 ? 0 : wordsAsInt;
 
-            return wordList.Count > l
-                ? string.Join(" ", wordList.Take(l).ToArray()) + truncateString
+            int wordsAsInt = (int)words;
+            return wordList.Count > wordsAsInt
+                ? string.Join(" ", wordList.Take(wordsAsInt).ToArray()) + truncateString
                 : input;
         }
 


### PR DESCRIPTION
Fixes `System.ArgumentException : Object of type 'System.Int64' cannot be converted to type 'System.Int32'` error when using `truncate` or `truncate-word` filters