### PR TITLE
Use ExceptionDispatchInto to preserve stack trace

### DIFF
--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -1,13 +1,14 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using System.Text.RegularExpressions;
 using DotLiquid.Exceptions;
 using DotLiquid.Util;
-using System.Diagnostics;
 
 namespace DotLiquid
 {
@@ -161,7 +162,9 @@ namespace DotLiquid
         public string HandleError(Exception ex)
         {
             if (ex is InterruptException || ex is TimeoutException || ex is RenderException)
-                throw ex;
+            {
+                ExceptionDispatchInfo.Capture(ex).Throw();
+            }
 
             Errors.Add(ex);
 
@@ -169,7 +172,9 @@ namespace DotLiquid
                 return string.Empty;
 
             if (_errorsOutputMode == ErrorsOutputMode.Rethrow)
-                throw ex;
+            {
+                ExceptionDispatchInfo.Capture(ex).Throw();
+            }
 
             if (ex is SyntaxException)
             {

--- a/src/DotLiquid/Strainer.cs
+++ b/src/DotLiquid/Strainer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using DotLiquid.Exceptions;
 
 namespace DotLiquid
@@ -171,7 +172,8 @@ namespace DotLiquid
             }
             catch (TargetInvocationException ex)
             {
-                throw ex.InnerException;
+                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                throw;
             }
         }
     }


### PR DESCRIPTION
Currently, the exception stack trace is rewritten by `throw ex` in `Context.HandleError` and `Strainer.Invoke`. We can update it with `ExceptionDispatchInfo.Capture(ex).Throw()` to perserve the stack trace ([reference](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.exceptionservices.exceptiondispatchinfo?view=net-5.0)).