### PR TITLE
Created IRenderableFactory and ability to pass it in to the Template.Parse

### DIFF
--- a/src/DotLiquid.Tests/RenderableFactoryTests.cs
+++ b/src/DotLiquid.Tests/RenderableFactoryTests.cs
@@ -1,0 +1,89 @@
+using NUnit.Framework;
+using System.IO;
+
+namespace DotLiquid.Tests
+{
+    [TestFixture]
+    public class RenderableFactoryTests
+    {
+
+        [Test]
+        public void TestDefaultVariableFactory()
+        {
+            Template template = Template.Parse("{{test}}");
+            Assert.AreEqual("worked", template.Render(Hash.FromAnonymousObject(new { test = "worked" })));
+            Assert.AreEqual("worked wonderfully", template.Render(Hash.FromAnonymousObject(new { test = "worked wonderfully" })));
+        }
+        public class SimpleTestRenderableFactory : IRenderableFactory
+        {
+            public IRenderable CreateVariable(string markup)
+            {
+                return new SimpleTestVariable(markup);
+            }
+        }
+
+        public class SimpleTestVariable : Variable, IRenderable
+        {
+            public SimpleTestVariable(string markup) : base(markup) { }
+
+            public new void Render(Context context, TextWriter result)
+            {
+                result.Write("<!-- before -->");
+                base.Render(context, result);
+                result.Write("<!-- after -->");
+            }
+        }
+
+        [Test]
+        public void TestSimpleVariableFactory()
+        {
+            Template template = Template.Parse("{{test}}", new SimpleTestRenderableFactory());
+            Assert.AreEqual("<!-- before -->worked<!-- after -->", template.Render(Hash.FromAnonymousObject(new { test = "worked" })));
+            Assert.AreEqual("<!-- before -->worked wonderfully<!-- after -->", template.Render(Hash.FromAnonymousObject(new { test = "worked wonderfully" })));
+        }
+        public class MoreComplexTestRenderableFactory : IRenderableFactory
+        {
+            private int VariableRenderCounter = 0;
+
+            public IRenderable CreateVariable(string markup)
+            {
+                return new MoreComplexTestVariable(markup, ++VariableRenderCounter);
+            }
+        }
+
+        public class MoreComplexTestVariable : Variable, IRenderable
+        {
+            private readonly int VariableNumber;
+
+            public MoreComplexTestVariable(string markup, int variableNumber) : base(markup)
+            {
+                VariableNumber = variableNumber;
+            }
+
+            public new void Render(Context context, TextWriter result)
+            {
+                result.Write($"<span data-render-num=\"{VariableNumber}\" data-original-variable-name=\"{Name}\">");
+                base.Render(context, result);
+                result.Write("</span>");
+            }
+        }
+
+        [Test]
+        public void TestMoreComplexVariableFactory()
+        {
+            Template template = Template.Parse("{{test}}{{test2}}{{test3}}", new MoreComplexTestRenderableFactory());
+            Assert.AreEqual(
+                $"<span data-render-num=\"1\" data-original-variable-name=\"test\">worked</span>" +
+                $"<span data-render-num=\"2\" data-original-variable-name=\"test2\">worked2</span>" +
+                $"<span data-render-num=\"3\" data-original-variable-name=\"test3\">worked3</span>",
+                template.Render(Hash.FromAnonymousObject(new { test = "worked", test2 = "worked2", test3 = "worked3" }))
+            );
+            Assert.AreEqual(
+                $"<span data-render-num=\"1\" data-original-variable-name=\"test\">worked wonderfully</span>" +
+                $"<span data-render-num=\"2\" data-original-variable-name=\"test2\">worked wonderfully2</span>" +
+                $"<span data-render-num=\"3\" data-original-variable-name=\"test3\">worked wonderfully3</span>",
+                template.Render(Hash.FromAnonymousObject(new { test = "worked wonderfully", test2 = "worked wonderfully2", test3 = "worked wonderfully3" }))
+            );
+        }
+    }
+}

--- a/src/DotLiquid/Document.cs
+++ b/src/DotLiquid/Document.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using DotLiquid.Exceptions;
 
@@ -9,6 +9,17 @@ namespace DotLiquid
     /// </summary>
     public class Document : Block
     {
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        public Document() : base() { }
+
+        /// <summary>
+        /// Constructor that takes <see cref="IRenderableFactory"/> param to pass through to block parsing
+        /// </summary>
+        /// <param name="renderableFactory"></param>
+        public Document(IRenderableFactory renderableFactory) : base(renderableFactory) { }
+
         /// <summary>
         /// We don't need markup to open this block
         /// </summary>

--- a/src/DotLiquid/IRenderable.cs
+++ b/src/DotLiquid/IRenderable.cs
@@ -1,12 +1,20 @@
-﻿using System.IO;
+using System.IO;
 
 namespace DotLiquid
 {
     /// <summary>
     /// Object that can render itslef
     /// </summary>
-    internal interface IRenderable
+    public interface IRenderable
     {
         void Render(Context context, TextWriter result);
+    }
+
+    /// <summary>
+    /// Factory object that generates <see cref="IRenderable"/>s for templates
+    /// </summary>
+    public interface IRenderableFactory
+    {
+        IRenderable CreateVariable(string markup);
     }
 }

--- a/src/DotLiquid/Template.cs
+++ b/src/DotLiquid/Template.cs
@@ -212,10 +212,10 @@ namespace DotLiquid
         /// </summary>
         /// <param name="source"></param>
         /// <returns></returns>
-        public static Template Parse(string source)
+        public static Template Parse(string source, IRenderableFactory renderableFactory = null)
         {
             Template template = new Template();
-            template.ParseInternal(source);
+            template.ParseInternal(source, renderableFactory);
             return template;
         }
 
@@ -275,12 +275,12 @@ namespace DotLiquid
         /// </summary>
         /// <param name="source">The source code.</param>
         /// <returns>The template.</returns>
-        internal Template ParseInternal(string source)
+        internal Template ParseInternal(string source, IRenderableFactory renderableFactory = null)
         {
             source = DotLiquid.Tags.Literal.FromShortHand(source);
             source = DotLiquid.Tags.Comment.FromShortHand(source);
 
-            this.Root = new Document();
+            this.Root = new Document(renderableFactory);
             this.Root.Initialize(tagName: null, markup: null, tokens: Template.Tokenize(source));
             return this;
         }


### PR DESCRIPTION
The company I work with uses this package heavily, and we recently needed the functionality to modify (at our discretion) the output of a variable in a custom way, that wouldn't require editing the source template files.

This leaves default functionality intact without any discernible performance impact. The only thing that the default behavior does now that it didn't before is the `if (tag is Block block)` check in `Block.cs`, so that it can pass the IRendererFactory to sub blocks.

I added in a couple unit tests to show a simple example of what we needed to accomplish.

This is ready to review and merge if accepted. 

There are no breaking changes, the parameter for the factory on the `Template.Parse` method is optional, and if not provided will work exactly as before.

Due to our reliance on this package, if you'd like, my company has shown interest in becoming a maintainer for DotLiquid, and could help in upgrading it to .netStandard2.0 and/or core.