### PR TITLE
Fix multiple regressions caused by PR#362

### DIFF
--- a/src/DotLiquid.Tests/CustomIndexableTests.cs
+++ b/src/DotLiquid.Tests/CustomIndexableTests.cs
@@ -21,8 +21,8 @@ namespace DotLiquid.Tests
             {
                 get
                 {
-                    long? index = key as long?;
-                    if (!index.HasValue || index.Value < 0L || index.Value >= items.Length) {
+                    int? index = key as int?;
+                    if (!index.HasValue || index.Value < 0 || index.Value >= items.Length) {
                         throw new KeyNotFoundException();
                     }
                     return items[index.Value];
@@ -31,7 +31,41 @@ namespace DotLiquid.Tests
 
             public bool ContainsKey(object key)
             {
-                long? index = key as long?;
+                int? index = key as int?;
+                return index.HasValue && index.Value >= 0 && index.Value < items.Length;
+            }
+
+            public IEnumerator GetEnumerator()
+            {
+                return items.GetEnumerator();
+            }
+        }
+
+        internal class VirtualLongList : IIndexable, IEnumerable
+        {
+            internal VirtualLongList(params object[] items)
+            {
+                this.items = items;
+            }
+
+            private readonly object[] items;
+
+            public object this[object key]
+            {
+                get
+                {
+                    var index = key != null ? (long?)System.Convert.ToInt64(key) : null;
+                    if (!index.HasValue || index.Value < 0L || index.Value >= items.Length)
+                    {
+                        throw new KeyNotFoundException();
+                    }
+                    return items[index.Value];
+                }
+            }
+
+            public bool ContainsKey(object key)
+            {
+                var index = key != null ? (long?)System.Convert.ToInt64(key) : null;
                 return index.HasValue && index.Value >= 0L && index.Value < items.Length;
             }
 
@@ -91,15 +125,23 @@ namespace DotLiquid.Tests
         public void TestVirtualListLoop()
         {
             string output = Template.Parse("{%for item in list%}{{ item }} {%endfor%}")
-                .Render(Hash.FromAnonymousObject(new {list = new VirtualList(1L, "Second", 3L)}));
+                .Render(Hash.FromAnonymousObject(new {list = new VirtualList(1, "Second", 3)}));
             Assert.AreEqual("1 Second 3 ", output);
         }
 
         [Test]
-        public void TestVirtualListIndex()
+        public void TestVirtualListIntIndex()
         {
             string output = Template.Parse("1: {{ list[0] }}, 2: {{ list[1] }}, 3: {{ list[2] }}")
-                .Render(Hash.FromAnonymousObject(new {list = new VirtualList(1L, "Second", 3L)}));
+                .Render(Hash.FromAnonymousObject(new {list = new VirtualList(1, "Second", 3)}));
+            Assert.AreEqual("1: 1, 2: Second, 3: 3", output);
+        }
+
+        [Test]
+        public void TestVirtualListLongIndex()
+        {
+            string output = Template.Parse("1: {{ list[0] }}, 2: {{ list[1] }}, 3: {{ list[2] }}")
+                .Render(Hash.FromAnonymousObject(new { list = new VirtualLongList(1L, "Second", 3L) }));
             Assert.AreEqual("1: 1, 2: Second, 3: 3", output);
         }
 
@@ -128,7 +170,15 @@ namespace DotLiquid.Tests
         {
             string output = Template.Parse("1: {{container[0]}}, 2: {{container[1]}}")
                 .Render(Hash.FromAnonymousObject(new {container = new CustomIndexable()}));
-            Assert.AreEqual("1: System.Int64 0, 2: System.Int64 1", output);
+            Assert.AreEqual("1: System.Int32 0, 2: System.Int32 1", output);
+        }
+
+        [Test]
+        public void TestCustomIndexableLongKeys()
+        {
+            string output = Template.Parse("1: {{container[2147483648]}}, 2: {{container[2999999999]}}")
+                .Render(Hash.FromAnonymousObject(new { container = new CustomIndexable() }));
+            Assert.AreEqual("1: System.Int64 2147483648, 2: System.Int64 2999999999", output);
         }
 
         [Test]

--- a/src/DotLiquid.Tests/FilterTests.cs
+++ b/src/DotLiquid.Tests/FilterTests.cs
@@ -31,7 +31,20 @@ namespace DotLiquid.Tests
             }
         }
 
-        private static class FiltersWithArguments
+        private static class FiltersWithArgumentsInt
+        {
+            public static string Adjust(int input, int offset = 10)
+            {
+                return string.Format("[{0:d}]", input + offset);
+            }
+
+            public static string AddSub(int input, int plus, int minus = 20)
+            {
+                return string.Format("[{0:d}]", input + plus - minus);
+            }
+        }
+
+        private static class FiltersWithArgumentsLong
         {
             public static string Adjust(long input, long offset = 10)
             {
@@ -115,7 +128,7 @@ namespace DotLiquid.Tests
         public void TestFilterWithNumericArgument()
         {
             _context["var"] = 1000L;
-            _context.AddFilters(typeof(FiltersWithArguments));
+            _context.AddFilters(typeof(FiltersWithArgumentsInt));
             Assert.AreEqual("[1005]", new Variable("var | adjust: 5").Render(_context));
         }
 
@@ -123,7 +136,7 @@ namespace DotLiquid.Tests
         public void TestFilterWithNegativeArgument()
         {
             _context["var"] = 1000L;
-            _context.AddFilters(typeof(FiltersWithArguments));
+            _context.AddFilters(typeof(FiltersWithArgumentsInt));
             Assert.AreEqual("[995]", new Variable("var | adjust: -5").Render(_context));
         }
 
@@ -131,7 +144,7 @@ namespace DotLiquid.Tests
         public void TestFilterWithDefaultArgument()
         {
             _context["var"] = 1000;
-            _context.AddFilters(typeof(FiltersWithArguments));
+            _context.AddFilters(typeof(FiltersWithArgumentsInt));
             Assert.AreEqual("[1010]", new Variable("var | adjust").Render(_context));
         }
 
@@ -139,7 +152,39 @@ namespace DotLiquid.Tests
         public void TestFilterWithTwoArguments()
         {
             _context["var"] = 1000L;
-            _context.AddFilters(typeof(FiltersWithArguments));
+            _context.AddFilters(typeof(FiltersWithArgumentsInt));
+            Assert.AreEqual("[1150]", new Variable("var | add_sub: 200, 50").Render(_context));
+        }
+
+        [Test]
+        public void TestFilterWithNumericArgumentLong()
+        {
+            _context["var"] = 1000;
+            _context.AddFilters(typeof(FiltersWithArgumentsLong));
+            Assert.AreEqual("[1005]", new Variable("var | adjust: 5").Render(_context));
+        }
+
+        [Test]
+        public void TestFilterWithNegativeArgumentLong()
+        {
+            _context["var"] = 1000;
+            _context.AddFilters(typeof(FiltersWithArgumentsLong));
+            Assert.AreEqual("[995]", new Variable("var | adjust: -5").Render(_context));
+        }
+
+        [Test]
+        public void TestFilterWithDefaultArgumentLong()
+        {
+            _context["var"] = 1000;
+            _context.AddFilters(typeof(FiltersWithArgumentsLong));
+            Assert.AreEqual("[1010]", new Variable("var | adjust").Render(_context));
+        }
+
+        [Test]
+        public void TestFilterWithTwoArgumentsLong()
+        {
+            _context["var"] = 1000;
+            _context.AddFilters(typeof(FiltersWithArgumentsLong));
             Assert.AreEqual("[1150]", new Variable("var | add_sub: 200, 50").Render(_context));
         }
 

--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -35,12 +35,13 @@ namespace DotLiquid.Tests
         [Test]
         public void TestTruncate()
         {
-            Assert.AreEqual(null, StandardFilters.Truncate(null));
-            Assert.AreEqual("", StandardFilters.Truncate(""));
-            Assert.AreEqual("1234...", StandardFilters.Truncate("1234567890", 7));
-            Assert.AreEqual("1234567890", StandardFilters.Truncate("1234567890", 20));
-            Assert.AreEqual("...", StandardFilters.Truncate("1234567890", 0));
-            Assert.AreEqual("1234567890", StandardFilters.Truncate("1234567890"));
+            Assert.AreEqual(expected: null, actual: StandardFilters.Truncate(null));
+            Assert.AreEqual(expected: "", actual: StandardFilters.Truncate(""));
+            Assert.AreEqual(expected: "1234...", actual: StandardFilters.Truncate("1234567890", 7));
+            Assert.AreEqual(expected: "1234567890", actual: StandardFilters.Truncate("1234567890", 20));
+            Assert.AreEqual(expected: "...", actual: StandardFilters.Truncate("1234567890", 0));
+            Assert.AreEqual(expected: "1234567890", actual: StandardFilters.Truncate("1234567890"));
+            Helper.AssertTemplateResult(expected: "H...", template: "{{ 'Hello' | truncate:4 }}");
         }
 
         [Test]

--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -42,6 +42,13 @@ namespace DotLiquid.Tests
             Assert.AreEqual(expected: "...", actual: StandardFilters.Truncate("1234567890", 0));
             Assert.AreEqual(expected: "1234567890", actual: StandardFilters.Truncate("1234567890"));
             Helper.AssertTemplateResult(expected: "H...", template: "{{ 'Hello' | truncate:4 }}");
+
+            Helper.AssertTemplateResult(expected: "Ground control to...", template: "{{ \"Ground control to Major Tom.\" | truncate: 20}}");
+            Helper.AssertTemplateResult(expected: "Ground control, and so on", template: "{{ \"Ground control to Major Tom.\" | truncate: 25, \", and so on\"}}");
+            Helper.AssertTemplateResult(expected: "Ground control to Ma", template: "{{ \"Ground control to Major Tom.\" | truncate: 20, \"\"}}");
+            Helper.AssertTemplateResult(expected: "...", template: "{{ \"Ground control to Major Tom.\" | truncate: 0}}");
+            Helper.AssertTemplateResult(expected: "Liquid error: Value was either too large or too small for an Int32.", template: $"{{{{ \"Ground control to Major Tom.\" | truncate: {((long)int.MaxValue) + 1}}}}}");
+            Helper.AssertTemplateResult(expected: "...", template: "{{ \"Ground control to Major Tom.\" | truncate: -1}}");
         }
 
         [Test]
@@ -62,6 +69,13 @@ namespace DotLiquid.Tests
             Assert.AreEqual("one two...", StandardFilters.TruncateWords("one two three", 2));
             Assert.AreEqual("one two three", StandardFilters.TruncateWords("one two three"));
             Assert.AreEqual("Two small (13&#8221; x 5.5&#8221; x 10&#8221; high) baskets fit inside one large basket (13&#8221;...", StandardFilters.TruncateWords("Two small (13&#8221; x 5.5&#8221; x 10&#8221; high) baskets fit inside one large basket (13&#8221; x 16&#8221; x 10.5&#8221; high) with cover.", 15));
+
+            Helper.AssertTemplateResult(expected: "Ground control to...", template: "{{ \"Ground control to Major Tom.\" | truncate_words: 3}}");
+            Helper.AssertTemplateResult(expected: "Ground control to--", template: "{{ \"Ground control to Major Tom.\" | truncate_words: 3, \"--\"}}");
+            Helper.AssertTemplateResult(expected: "Ground control to", template: "{{ \"Ground control to Major Tom.\" | truncate_words: 3, \"\"}}");
+            Helper.AssertTemplateResult(expected: "...", template: "{{ \"Ground control to Major Tom.\" | truncate_words: 0}}");
+            Helper.AssertTemplateResult(expected: "...", template: "{{ \"Ground control to Major Tom.\" | truncate_words: -1}}");
+            Helper.AssertTemplateResult(expected: "Liquid error: Value was either too large or too small for an Int32.", template: $"{{{{ \"Ground control to Major Tom.\" | truncate_words: {((long)int.MaxValue) + 1}}}}}");
         }
 
         [Test]

--- a/src/DotLiquid.Tests/Tags/StandardTagTests.cs
+++ b/src/DotLiquid.Tests/Tags/StandardTagTests.cs
@@ -182,6 +182,17 @@ namespace DotLiquid.Tests.Tags
         public void TestDynamicVariableLimiting()
         {
             Hash assigns = Hash.FromAnonymousObject(new { array = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0 } });
+            assigns["limit"] = 2;
+            assigns["offset"] = 2;
+            Helper.AssertTemplateResult("34", "{%for i in array limit: limit offset: offset %}{{ i }}{%endfor%}", assigns);
+        }
+
+        [Test]
+        public void TestDynamicVariableLimitingLong()
+        {
+            Hash assigns = Hash.FromAnonymousObject(new { array = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0 } });
+
+            // NOTE(David Burg): Although using long type here for the sake of argument, not using a value necessitating as such extreme large iteration would lead to DOS / extreme execution time.
             assigns["limit"] = 2L;
             assigns["offset"] = 2;
             Helper.AssertTemplateResult("34", "{%for i in array limit: limit offset: offset %}{{ i }}{%endfor%}", assigns);

--- a/src/DotLiquid/StandardFilters.cs
+++ b/src/DotLiquid/StandardFilters.cs
@@ -614,7 +614,7 @@ namespace DotLiquid
         /// <returns></returns>
         public static object Times(object input, object operand)
         {
-            return input is string && operand is long
+            return input is string && (operand is int || operand is long)
                 ? Enumerable.Repeat((string)input, Convert.ToInt32(operand))
                 : DoMathsOperation(input, operand, Expression.MultiplyChecked);
         }

--- a/src/DotLiquid/StandardFilters.cs
+++ b/src/DotLiquid/StandardFilters.cs
@@ -169,12 +169,18 @@ namespace DotLiquid
         public static string Truncate(string input, int length = 50, string truncateString = "...")
         {
             if (string.IsNullOrEmpty(input))
+            {
                 return input;
+            }
 
-            int l = length - truncateString.Length;
+            if (length < 0)
+            {
+                return truncateString;
+            }
 
+            var lengthExcludingTruncateString = length - truncateString.Length;
             return input.Length > length
-                ? input.Substring(0, l < 0 ? 0 : l) + truncateString
+                ? input.Substring(startIndex: 0, length: lengthExcludingTruncateString < 0 ? 0 : lengthExcludingTruncateString) + truncateString
                 : input;
         }
 
@@ -188,13 +194,18 @@ namespace DotLiquid
         public static string TruncateWords(string input, int words = 15, string truncateString = "...")
         {
             if (string.IsNullOrEmpty(input))
+            {
                 return input;
+            }
 
-            var wordList = input.Split(' ').ToList();
-            int l = words < 0 ? 0 : words;
+            if (words <= 0)
+            {
+                return truncateString;
+            }
 
-            return wordList.Count > l
-                ? string.Join(" ", wordList.Take(l).ToArray()) + truncateString
+            var wordArray = input.Split(' ');
+            return wordArray.Length > words
+                ? string.Join(separator: " ", values: wordArray.Take(words)) + truncateString
                 : input;
         }
 

--- a/src/DotLiquid/Strainer.cs
+++ b/src/DotLiquid/Strainer.cs
@@ -133,6 +133,18 @@ namespace DotLiquid
                     args.Add(parameterInfos[i].DefaultValue);
                 }
 
+            // Attempt conversions where required by type mismatch and possible by value range.
+            // These may be narrowing conversions (e.g. Int64 to Int32) when the actual range doesn't cause an overflow.
+            for (var argumentIndex = 0; argumentIndex < parameterInfos.Length; argumentIndex++)
+            {
+                if (args[argumentIndex] != null
+                    && args[argumentIndex].GetType() != parameterInfos[argumentIndex].ParameterType
+                    && args[argumentIndex] is IConvertible)
+                {
+                    args[argumentIndex] = Convert.ChangeType(args[argumentIndex], parameterInfos[argumentIndex].ParameterType);
+                }
+            }
+
             try
             {
                 return methodInfo.Item2.Invoke(methodInfo.Item1, args.ToArray());

--- a/src/DotLiquid/Tags/For.cs
+++ b/src/DotLiquid/Tags/For.cs
@@ -107,8 +107,8 @@ namespace DotLiquid.Tags
                     : Convert.ToInt32(context[_attributes["offset"]])
                 : 0;
 
-            long? limit = _attributes.ContainsKey("limit") ? context[_attributes["limit"]] as long? : null;
-            long? to = (limit != null) ? (long?) (limit.Value + from) : null;
+            int? limit = _attributes.ContainsKey("limit") ? (int?)Convert.ToInt32(context[_attributes["limit"]]) : null;
+            int? to = (limit != null) ? (int?)(limit.Value + from) : null;
 
             List<object> segment = SliceCollectionUsingEach(context, (IEnumerable) collection, from, to);
 
@@ -166,7 +166,7 @@ namespace DotLiquid.Tags
             });
         }
 
-        private static List<object> SliceCollectionUsingEach(Context context, IEnumerable collection, int from, long? to)
+        private static List<object> SliceCollectionUsingEach(Context context, IEnumerable collection, int from, int? to)
         {
             List<object> segments = new List<object>();
             int index = 0;


### PR DESCRIPTION
I messed up with #362 
@dsparkplug drafted a fix with #365 
Upon thorough review of #362 found ~15 different incorrect changes. Correcting each and all of them.
Adding also the additional truncate and truncate-words test cases from @dsparkplug 
Restored a number of units tests back to their original 32 bit int testing behaviors, and forked additional tests for 64 bit input.