### PR TITLE
Fix of some cast problems between epoch date, plus method and back to date

### DIFF
--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -715,6 +715,9 @@ namespace DotLiquid.Tests
                 Helper.AssertTemplateResult("5.5", "{{ 2  | plus:3.5 }}");
                 Helper.AssertTemplateResult("5.5", "{{ 3.5 | plus:2 }}");
                 Helper.AssertTemplateResult("11", "{{ '1' | plus:'1' }}");
+                Liquid.UseRubyDateFormat = true;
+                Helper.AssertTemplateResult("2", "{{ '1' | plus:'1' }}");
+                Liquid.UseRubyDateFormat = false;
 
                 // Test that decimals are not introducing rounding-precision issues
                 Helper.AssertTemplateResult("148397.77", "{{ 148387.77 | plus:10 }}");

--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -715,8 +715,10 @@ namespace DotLiquid.Tests
                 Helper.AssertTemplateResult("5.5", "{{ 2  | plus:3.5 }}");
                 Helper.AssertTemplateResult("5.5", "{{ 3.5 | plus:2 }}");
                 Helper.AssertTemplateResult("11", "{{ '1' | plus:'1' }}");
+
                 Liquid.UseRubyDateFormat = true;
-                Helper.AssertTemplateResult("2", "{{ '1' | plus:'1' }}");
+                Helper.AssertTemplateResult("13/10/2020 00:00:00", @"{{ ""12/10/2020 00:00:00"" | date: ""%s"" | plus: " + 24*60*60 +
+                                                  @" | date: ""%d/%m/%Y %H:%M:%S"" }}");
                 Liquid.UseRubyDateFormat = false;
 
                 // Test that decimals are not introducing rounding-precision issues
@@ -777,6 +779,7 @@ namespace DotLiquid.Tests
                 Helper.AssertTemplateResult("125", "{{ 10.0 | times:12.5 }}");
                 Helper.AssertTemplateResult("125", "{{ 12.5 | times:10 }}");
                 Helper.AssertTemplateResult("125", "{{ 12.5 | times:10.0 }}");
+                Helper.AssertTemplateResult("125", @"{{ ""12.5"" | times:10.0 }}");
                 Helper.AssertTemplateResult("foofoofoofoo", "{{ 'foo' | times:4 }}");
 
                 // Test against overflows when we try to be precise but the result exceeds the range of the input type.

--- a/src/DotLiquid.Tests/Util/StrFTimeTests.cs
+++ b/src/DotLiquid.Tests/Util/StrFTimeTests.cs
@@ -39,7 +39,7 @@ namespace DotLiquid.Tests.Util
         [TestCase("%y", ExpectedResult = "12")]
         [TestCase("%Y", ExpectedResult = "2012")]
         [TestCase("%", ExpectedResult = "%")]
-        public string TestFormat(string format)
+        public object TestFormat(string format)
         {
             using (CultureHelper.SetCulture("en-GB"))
             {

--- a/src/DotLiquid/StandardFilters.cs
+++ b/src/DotLiquid/StandardFilters.cs
@@ -601,8 +601,11 @@ namespace DotLiquid
         /// <returns></returns>
         public static object Plus(object input, object operand)
         {
-            return input is string
-                ? string.Concat(input, operand)
+            return input is string s
+                ? (Liquid.UseRubyDateFormat
+                    ? DoMathsOperation((decimal.TryParse(s, out var parsedValue) ? parsedValue : 0), operand,
+                        Expression.AddChecked)
+                    : string.Concat(s, operand))
                 : DoMathsOperation(input, operand, Expression.AddChecked);
         }
 

--- a/src/DotLiquid/StandardFilters.cs
+++ b/src/DotLiquid/StandardFilters.cs
@@ -525,7 +525,7 @@ namespace DotLiquid
         /// <param name="input"></param>
         /// <param name="format"></param>
         /// <returns></returns>
-        public static string Date(object input, string format)
+        public static object Date(object input, string format)
         {
             if (input == null)
                 return null;
@@ -540,22 +540,32 @@ namespace DotLiquid
             }
             else
             {
-                string value = input.ToString();
-
-                if (string.Equals(value, "now", StringComparison.OrdinalIgnoreCase) || string.Equals(value, "today", StringComparison.OrdinalIgnoreCase))
+                if (input is decimal)
                 {
-                    date = DateTime.Now;
+                    date = new DateTime(1970, 1, 1).AddSeconds(Convert.ToInt64(input));
+                }
+                else
+                {
+                    string value = input.ToString();
+
+                    if (string.Equals(value, "now", StringComparison.OrdinalIgnoreCase) ||
+                        string.Equals(value, "today", StringComparison.OrdinalIgnoreCase))
+                    {
+                        date = DateTime.Now;
+
+                        if (format.IsNullOrWhiteSpace())
+                            return date.ToString();
+                    }
+                    else if (!DateTime.TryParse(value, out date))
+                    {
+                        return value;
+                    }
 
                     if (format.IsNullOrWhiteSpace())
-                        return date.ToString();
-                }
-                else if (!DateTime.TryParse(value, out date))
-                {
-                    return value;
+                        return value;
                 }
 
-                if (format.IsNullOrWhiteSpace())
-                    return value;
+              
             }
 
             return Liquid.UseRubyDateFormat ? date.ToStrFTime(format) : date.ToString(format);
@@ -601,11 +611,8 @@ namespace DotLiquid
         /// <returns></returns>
         public static object Plus(object input, object operand)
         {
-            return input is string s
-                ? (Liquid.UseRubyDateFormat
-                    ? DoMathsOperation((decimal.TryParse(s, out var parsedValue) ? parsedValue : 0), operand,
-                        Expression.AddChecked)
-                    : string.Concat(s, operand))
+            return input is string
+                ? string.Concat(input, operand)
                 : DoMathsOperation(input, operand, Expression.AddChecked);
         }
 

--- a/src/DotLiquid/Util/StrFTime.cs
+++ b/src/DotLiquid/Util/StrFTime.cs
@@ -6,7 +6,7 @@ namespace DotLiquid.Util
 {
     public static class StrFTime
     {
-        public delegate string DateTimeDelegate(DateTime dateTime);
+        public delegate object DateTimeDelegate(DateTime dateTime);
 
         private static readonly Dictionary<string, DateTimeDelegate> Formats = new Dictionary<string, DateTimeDelegate>
         {
@@ -28,7 +28,7 @@ namespace DotLiquid.Util
             { "M", (dateTime) => dateTime.Minute.ToString().PadLeft(2, '0') },
             { "P", (dateTime) => dateTime.ToString("tt", CultureInfo.CurrentCulture).ToLower() },
             { "p", (dateTime) => dateTime.ToString("tt", CultureInfo.CurrentCulture).ToUpper() },
-            { "s", (dateTime) => ((int)(dateTime - new DateTime(1970, 1, 1)).TotalSeconds).ToString() },
+            { "s", (dateTime) => ((int)(dateTime - new DateTime(1970, 1, 1)).TotalSeconds) },
             { "S", (dateTime) => dateTime.ToString("ss", CultureInfo.CurrentCulture) },
             { "u", (dateTime) => ((int)(dateTime.DayOfWeek) == 0 ? ((int)(dateTime).DayOfWeek) + 7 : ((int)(dateTime).DayOfWeek)).ToString() },
             { "U", (dateTime) => CultureInfo.CurrentCulture.Calendar.GetWeekOfYear(dateTime, CultureInfo.CurrentCulture.DateTimeFormat.CalendarWeekRule, DayOfWeek.Sunday).ToString().PadLeft(2, '0') },
@@ -42,7 +42,7 @@ namespace DotLiquid.Util
             { "%", (dateTime) => "%" }
         };
 
-        public static string ToStrFTime(this DateTime dateTime, string pattern)
+        public static object ToStrFTime(this DateTime dateTime, string pattern)
         {
             string output = "";
 
@@ -61,6 +61,8 @@ namespace DotLiquid.Util
                 n++;
             }
 
+
+            if (double.TryParse(output, out double numberOnly)) return numberOnly;
             return output;
         }
     }


### PR DESCRIPTION
The main porpoise of this fix is to correctly handle a common pattern in Liquid date managements

The following code will explain what I'm trying to accomplish, add a day to a date.

```
Liquid.UseRubyDateFormat = true;
Template template = Template.Parse(@"Add one day to current date: {% assign seconds = 14 | times: 24 | times: 60 | times: 60 %}{{mydate | date: ""%s"" | plus: seconds | date: ""%a, %b %d, %y"" }}"); 
Console.WriteLine(template.Render(Hash.FromAnonymousObject(new { mydate = DateTime.Now })));
```
