### PR TITLE
Updated "Capitalize" method to follow Shopify spec

### DIFF
--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -881,16 +881,17 @@ namespace DotLiquid.Tests
             Assert.AreEqual(null, StandardFilters.Capitalize(null));
             Assert.AreEqual("", StandardFilters.Capitalize(""));
             Assert.AreEqual(" ", StandardFilters.Capitalize(" "));
-            Assert.AreEqual("That Is One Sentence.", StandardFilters.Capitalize("That is one sentence."));
+            Assert.AreEqual("That is one sentence.", StandardFilters.Capitalize("That Is One Sentence."));
+            Assert.AreEqual("That is one sentence. This is another.", StandardFilters.Capitalize("That Is One Sentence. this Is Another."));
 
             Helper.AssertTemplateResult(
                 expected: "Title",
                 template: "{{ 'title' | capitalize }}");
 
             // Following test disabled due to out-of-spec bug see https://github.com/dotliquid/dotliquid/issues/390
-            //// Helper.AssertTemplateResult(
-            ////     expected: "My great title",
-            ////     template: "{{ 'my great title' | capitalize }}");
+            Helper.AssertTemplateResult(
+                expected: "My great title",
+                template: "{{ 'my great title' | capitalize }}");
         }
 
         [Test]

--- a/src/DotLiquid/StandardFilters.cs
+++ b/src/DotLiquid/StandardFilters.cs
@@ -109,22 +109,15 @@ namespace DotLiquid
         }
 
         /// <summary>
-        /// capitalize words in the input sentence
+        /// Capitalizes the first word in each sentence of <paramref name="input"/>
         /// </summary>
         /// <param name="input"></param>
         /// <returns></returns>
         public static string Capitalize(string input)
         {
-            if (input.IsNullOrWhiteSpace())
-                return input;
-
-            return string.IsNullOrEmpty(input)
+            return input.IsNullOrWhiteSpace()
                 ? input
-#if CORE
-                : Regex.Replace(input, @"\b(\w)", m => m.Value.ToUpper(), RegexOptions.None, Template.RegexTimeOut);
-#else
-                : CultureInfo.CurrentCulture.TextInfo.ToTitleCase(input);
-#endif
+                : Regex.Replace(input.ToLower(), @"^\D|\.( ){1,}\D", m => m.Value.ToUpper(), RegexOptions.None, Template.RegexTimeOut);
         }
 
         /// <summary>


### PR DESCRIPTION
## Describe in your message, what you're fixing. Reference the original issue, if possible.
"Capitalize does not follow Shopify spec - capitalizes each word #390"

Rather than using the title-case approach, this code uses a regex match to find the first letter after full stops

The regex pattern used is `^\D|\.( ){1,}\D`
- `^\D` will match with the starting letter of the string
- `|` represents `OR`
- `\.( ){1,}\D` will match with the remaining letters that follow a full stop and some whitespace

For a visual representation of the regex pattern, open [this regexr link](https://regexr.com/5alh7)


## Describe how if any API-breaking changes your PR may introduce.

This code changes how dotliquid renders content; the current implementation of the 'Capitalize' tag may now be 'a feature rather than a bug'

For backwards compatibility, it might make more sense to leave the current implementation as is

There was a comment above the unit test of the updated code that indicates this bug is out of spec
> ``` csharp
> // Following test disabled due to out-of-spec bug see https://github.com/dotliquid/dotliquid/issues/390
> ```


## State whether it's ready-to-review/-merge or if it's a WIP PR.

***ready-to-review** - please read the API-breaking changes section before accepting*

The test method included in the pull request has been updated to reflect the expected behavior of Shopify (as outlined by #390)

The test passes using the test runner inside Visual Studio

![image](https://user-images.githubusercontent.com/14317886/90937706-41e65080-e3ff-11ea-9e8e-feaf25da76ed.png)
