### PR TITLE
C# Naming Convention

### DIFF
--- a/src/DotLiquid.Tests/ConditionTests.cs
+++ b/src/DotLiquid.Tests/ConditionTests.cs
@@ -439,6 +439,7 @@ namespace DotLiquid.Tests
                 AssertEvaluatesTrue("16", "is_multiple_of", "4");
                 AssertEvaluatesFalse("16", "is_multiple_of", "5");
 
+                // camel case : incompatible
                 AssertError("16", "isMultipleOf", "4", typeof(ArgumentException));
 
                 //Run tests through the template to verify that capitalization rules are followed through template parsing
@@ -477,6 +478,7 @@ namespace DotLiquid.Tests
                 AssertEvaluatesTrue("16", "is_multiple_of", "4");
                 AssertEvaluatesFalse("16", "is_multiple_of", "5");
 
+                // camel case : incompatible
                 AssertError("16", "isMultipleOf", "4", typeof(ArgumentException));
 
                 //Run tests through the template to verify that capitalization rules are followed through template parsing
@@ -519,14 +521,19 @@ namespace DotLiquid.Tests
                     AssertEvaluatesTrue("16", "divisibleby", "4");
                     AssertEvaluatesFalse("16", "divisibleby", "5");
 
-                    AssertError("16", "divisibleBy", "4", typeof(ArgumentException));
+                    // camel case : compatibility
+                    AssertEvaluatesTrue("16", "divisibleBy", "4");
+                    AssertEvaluatesFalse("16", "divisibleBy", "5");
+
+                    // snake case : incompatible
+                    AssertError("16", "divisible_by", "4", typeof(ArgumentException));
 
                     //Run tests through the template to verify that capitalization rules are followed through template parsing
                     Helper.AssertTemplateResult(" TRUE ", "{% if 16 DivisibleBy 4 %} TRUE {% endif %}");
                     Helper.AssertTemplateResult("", "{% if 16 DivisibleBy 5 %} TRUE {% endif %}");
                     Helper.AssertTemplateResult(" TRUE ", "{% if 16 divisibleby 4 %} TRUE {% endif %}");
                     Helper.AssertTemplateResult("", "{% if 16 divisibleby 5 %} TRUE {% endif %}");
-                    Helper.AssertTemplateResult("Liquid error: Unknown operator divisibleBy", "{% if 16 divisibleBy 4 %} TRUE {% endif %}");
+                    Helper.AssertTemplateResult("Liquid error: Unknown operator divisible_by", "{% if 16 divisible_by 4 %} TRUE {% endif %}");
                 }
                 finally
                 {
@@ -561,14 +568,19 @@ namespace DotLiquid.Tests
                     AssertEvaluatesTrue("16", "divisibleby", "4");
                     AssertEvaluatesFalse("16", "divisibleby", "5");
 
-                    AssertError("16", "divisibleBy", "4", typeof(ArgumentException));
+                    // camel case: compatibility
+                    AssertEvaluatesTrue("16", "divisibleBy", "4");
+                    AssertEvaluatesFalse("16", "divisibleBy", "5");
+
+                    // snake case: incompatible
+                    AssertError("16", "divisible_by", "4", typeof(ArgumentException));
 
                     //Run tests through the template to verify that capitalization rules are followed through template parsing
                     Helper.AssertTemplateResult(" TRUE ", "{% if 16 DivisibleBy 4 %} TRUE {% endif %}");
                     Helper.AssertTemplateResult("", "{% if 16 DivisibleBy 5 %} TRUE {% endif %}");
                     Helper.AssertTemplateResult(" TRUE ", "{% if 16 divisibleby 4 %} TRUE {% endif %}");
                     Helper.AssertTemplateResult("", "{% if 16 divisibleby 5 %} TRUE {% endif %}");
-                    Helper.AssertTemplateResult("Liquid error: Unknown operator divisibleBy", "{% if 16 divisibleBy 4 %} TRUE {% endif %}");
+                    Helper.AssertTemplateResult("Liquid error: Unknown operator divisible_by", "{% if 16 divisible_by 4 %} TRUE {% endif %}");
                 }
                 finally
                 {

--- a/src/DotLiquid.Tests/ConditionTests.cs
+++ b/src/DotLiquid.Tests/ConditionTests.cs
@@ -531,9 +531,8 @@ namespace DotLiquid.Tests
                 finally
                 {
                     Condition.Operators.Remove("DivisibleBy");
+                    Template.NamingConvention = oldconvention;
                 }
-
-                Template.NamingConvention = oldconvention;
             }
         }
 
@@ -574,9 +573,8 @@ namespace DotLiquid.Tests
                 finally
                 {
                     Condition.Operators.Remove("DivisibleBy");
+                    Template.NamingConvention = oldconvention;
                 }
-
-                Template.NamingConvention = oldconvention;
             }
         }
 

--- a/src/DotLiquid.Tests/DropTests.cs
+++ b/src/DotLiquid.Tests/DropTests.cs
@@ -391,14 +391,11 @@ namespace DotLiquid.Tests
         [Test]
         public void TestRubyNamingConventionPrintsHelpfulErrorIfMissingPropertyWouldMatchCSharpNamingConvention()
         {
-            INamingConvention savedNamingConvention = Template.NamingConvention;
-            Template.NamingConvention = new RubyNamingConvention();
-            Template template = Template.Parse("{{ value.ProductID }}");
-            Assert.AreEqual("Missing property. Did you mean 'product_id'?", template.Render(Hash.FromAnonymousObject(new
-            {
-                value = new CamelCaseDrop()
-            })));
-            Template.NamingConvention = savedNamingConvention;
+            Helper.AssertTemplateResult(
+                expected:"Missing property. Did you mean 'product_id'?",
+                template: "{{ value.ProductID }}",
+                anonymousObject: new { value = new CamelCaseDrop() },
+                namingConvention: new RubyNamingConvention());
         }
     }
 }

--- a/src/DotLiquid.Tests/Helper.cs
+++ b/src/DotLiquid.Tests/Helper.cs
@@ -1,11 +1,11 @@
-﻿using DotLiquid.NamingConventions;
+using DotLiquid.NamingConventions;
 using NUnit.Framework;
 
 namespace DotLiquid.Tests
 {
     public class Helper
     {
-        public static void AssertTemplateResult(string expected, string template, Hash localVariables, INamingConvention namingConvention)
+        public static void AssertTemplateResult(string expected, string template, object anonymousObject, INamingConvention namingConvention)
         {
             //Have to lock Template.NamingConvention for this test to
             //prevent other tests from being run simultaneously that
@@ -17,6 +17,7 @@ namespace DotLiquid.Tests
 
                 try
                 {
+                    var localVariables = anonymousObject == null ? null : Hash.FromAnonymousObject(anonymousObject);
                     AssertTemplateResult(expected, template, localVariables);
                 }
                 finally
@@ -26,6 +27,11 @@ namespace DotLiquid.Tests
             }
         }
 
+        public static void AssertTemplateResult(string expected, string template, INamingConvention namingConvention)
+        {
+            AssertTemplateResult(expected: expected, template: template, anonymousObject: null, namingConvention: namingConvention);
+        }
+
         public static void AssertTemplateResult(string expected, string template, Hash localVariables)
         {
             Assert.AreEqual(expected, Template.Parse(template).Render(localVariables));
@@ -33,7 +39,7 @@ namespace DotLiquid.Tests
 
         public static void AssertTemplateResult(string expected, string template)
         {
-            AssertTemplateResult(expected, template, null);
+            AssertTemplateResult(expected: expected, template: template, localVariables: null);
         }
 
         [LiquidTypeAttribute("PropAllowed")]

--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -598,8 +598,25 @@ namespace DotLiquid.Tests
         }
 
         [Test]
-        public void TestFirstLast()
+        public void TestFirstLastUsingRuby()
         {
+            var namingConvention = new NamingConventions.RubyNamingConvention();
+            TestFirstLast(namingConvention, (name) => namingConvention.GetMemberName(name));
+        }
+
+        [Test]
+        public void TestFirstLastUsingCSharp()
+        {
+            var namingConvention = new NamingConventions.CSharpNamingConvention();
+            TestFirstLast(namingConvention, (name) => char.ToUpperInvariant(name[0]) + name.Substring(1));
+        }
+
+        private void TestFirstLast(NamingConventions.INamingConvention namingConvention, Func<string, string> filterNameFunc )
+        {
+            var splitFilter = filterNameFunc("split");
+            var firstFilter = filterNameFunc("first");
+            var lastFilter = filterNameFunc("last");
+
             Assert.Null(StandardFilters.First(null));
             Assert.Null(StandardFilters.Last(null));
             Assert.AreEqual(1, StandardFilters.First(new[] { 1, 2, 3 }));
@@ -609,29 +626,37 @@ namespace DotLiquid.Tests
 
             Helper.AssertTemplateResult(
                 expected: ".",
-                template: "{{ 'Ground control to Major Tom.' | last }}");
+                template: "{{ 'Ground control to Major Tom.' | " + lastFilter + " }}",
+                namingConvention: namingConvention);
             Helper.AssertTemplateResult(
                 expected: "Tom.",
-                template: "{{ 'Ground control to Major Tom.' | split: ' ' | last }}");
+                template: "{{ 'Ground control to Major Tom.' | "+ splitFilter + ": ' ' | " + lastFilter + " }}",
+                namingConvention: namingConvention);
             Helper.AssertTemplateResult(
                 expected: "tiger",
-                template: "{% assign my_array = 'zebra, octopus, giraffe, tiger' | split: ', ' %}{{ my_array.last }}");
+                template: "{% assign my_array = 'zebra, octopus, giraffe, tiger' | " + splitFilter + ": ', ' %}{{ my_array." + lastFilter + " }}",
+                namingConvention: namingConvention);
             Helper.AssertTemplateResult(
                 expected: "There goes a tiger!",
-                template: "{% assign my_array = 'zebra, octopus, giraffe, tiger' | split: ', ' %}{% if my_array.last == 'tiger' %}There goes a tiger!{% endif %}");
+                template: "{% assign my_array = 'zebra, octopus, giraffe, tiger' | " + splitFilter + ": ', ' %}{% if my_array." + lastFilter + " == 'tiger' %}There goes a tiger!{% endif %}",
+                namingConvention: namingConvention);
 
             Helper.AssertTemplateResult(
                 expected: "G",
-                template: "{{ 'Ground control to Major Tom.' | first }}");
+                template: "{{ 'Ground control to Major Tom.' | " + firstFilter + " }}",
+                namingConvention: namingConvention);
             Helper.AssertTemplateResult(
                 expected: "Ground",
-                template: "{{ 'Ground control to Major Tom.' | split: ' ' | first }}");
+                template: "{{ 'Ground control to Major Tom.' | " + splitFilter + ": ' ' | " + firstFilter + " }}",
+                namingConvention: namingConvention);
             Helper.AssertTemplateResult(
                 expected: "zebra",
-                template: "{% assign my_array = 'zebra, octopus, giraffe, tiger' | split: ', ' %}{{ my_array.first }}");
+                template: "{% assign my_array = 'zebra, octopus, giraffe, tiger' | " + splitFilter + ": ', ' %}{{ my_array." + firstFilter + " }}",
+                namingConvention: namingConvention);
             Helper.AssertTemplateResult(
                 expected: "There goes a zebra!",
-                template: "{% assign my_array = 'zebra, octopus, giraffe, tiger' | split: ', ' %}{% if my_array.first == 'zebra' %}There goes a zebra!{% endif %}");
+                template: "{% assign my_array = 'zebra, octopus, giraffe, tiger' | " + splitFilter + ": ', ' %}{% if my_array." + firstFilter + " == 'zebra' %}There goes a zebra!{% endif %}",
+                namingConvention: namingConvention);
         }
 
         [Test]

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -520,17 +520,17 @@ namespace DotLiquid
                     // Some special cases. If the part wasn't in square brackets and
                     // no key with the same name was found we interpret following calls
                     // as commands and call them on the current object
-                    else if (!partResolved && (@object is IEnumerable) && ((part as string) == "size" || (part as string) == "first" || (part as string) == "last"))
+                    else if (!partResolved && (@object is IEnumerable) && (Template.NamingConvention.OperatorEquals(part as string, "size") || Template.NamingConvention.OperatorEquals(part as string, "first") || Template.NamingConvention.OperatorEquals(part as string, "last")))
                     {
                         var castCollection = ((IEnumerable)@object).Cast<object>();
-                        if ((part as string) == "size")
+                        if (Template.NamingConvention.OperatorEquals(part as string, "size"))
                             @object = castCollection.Count();
-                        else if ((part as string) == "first")
+                        else if (Template.NamingConvention.OperatorEquals(part as string, "first"))
                         {
                             object res = castCollection.FirstOrDefault();
                             @object = Liquidize(res);
                         }
-                        else if ((part as string) == "last")
+                        else if (Template.NamingConvention.OperatorEquals(part as string, "last"))
                         {
                             object res = castCollection.LastOrDefault();
                             @object = Liquidize(res);

--- a/src/DotLiquid/NamingConventions/CSharpNamingConvention.cs
+++ b/src/DotLiquid/NamingConventions/CSharpNamingConvention.cs
@@ -27,7 +27,7 @@ namespace DotLiquid.NamingConventions
 
         private static string LowerFirstLetter(string word)
         {
-            return char.ToUpperInvariant(word[0]) + word.Substring(1);
+            return char.ToLowerInvariant(word[0]) + word.Substring(1);
         }
     }
 }


### PR DESCRIPTION
This addresses several bugs with the C# naming convention:
- `{% if Array.Size > 0 %} ` did not evaluate - it expects size regardless of convention. `{{ Array | Size }}` does respect convention.
- C# devs use PascalCase and camelCase. The latter was supposed to be allowed, but was uppercasing the C instead of lower-casing it resulting in PascalCase being allowed twice. Reason this wasn't caught is there is a third convention allowed of all lowercase (at least conditionals) which most tests were using.
- Testing naming convention requires a change to the static property. While many tests correctly reverted, some used older syntax that did not. I followed previous practice in updating what I hope is all of them.

This introduced two tests that were failing - after review the tests themselves are incorrectly defining the expected behavior. The above bug fixed revealed these and my rational for changing the tests are noted below.