### PR TITLE
[WIP] Strict Liquid Syntax (Part 2)

### DIFF
--- a/src/DotLiquid/ExtendedFilters.cs
+++ b/src/DotLiquid/ExtendedFilters.cs
@@ -1,0 +1,46 @@
+using System.Text.RegularExpressions;
+using System.Globalization;
+
+namespace DotLiquid
+{
+    /// <summary>
+    /// Extended DotLiquid Filters. Not registered by default.
+    /// </summary>
+    public static class ExtendedFilters
+    {
+        /// <summary>
+        /// Capitalize all the words in the input sentence
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static string Titleize(Context context, string input)
+        {
+            if (input.IsNullOrWhiteSpace())
+                return input;
+
+            return string.IsNullOrEmpty(input)
+                ? input
+#if CORE
+                : Regex.Replace(input, @"\b(\w)", m => m.Value.ToUpper(), RegexOptions.None, Template.RegexTimeOut);
+#else
+                : CultureInfo.CurrentCulture.TextInfo.ToTitleCase(input);
+#endif
+        }
+
+        /// <summary>
+        /// Converts just the first character to uppercase
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static string UpcaseFirst(Context context, string input)
+        {
+            if (input.IsNullOrWhiteSpace())
+                return input;
+
+            var trimmed = input.TrimStart();
+            return input.Substring(0, input.Length - trimmed.Length) + char.ToUpper(trimmed[0]) + trimmed.Substring(1);
+        }
+    }
+}

--- a/src/DotLiquid/SyntaxCompatibilityEnum.cs
+++ b/src/DotLiquid/SyntaxCompatibilityEnum.cs
@@ -14,5 +14,10 @@ namespace DotLiquid
         /// Behavior as of DotLiquid 2.1
         /// </summary>
         DotLiquid21 = 210,
+
+        /// <summary>
+        /// Behavior as of DotLiquid 2.1a
+        /// </summary>
+        DotLiquid21a = 211,
     }
 }


### PR DESCRIPTION
- Updated Capitalize filters to be inline with Reference Library.
- Partially updated Sort filters to be inline with Reference Library - sorting by a property is not changed.
- Adds Missing SortNatural filter - useful if you liked the old behavior of Sort - Part of Issue #330 
- Adds a way to get back old behaviors of Capitalize