### PR TITLE
Fix ArgumentNullException upon calling Regex.Match() due to invalid variable name

### DIFF
--- a/src/DotLiquid.Tests/ContextTests.cs
+++ b/src/DotLiquid.Tests/ContextTests.cs
@@ -279,6 +279,17 @@ namespace DotLiquid.Tests
         }
 
         [Test]
+        public void TestVariableNotFoundExceptionFromInvalidVariableName()
+        {
+            Template template = Template.Parse("{{ . }}");
+            string rendered = template.Render();
+
+            Assert.AreEqual("", rendered);
+            Assert.AreEqual(1, template.Errors.Count);
+            Assert.AreEqual(string.Format(Liquid.ResourceManager.GetString("VariableNotFoundException"), "."), template.Errors[0].Message);
+        }
+
+        [Test]
         public void TestScoping()
         {
             Assert.DoesNotThrow(() =>

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -465,6 +465,12 @@ namespace DotLiquid
 
             // first item in list, if any
             string firstPart = parts.TryGetAtIndex(0);
+            if (firstPart == null)
+            {
+                if (notifyNotFound)
+                    Errors.Add(new VariableNotFoundException(string.Format(Liquid.ResourceManager.GetString("VariableNotFoundException"), markup)));
+                return null;
+            }
 
             Match firstPartSquareBracketedMatch = SquareBracketedRegex.Match(firstPart);
             if (firstPartSquareBracketedMatch.Success)


### PR DESCRIPTION
Encountered this while moving out templates from Mustache to Liquid, a if statement can be written as follow in Mustache:
```Mustache
{{#person}}
  {{.}}
{{/person}}
```
Where `{{.}}` refers to the person variable itself, so the Liquid equivalent would be:
```Liquid
{% if person %}
  {{ person }}
{% endif %}
```

Obviously it's not gonna work when the Mustache template is being processed by dotliquid, but if you would have `{{.}}` in your liquid template you'd get an `ArgumentNullException` when the library calls:
```csharp
Match firstPartSquareBracketedMatch = SquareBracketedRegex.Match(firstPart);
```

This is because a null is passed into `.Match()` due to the parts list having a length of zero.

---

To fix this, I've added an explicit null check on the variable `firstPart` and return a `VariableNotFoundException` if requested. This should result in a clearer error message to the end user, in order to fix their template.