### PR TITLE
Strict Liquid Syntax (Part 2) + Render Performance

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
-﻿# Build script for dotliquid, see https://www.appveyor.com/docs/appveyor-yml for reference
-version: 2.1.{build}
+# Build script for dotliquid, see https://www.appveyor.com/docs/appveyor-yml for reference
+version: 2.2.{build}
 image: Visual Studio 2017
 
 cache:

--- a/src/DotLiquid.Tests/ContextTests.cs
+++ b/src/DotLiquid.Tests/ContextTests.cs
@@ -953,7 +953,7 @@ namespace DotLiquid.Tests
 
         private void TestVariableParser(Func<string, IEnumerable<string>> variableSplitterFunc)
         {
-            CollectionAssert.IsEmpty(GetVariableParts(""));
+            CollectionAssert.IsEmpty(variableSplitterFunc(""));
             CollectionAssert.AreEqual(new[] { "var" }, variableSplitterFunc("var"));
             CollectionAssert.AreEqual(new[] { "var", "method" }, variableSplitterFunc("var.method"));
             CollectionAssert.AreEqual(new[] { "var", "[method]" }, variableSplitterFunc("var[method]"));

--- a/src/DotLiquid.Tests/ContextTests.cs
+++ b/src/DotLiquid.Tests/ContextTests.cs
@@ -349,25 +349,31 @@ namespace DotLiquid.Tests
             Context context = new Context(CultureInfo.InvariantCulture);
             context.AddFilters(new[] { typeof(TestFilters) });
             Assert.AreEqual("hi? hi!", context.Invoke("hi", new List<object> { "hi?" }));
+            context.SyntaxCompatibilityLevel = SyntaxCompatibility.DotLiquid22;
+            Assert.AreEqual("hi? hi!", context.Invoke("hi", new List<object> { "hi?" }));
 
             context = new Context(CultureInfo.InvariantCulture);
             Assert.AreEqual("hi?", context.Invoke("hi", new List<object> { "hi?" }));
-
-            context.AddFilters(new[] { typeof(TestFilters) });
-            Assert.AreEqual("hi? hi!", context.Invoke("hi", new List<object> { "hi?" }));
+            context.SyntaxCompatibilityLevel = SyntaxCompatibility.DotLiquid22;
+            Assert.Throws<FilterNotFoundException>(() => context.Invoke("hi", new List<object> { "hi?" }));
         }
 
         [Test]
         public void TestAddContextFilter()
         {
-            Context context = new Context(CultureInfo.InvariantCulture);
+            // This test differs from TestAddFilter only in that the Hi method within this class has a Context parameter in addition to the input string
+            Context context = new Context(CultureInfo.InvariantCulture) { SyntaxCompatibilityLevel = SyntaxCompatibility.DotLiquid20 };
             context["name"] = "King Kong";
 
             context.AddFilters(new[] { typeof(TestContextFilters) });
             Assert.AreEqual("hi? hi from King Kong!", context.Invoke("hi", new List<object> { "hi?" }));
+            context.SyntaxCompatibilityLevel = SyntaxCompatibility.DotLiquid22;
+            Assert.AreEqual("hi? hi from King Kong!", context.Invoke("hi", new List<object> { "hi?" }));
 
-            context = new Context(CultureInfo.InvariantCulture);
+            context = new Context(CultureInfo.InvariantCulture) { SyntaxCompatibilityLevel = SyntaxCompatibility.DotLiquid20 };
             Assert.AreEqual("hi?", context.Invoke("hi", new List<object> { "hi?" }));
+            context.SyntaxCompatibilityLevel = SyntaxCompatibility.DotLiquid22;
+            Assert.Throws<FilterNotFoundException>(() => context.Invoke("hi", new List<object> { "hi?" })); 
         }
 
         [Test]

--- a/src/DotLiquid.Tests/ExtendedFilterTests.cs
+++ b/src/DotLiquid.Tests/ExtendedFilterTests.cs
@@ -31,8 +31,7 @@ namespace DotLiquid.Tests
 
             Helper.AssertTemplateResult(
                 expected: "Title",
-                template: "{{ 'title' | titleize }}",
-                syntax: context.SyntaxCompatibilityLevel);
+                template: "{{ 'title' | titleize }}");
         }
 
         [Test]
@@ -46,8 +45,7 @@ namespace DotLiquid.Tests
 
             Helper.AssertTemplateResult(
                 expected: "My great title",
-                template: "{{ 'my great title' | upcase_first }}",
-                syntax: context.SyntaxCompatibilityLevel);
+                template: "{{ 'my great title' | upcase_first }}");
         }
     }
 }

--- a/src/DotLiquid.Tests/ExtendedFilterTests.cs
+++ b/src/DotLiquid.Tests/ExtendedFilterTests.cs
@@ -1,0 +1,53 @@
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DotLiquid.Tests
+{
+    [TestFixture]
+    public class ExtendedFilterTests
+    {
+        private Context _context;
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            _context = new Context(CultureInfo.InvariantCulture);
+            Template.RegisterFilter(typeof(ExtendedFilters));
+        }
+
+        [Test]
+        public void TestTitleize()
+        {
+            var context = _context;
+            Assert.AreEqual(null, ExtendedFilters.Titleize(context: context, input: null));
+            Assert.AreEqual("", ExtendedFilters.Titleize(context: context, input: ""));
+            Assert.AreEqual(" ", ExtendedFilters.Titleize(context: context, input: " "));
+            Assert.AreEqual("That Is One Sentence.", ExtendedFilters.Titleize(context: context, input: "That is one sentence."));
+
+            Helper.AssertTemplateResult(
+                expected: "Title",
+                template: "{{ 'title' | titleize }}",
+                syntax: context.SyntaxCompatibilityLevel);
+        }
+
+        [Test]
+        public void TestUpcaseFirst()
+        {
+            var context = _context;
+            Assert.AreEqual(null, ExtendedFilters.UpcaseFirst(context: context, input: null));
+            Assert.AreEqual("", ExtendedFilters.UpcaseFirst(context: context, input: ""));
+            Assert.AreEqual(" ", ExtendedFilters.UpcaseFirst(context: context, input: " "));
+            Assert.AreEqual(" My boss is Mr. Doe.", ExtendedFilters.UpcaseFirst(context: context, input: " my boss is Mr. Doe."));
+
+            Helper.AssertTemplateResult(
+                expected: "My great title",
+                template: "{{ 'my great title' | upcase_first }}",
+                syntax: context.SyntaxCompatibilityLevel);
+        }
+    }
+}

--- a/src/DotLiquid.Tests/HashTests.cs
+++ b/src/DotLiquid.Tests/HashTests.cs
@@ -126,9 +126,8 @@ namespace DotLiquid.Tests
             var hash = new Hash(0); // default value of zero
             hash["key"] = "value";
 
-            // NOTE: the next two asserts will change to true when performance changes are introduced by PR #441.
-            Assert.False(hash.Contains("unknown-key"));
-            Assert.False(hash.ContainsKey("unknown-key"));
+            Assert.True(hash.Contains("unknown-key"));
+            Assert.True(hash.ContainsKey("unknown-key"));
             Assert.AreEqual(0, hash["unknown-key"]); // ensure the default value is returned
 
             Assert.True(hash.Contains("key"));
@@ -136,8 +135,8 @@ namespace DotLiquid.Tests
             Assert.AreEqual("value", hash["key"]);
 
             hash.Remove("key");
-            Assert.False(hash.Contains("key"));
-            Assert.False(hash.ContainsKey("key"));
+            Assert.True(hash.Contains("key"));
+            Assert.True(hash.ContainsKey("key"));
             Assert.AreEqual(0, hash["key"]); // ensure the default value is returned after key removed
         }
 
@@ -147,8 +146,8 @@ namespace DotLiquid.Tests
             var hash = new Hash((h, k) => { return "Lambda Value"; });
             hash["key"] = "value";
 
-            Assert.False(hash.Contains("unknown-key"));
-            Assert.False(hash.ContainsKey("unknown-key"));
+            Assert.True(hash.Contains("unknown-key"));
+            Assert.True(hash.ContainsKey("unknown-key"));
             Assert.AreEqual("Lambda Value", hash["unknown-key"]);
 
             Assert.True(hash.Contains("key"));

--- a/src/DotLiquid.Tests/ParsingQuirksTests.cs
+++ b/src/DotLiquid.Tests/ParsingQuirksTests.cs
@@ -126,9 +126,9 @@ namespace DotLiquid.Tests
         [Test]
         public void TestShortHandSyntaxIsIgnored()
         {
-            //These tests are based on actual handling on Ruby Liquid, not indicative of wanted behavior
+            //These tests are based on actual handling on Ruby Liquid, not indicative of wanted behavior. Behavior for legacy dotliquid parser is in TestEmptyLiteral
             Assert.AreEqual("}", Template.Parse("{{{}}}", SyntaxCompatibility.DotLiquid22).Render());
-            Assert.AreEqual(string.Empty, Template.Parse("{{%%}}", SyntaxCompatibility.DotLiquid22).Render());
+            Assert.AreEqual("{##}", Template.Parse("{##}", SyntaxCompatibility.DotLiquid22).Render());
         }
     }
 }

--- a/src/DotLiquid.Tests/ParsingQuirksTests.cs
+++ b/src/DotLiquid.Tests/ParsingQuirksTests.cs
@@ -74,14 +74,16 @@ namespace DotLiquid.Tests
         [TestCase(".y")]
         public void TestVariableNotTerminatedFromInvalidVariableName(string variableName)
         {
-            Template template = Template.Parse("{{ " + variableName + " }}");
+            var template = Template.Parse("{{ " + variableName + " }}");
             SyntaxException ex = Assert.Throws<SyntaxException>(() => template.Render(new RenderParameters(System.Globalization.CultureInfo.InvariantCulture)
             {
                 LocalVariables = Hash.FromAnonymousObject(new { x = "" }),
                 ErrorsOutputMode = ErrorsOutputMode.Rethrow,
                 SyntaxCompatibilityLevel = SyntaxCompatibility.DotLiquid22
             }));
-            Assert.AreEqual(string.Format(Liquid.ResourceManager.GetString("VariableNotTerminatedException"), variableName), ex.Message);
+            Assert.AreEqual(
+                expected: string.Format(Liquid.ResourceManager.GetString("VariableNotTerminatedException"), variableName),
+                actual: ex.Message);
 
             template = Template.Parse("{{ x[" + variableName + "] }}");
             ex = Assert.Throws<SyntaxException>(() => template.Render(new RenderParameters(System.Globalization.CultureInfo.InvariantCulture)
@@ -90,7 +92,9 @@ namespace DotLiquid.Tests
                 ErrorsOutputMode = ErrorsOutputMode.Rethrow,
                 SyntaxCompatibilityLevel = SyntaxCompatibility.DotLiquid22
             }));
-            Assert.AreEqual(string.Format(Liquid.ResourceManager.GetString("VariableNotTerminatedException"), variableName), ex.Message);
+            Assert.AreEqual(
+                expected: string.Format(Liquid.ResourceManager.GetString("VariableNotTerminatedException"), variableName),
+                actual: ex.Message);
         }
 
         [Test]
@@ -103,7 +107,9 @@ namespace DotLiquid.Tests
                 ErrorsOutputMode = ErrorsOutputMode.Rethrow,
                 SyntaxCompatibilityLevel = SyntaxCompatibility.DotLiquid22
             }));
-            Assert.AreEqual(string.Format(Liquid.ResourceManager.GetString("VariableNotTerminatedException"), "["), ex.Message);
+            Assert.AreEqual(
+                expected: string.Format(Liquid.ResourceManager.GetString("VariableNotTerminatedException"), "["),
+                actual: ex.Message);
         }
 
         [TestCase("[\"]")]
@@ -112,7 +118,9 @@ namespace DotLiquid.Tests
         public void TestVariableTokenizerNotTerminated(string variableName)
         {
             var ex = Assert.Throws<SyntaxException>(() => Tokenizer.GetVariableEnumerator(variableName).MoveNext());
-            Assert.AreEqual(string.Format(Liquid.ResourceManager.GetString("VariableNotTerminatedException"), variableName), ex.Message);
+            Assert.AreEqual(
+                expected: string.Format(Liquid.ResourceManager.GetString("VariableNotTerminatedException"), variableName),
+                actual: ex.Message);
         }
 
         [Test]

--- a/src/DotLiquid.Tests/ParsingQuirksTests.cs
+++ b/src/DotLiquid.Tests/ParsingQuirksTests.cs
@@ -114,5 +114,13 @@ namespace DotLiquid.Tests
             var ex = Assert.Throws<SyntaxException>(() => Tokenizer.GetVariableEnumerator(variableName).MoveNext());
             Assert.AreEqual(string.Format(Liquid.ResourceManager.GetString("VariableNotTerminatedException"), variableName), ex.Message);
         }
+
+        [Test]
+        public void TestShortHandSyntaxIsIgnored()
+        {
+            //These tests are based on actual handling on Ruby Liquid, not indicative of wanted behavior
+            Assert.AreEqual("}", Template.Parse("{{{}}}", SyntaxCompatibility.DotLiquid22).Render());
+            Assert.AreEqual(string.Empty, Template.Parse("{{%%}}", SyntaxCompatibility.DotLiquid22).Render());
+        }
     }
 }

--- a/src/DotLiquid.Tests/ParsingQuirksTests.cs
+++ b/src/DotLiquid.Tests/ParsingQuirksTests.cs
@@ -126,7 +126,7 @@ namespace DotLiquid.Tests
         [Test]
         public void TestShortHandSyntaxIsIgnored()
         {
-            //These tests are based on actual handling on Ruby Liquid, not indicative of wanted behavior. Behavior for legacy dotliquid parser is in TestEmptyLiteral
+            // These tests are based on actual handling on Ruby Liquid, not indicative of wanted behavior. Behavior for legacy dotliquid parser is in TestEmptyLiteral
             Assert.AreEqual("}", Template.Parse("{{{}}}", SyntaxCompatibility.DotLiquid22).Render());
             Assert.AreEqual("{##}", Template.Parse("{##}", SyntaxCompatibility.DotLiquid22).Render());
         }

--- a/src/DotLiquid.Tests/RegexpTests.cs
+++ b/src/DotLiquid.Tests/RegexpTests.cs
@@ -81,17 +81,6 @@ namespace DotLiquid.Tests
             CollectionAssert.AreEqual(new[] { "arg1", "arg2", "\"arg 3\"", "arg4" }, Run("arg1 arg2 \"arg 3\" arg4", Liquid.QuotedFragment));
         }
 
-        [Test]
-        public void TestVariableParser()
-        {
-            CollectionAssert.AreEqual(new[] { "var" }, Run("var", Liquid.VariableParser));
-            CollectionAssert.AreEqual(new[] { "var", "method" }, Run("var.method", Liquid.VariableParser));
-            CollectionAssert.AreEqual(new[] { "var", "[method]" }, Run("var[method]", Liquid.VariableParser));
-            CollectionAssert.AreEqual(new[] { "var", "[method]", "[0]" }, Run("var[method][0]", Liquid.VariableParser));
-            CollectionAssert.AreEqual(new[] { "var", "[\"method\"]", "[0]" }, Run("var[\"method\"][0]", Liquid.VariableParser));
-            CollectionAssert.AreEqual(new[] { "var", "[method]", "[0]", "method" }, Run("var[method][0].method", Liquid.VariableParser));
-        }
-
         private static List<string> Run(string input, string pattern)
         {
             return R.Scan(input, new Regex(pattern));

--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -12,6 +12,7 @@ namespace DotLiquid.Tests
     {
         private Context _contextV20;
         private Context _contextV21;
+        private Context _contextV22;
 
         [OneTimeSetUp]
         public void SetUp()
@@ -23,6 +24,10 @@ namespace DotLiquid.Tests
             _contextV21 = new Context(CultureInfo.InvariantCulture)
             {
                 SyntaxCompatibilityLevel = SyntaxCompatibility.DotLiquid21
+            };
+            _contextV22 = new Context(CultureInfo.InvariantCulture)
+            {
+                SyntaxCompatibilityLevel = SyntaxCompatibility.DotLiquid22
             };
         }
 
@@ -1299,6 +1304,21 @@ namespace DotLiquid.Tests
             Helper.AssertTemplateResult(
                 expected: "My great title",
                 template: "{{ 'my great title' | capitalize }}",
+                syntax: context.SyntaxCompatibilityLevel);
+        }
+
+        [Test]
+        public void TestCapitalizeV22()
+        {
+            var context = _contextV22;
+            Assert.AreEqual(null, StandardFilters.Capitalize(context: context, input: null));
+            Assert.AreEqual("", StandardFilters.Capitalize(context: context, input: ""));
+            Assert.AreEqual(" ", StandardFilters.Capitalize(context: context, input: " "));
+            Assert.AreEqual("My boss is mr. doe.", StandardFilters.Capitalize(context: context, input: "my boss is Mr. Doe."));
+
+            Helper.AssertTemplateResult(
+                expected: "My great title",
+                template: "{{ 'my Great Title' | capitalize }}",
                 syntax: context.SyntaxCompatibilityLevel);
         }
 

--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -205,27 +205,87 @@ namespace DotLiquid.Tests
         }
 
         [Test]
-        public void TestSort()
+        public void TestSortV20()
         {
-            Assert.AreEqual(null, StandardFilters.Sort(null));
-            CollectionAssert.AreEqual(new string[] { }, StandardFilters.Sort(new string[] { }));
-            CollectionAssert.AreEqual(new[] { 1, 2, 3, 4 }, StandardFilters.Sort(new[] { 4, 3, 2, 1 }));
-            CollectionAssert.AreEqual(new[] { new { a = 1 }, new { a = 2 }, new { a = 3 }, new { a = 4 } },
-                StandardFilters.Sort(new[] { new { a = 4 }, new { a = 3 }, new { a = 1 }, new { a = 2 } }, "a"));
+            var ints = new[] { 10, 3, 2, 1 };
+            Assert.AreEqual(null, StandardFilters.Sort(_contextV20, null));
+            CollectionAssert.AreEqual(new string[] { }, StandardFilters.Sort(_contextV20, new string[] { }));
+            CollectionAssert.AreEqual(new[] { 1, 2, 3, 10 }, StandardFilters.Sort(_contextV20, ints));
+            CollectionAssert.AreEqual(new[] { new { a = 1 }, new { a = 2 }, new { a = 3 }, new { a = 10 } },
+                StandardFilters.Sort(_contextV20, new[] { new { a = 10 }, new { a = 3 }, new { a = 1 }, new { a = 2 } }, "a"));
+
+            // Issue #393 - Incorrect (Case-Insensitve) Alphabetic Sort
+            var strings = new[] { "zebra", "octopus", "giraffe", "Sally Snake" };
+            CollectionAssert.AreEqual(new[] { "giraffe", "octopus", "Sally Snake", "zebra" },
+                StandardFilters.Sort(_contextV20, strings));
+
+            var hashes = new List<Hash>();
+            for (var i = 0; i < strings.Length; i++)
+                hashes.Add(CreateHash(ints[i], strings[i]));
+            CollectionAssert.AreEqual(new[] { hashes[2], hashes[1], hashes[3], hashes[0] },
+                StandardFilters.Sort(_contextV20, hashes, "content"));
+            CollectionAssert.AreEqual(new[] { hashes[3], hashes[2], hashes[1], hashes[0] },
+                StandardFilters.Sort(_contextV20, hashes, "sortby"));
+        }
+
+        [Test]
+        public void TestSortV22()
+        {
+            var ints = new[] { 10, 3, 2, 1 };
+            Assert.AreEqual(null, StandardFilters.Sort(_contextV22, null));
+            CollectionAssert.AreEqual(new string[] { }, StandardFilters.Sort(_contextV22, new string[] { }));
+            CollectionAssert.AreEqual(new[] { 1, 2, 3, 10 }, StandardFilters.Sort(_contextV22, ints));
+            CollectionAssert.AreEqual(new[] { new { a = 1 }, new { a = 2 }, new { a = 3 }, new { a = 10 } },
+                StandardFilters.Sort(_contextV22, new[] { new { a = 10 }, new { a = 3 }, new { a = 1 }, new { a = 2 } }, "a"));
+
+            var strings = new[] { "zebra", "octopus", "giraffe", "Sally Snake" };
+            CollectionAssert.AreEqual(new[] { "Sally Snake", "giraffe", "octopus", "zebra" },
+                StandardFilters.Sort(_contextV22, strings));
+
+            var hashes = new List<Hash>();
+            for (var i = 0; i < strings.Length; i++)
+                hashes.Add(CreateHash(ints[i], strings[i]));
+            CollectionAssert.AreEqual(new[] { hashes[3], hashes[2], hashes[1], hashes[0]  },
+                StandardFilters.Sort(_contextV22, hashes, "content"));
+            CollectionAssert.AreEqual(new[] { hashes[3], hashes[2], hashes[1], hashes[0] },
+                StandardFilters.Sort(_contextV22, hashes, "sortby"));
+        }
+
+        [Test]
+        public void TestSortNatural()
+        {
+            var ints = new[] { 10, 3, 2, 1 };
+            Assert.AreEqual(null, StandardFilters.SortNatural(null));
+            CollectionAssert.AreEqual(new string[] { }, StandardFilters.SortNatural(new string[] { }));
+            CollectionAssert.AreEqual(new[] { 1, 2, 3, 10 }, StandardFilters.SortNatural(ints));
+            CollectionAssert.AreEqual(new[] { new { a = 1 }, new { a = 2 }, new { a = 3 }, new { a = 10 } },
+                StandardFilters.SortNatural(new[] { new { a = 10 }, new { a = 3 }, new { a = 1 }, new { a = 2 } }, "a"));
+
+            var strings = new[] { "zebra", "octopus", "giraffe", "Sally Snake" };
+            CollectionAssert.AreEqual(new[] { "giraffe", "octopus", "Sally Snake", "zebra" },
+                StandardFilters.SortNatural(strings));
+
+            var hashes = new List<Hash>();
+            for (var i = 0; i < strings.Length; i++)
+                hashes.Add(CreateHash(ints[i], strings[i]));
+            CollectionAssert.AreEqual(new[] { hashes[2], hashes[1], hashes[3], hashes[0] },
+                StandardFilters.SortNatural(hashes, "content"));
+            CollectionAssert.AreEqual(new[] { hashes[3], hashes[2], hashes[1], hashes[0] },
+                StandardFilters.SortNatural(hashes, "sortby"));
         }
 
         [Test]
         public void TestSort_OnHashList_WithProperty_DoesNotFlattenList()
         {
             var list = new List<Hash>();
-            var hash1 = CreateHash("1", "Text1");
-            var hash2 = CreateHash("2", "Text2");
-            var hash3 = CreateHash("3", "Text3");
+            var hash1 = CreateHash(1, "Text1");
+            var hash2 = CreateHash(2, "Text2");
+            var hash3 = CreateHash(3, "Text3");
             list.Add(hash3);
             list.Add(hash1);
             list.Add(hash2);
 
-            var result = StandardFilters.Sort(list, "sortby").Cast<Hash>().ToArray();
+            var result = StandardFilters.Sort(_contextV20, list, "sortby").Cast<Hash>().ToArray();
             Assert.AreEqual(3, result.Count());
             Assert.AreEqual(hash1["content"], result[0]["content"]);
             Assert.AreEqual(hash2["content"], result[1]["content"]);
@@ -236,22 +296,22 @@ namespace DotLiquid.Tests
         public void TestSort_OnDictionaryWithPropertyOnlyInSomeElement_ReturnsSortedDictionary()
         {
             var list = new List<Hash>();
-            var hash1 = CreateHash("1", "Text1");
-            var hash2 = CreateHash("2", "Text2");
+            var hash1 = CreateHash(1, "Text1");
+            var hash2 = CreateHash(2, "Text2");
             var hashWithNoSortByProperty = new Hash();
             hashWithNoSortByProperty.Add("content", "Text 3");
             list.Add(hash2);
             list.Add(hashWithNoSortByProperty);
             list.Add(hash1);
 
-            var result = StandardFilters.Sort(list, "sortby").Cast<Hash>().ToArray();
+            var result = StandardFilters.Sort(_contextV20, list, "sortby").Cast<Hash>().ToArray();
             Assert.AreEqual(3, result.Count());
             Assert.AreEqual(hashWithNoSortByProperty["content"], result[0]["content"]);
             Assert.AreEqual(hash1["content"], result[1]["content"]);
             Assert.AreEqual(hash2["content"], result[2]["content"]);
         }
 
-        private static Hash CreateHash(string sortby, string content) =>
+        private static Hash CreateHash(int sortby, string content) =>
             new Hash
             {
                 { "sortby", sortby },

--- a/src/DotLiquid.Tests/Tags/CommentTests.cs
+++ b/src/DotLiquid.Tests/Tags/CommentTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using DotLiquid.Exceptions;
+using NUnit.Framework;
+using DotLiquid.Tags;
+
+namespace DotLiquid.Tests.Tags
+{
+    [TestFixture]
+    public class CommentTests
+    {
+        [Test]
+        public void TestEmptyComment()
+        {
+            Assert.AreEqual(string.Empty, Template.Parse("{% comment %}{% endcomment %}").Render());
+            // Next test is specific to legacy parser and was removed from Ruby Liquid. Test that it is ignored is in TestShortHandSyntaxIsIgnored
+            Assert.AreEqual(string.Empty, Template.Parse("{##}", SyntaxCompatibility.DotLiquid20).Render());
+        }
+
+        [Test]
+        public void TestSimpleCommentValue()
+        {
+            Assert.AreEqual("", Template.Parse("{% comment %}howdy{% endcomment %}").Render());
+        }
+
+        [Test]
+        public void TestCommentsIgnoreLiquidMarkup()
+        {
+            Assert.AreEqual(
+                expected: "",
+                actual: Template.Parse("{% comment %}{% if 'gnomeslab' contains 'liquid' %}yes{% else %}no{ % endif %}{% endcomment %}").Render());
+        }
+
+        [Test]
+        public void TestCommentShorthand()
+        {
+            Assert.AreEqual("{% comment %}gnomeslab{% endcomment %}", Comment.FromShortHand("{# gnomeslab #}"));
+            Assert.AreEqual(null, Comment.FromShortHand(null));
+
+            Assert.AreEqual(
+                expected: "",
+                actual: Template.Parse("{#{% if 'gnomeslab' contains 'liquid' %}yes{ % endif %}#}", SyntaxCompatibility.DotLiquid20).Render());
+        }
+    }
+}

--- a/src/DotLiquid.Tests/Tags/CommentTests.cs
+++ b/src/DotLiquid.Tests/Tags/CommentTests.cs
@@ -1,8 +1,5 @@
-using System;
-using System.Collections.Generic;
-using DotLiquid.Exceptions;
-using NUnit.Framework;
 using DotLiquid.Tags;
+using NUnit.Framework;
 
 namespace DotLiquid.Tests.Tags
 {
@@ -13,6 +10,7 @@ namespace DotLiquid.Tests.Tags
         public void TestEmptyComment()
         {
             Assert.AreEqual(string.Empty, Template.Parse("{% comment %}{% endcomment %}").Render());
+
             // Next test is specific to legacy parser and was removed from Ruby Liquid. Test that it is ignored is in TestShortHandSyntaxIsIgnored
             Assert.AreEqual(string.Empty, Template.Parse("{##}", SyntaxCompatibility.DotLiquid20).Render());
         }

--- a/src/DotLiquid.Tests/Tags/LiteralTests.cs
+++ b/src/DotLiquid.Tests/Tags/LiteralTests.cs
@@ -14,8 +14,7 @@ namespace DotLiquid.Tests.Tags
         {
             Template t = Template.Parse("{% literal %}{% endliteral %}");
             Assert.AreEqual(string.Empty, t.Render());
-            t = Template.Parse("{{{}}}");
-            Assert.AreEqual(string.Empty, t.Render());
+            Assert.AreEqual(string.Empty, Template.Parse("{{{}}}", SyntaxCompatibility.DotLiquid20).Render());
         }
 
         [Test]
@@ -35,14 +34,14 @@ namespace DotLiquid.Tests.Tags
         [Test]
         public void TestShorthandSyntax()
         {
-            Template t = Template.Parse("{{{{% if 'gnomeslab' contains 'liquid' %}yes{ % endif %}}}}");
+            Template t = Template.Parse("{{{{% if 'gnomeslab' contains 'liquid' %}yes{ % endif %}}}}", SyntaxCompatibility.DotLiquid20);
             Assert.AreEqual("{% if 'gnomeslab' contains 'liquid' %}yes{ % endif %}", t.Render());
         }
 
         [Test]
         public void TestLiteralsDontRemoveComments()
         {
-            Template t = Template.Parse("{{{ {# comment #} }}}");
+            Template t = Template.Parse("{{{ {# comment #} }}}", SyntaxCompatibility.DotLiquid20);
             Assert.AreEqual("{# comment #}", t.Render());
         }
 

--- a/src/DotLiquid.Tests/Tags/LiteralTests.cs
+++ b/src/DotLiquid.Tests/Tags/LiteralTests.cs
@@ -13,6 +13,7 @@ namespace DotLiquid.Tests.Tags
         public void TestEmptyLiteral()
         {
             Assert.AreEqual(string.Empty, Template.Parse("{% literal %}{% endliteral %}").Render());
+
             // Next test is specific to legacy parser and was removed from Ruby Liquid. Test that it is ignored is in TestShortHandSyntaxIsIgnored
             Assert.AreEqual(string.Empty, Template.Parse("{{{}}}", SyntaxCompatibility.DotLiquid20).Render());
         }

--- a/src/DotLiquid.Tests/Tags/LiteralTests.cs
+++ b/src/DotLiquid.Tests/Tags/LiteralTests.cs
@@ -12,37 +12,36 @@ namespace DotLiquid.Tests.Tags
         [Test]
         public void TestEmptyLiteral()
         {
-            Template t = Template.Parse("{% literal %}{% endliteral %}");
-            Assert.AreEqual(string.Empty, t.Render());
+            Assert.AreEqual(string.Empty, Template.Parse("{% literal %}{% endliteral %}").Render());
             Assert.AreEqual(string.Empty, Template.Parse("{{{}}}", SyntaxCompatibility.DotLiquid20).Render());
         }
 
         [Test]
         public void TestSimpleLiteralValue()
         {
-            Template t = Template.Parse("{% literal %}howdy{% endliteral %}");
-            Assert.AreEqual("howdy", t.Render());
+            Assert.AreEqual("howdy", Template.Parse("{% literal %}howdy{% endliteral %}").Render());
         }
 
         [Test]
         public void TestLiteralsIgnoreLiquidMarkup()
         {
-            Template t = Template.Parse("{% literal %}{% if 'gnomeslab' contains 'liquid' %}yes{ % endif %}{% endliteral %}");
-            Assert.AreEqual("{% if 'gnomeslab' contains 'liquid' %}yes{ % endif %}", t.Render());
+            Assert.AreEqual(
+                expected: "{% if 'gnomeslab' contains 'liquid' %}yes{ % endif %}",
+                actual: Template.Parse("{% literal %}{% if 'gnomeslab' contains 'liquid' %}yes{ % endif %}{% endliteral %}").Render());
         }
 
         [Test]
         public void TestShorthandSyntax()
         {
-            Template t = Template.Parse("{{{{% if 'gnomeslab' contains 'liquid' %}yes{ % endif %}}}}", SyntaxCompatibility.DotLiquid20);
-            Assert.AreEqual("{% if 'gnomeslab' contains 'liquid' %}yes{ % endif %}", t.Render());
+            Assert.AreEqual(
+                expected: "{% if 'gnomeslab' contains 'liquid' %}yes{ % endif %}",
+                actual: Template.Parse("{{{{% if 'gnomeslab' contains 'liquid' %}yes{ % endif %}}}}", SyntaxCompatibility.DotLiquid20).Render());
         }
 
         [Test]
         public void TestLiteralsDontRemoveComments()
         {
-            Template t = Template.Parse("{{{ {# comment #} }}}", SyntaxCompatibility.DotLiquid20);
-            Assert.AreEqual("{# comment #}", t.Render());
+            Assert.AreEqual("{# comment #}", Template.Parse("{{{ {# comment #} }}}", SyntaxCompatibility.DotLiquid20).Render());
         }
 
         [Test]

--- a/src/DotLiquid.Tests/Tags/LiteralTests.cs
+++ b/src/DotLiquid.Tests/Tags/LiteralTests.cs
@@ -13,6 +13,7 @@ namespace DotLiquid.Tests.Tags
         public void TestEmptyLiteral()
         {
             Assert.AreEqual(string.Empty, Template.Parse("{% literal %}{% endliteral %}").Render());
+            // Next test is specific to legacy parser and was removed from Ruby Liquid. Test that it is ignored is in TestShortHandSyntaxIsIgnored
             Assert.AreEqual(string.Empty, Template.Parse("{{{}}}", SyntaxCompatibility.DotLiquid20).Render());
         }
 
@@ -48,6 +49,7 @@ namespace DotLiquid.Tests.Tags
         public void TestFromShorthand()
         {
             Assert.AreEqual("{% literal %}gnomeslab{% endliteral %}", Literal.FromShortHand("{{{gnomeslab}}}"));
+            Assert.AreEqual(null, Literal.FromShortHand(null));
         }
 
         [Test]

--- a/src/DotLiquid.Tests/TemplateTests.cs
+++ b/src/DotLiquid.Tests/TemplateTests.cs
@@ -8,8 +8,7 @@ namespace DotLiquid.Tests
     [TestFixture]
     public class TemplateTests
     {
-
-        private System.Collections.Generic.List<string> TokenizeValidateBackwardCompat(string input)
+        private System.Collections.Generic.List<string> TokenizeValidateBackwardCompatibility(string input)
         {
             var v20 = Tokenizer.Tokenize(input, SyntaxCompatibility.DotLiquid20);
             var v22 = Tokenizer.Tokenize(input, SyntaxCompatibility.DotLiquid22);
@@ -20,27 +19,27 @@ namespace DotLiquid.Tests
         [Test]
         public void TestTokenizeStrings()
         {
-            CollectionAssert.AreEqual(new[] { " " }, TokenizeValidateBackwardCompat(" "));
-            CollectionAssert.AreEqual(new[] { "hello world" }, TokenizeValidateBackwardCompat("hello world"));
+            CollectionAssert.AreEqual(new[] { " " }, TokenizeValidateBackwardCompatibility(" "));
+            CollectionAssert.AreEqual(new[] { "hello world" }, TokenizeValidateBackwardCompatibility("hello world"));
         }
 
         [Test]
         public void TestTokenizeVariables()
         {
-            CollectionAssert.AreEqual(new[] { "{{funk}}" }, TokenizeValidateBackwardCompat("{{funk}}"));
-            CollectionAssert.AreEqual(new[] { " ", "{{funk}}", " " }, TokenizeValidateBackwardCompat(" {{funk}} "));
-            CollectionAssert.AreEqual(new[] { " ", "{{funk}}", " ", "{{so}}", " ", "{{brother}}", " " }, TokenizeValidateBackwardCompat(" {{funk}} {{so}} {{brother}} "));
-            CollectionAssert.AreEqual(new[] { " ", "{{  funk  }}", " " }, TokenizeValidateBackwardCompat(" {{  funk  }} "));
+            CollectionAssert.AreEqual(new[] { "{{funk}}" }, TokenizeValidateBackwardCompatibility("{{funk}}"));
+            CollectionAssert.AreEqual(new[] { " ", "{{funk}}", " " }, TokenizeValidateBackwardCompatibility(" {{funk}} "));
+            CollectionAssert.AreEqual(new[] { " ", "{{funk}}", " ", "{{so}}", " ", "{{brother}}", " " }, TokenizeValidateBackwardCompatibility(" {{funk}} {{so}} {{brother}} "));
+            CollectionAssert.AreEqual(new[] { " ", "{{  funk  }}", " " }, TokenizeValidateBackwardCompatibility(" {{  funk  }} "));
         }
 
         [Test]
         public void TestTokenizeBlocks()
         {
-            CollectionAssert.AreEqual(new[] { "{%assign%}" }, TokenizeValidateBackwardCompat("{%assign%}"));
-            CollectionAssert.AreEqual(new[] { " ", "{%assign%}", " " }, TokenizeValidateBackwardCompat(" {%assign%} "));
+            CollectionAssert.AreEqual(new[] { "{%assign%}" }, TokenizeValidateBackwardCompatibility("{%assign%}"));
+            CollectionAssert.AreEqual(new[] { " ", "{%assign%}", " " }, TokenizeValidateBackwardCompatibility(" {%assign%} "));
 
-            CollectionAssert.AreEqual(new[] { " ", "{%comment%}", " ", "{%endcomment%}", " " }, TokenizeValidateBackwardCompat(" {%comment%} {%endcomment%} "));
-            CollectionAssert.AreEqual(new[] { "  ", "{% comment %}", " ", "{% endcomment %}", " " }, TokenizeValidateBackwardCompat("  {% comment %} {% endcomment %} "));
+            CollectionAssert.AreEqual(new[] { " ", "{%comment%}", " ", "{%endcomment%}", " " }, TokenizeValidateBackwardCompatibility(" {%comment%} {%endcomment%} "));
+            CollectionAssert.AreEqual(new[] { "  ", "{% comment %}", " ", "{% endcomment %}", " " }, TokenizeValidateBackwardCompatibility("  {% comment %} {% endcomment %} "));
         }
 
         [Test]
@@ -108,7 +107,7 @@ namespace DotLiquid.Tests
         {
             Template t = new Template();
             int global = 0;
-            t.Assigns["number"] = (Proc) (c => ++global);
+            t.Assigns["number"] = (Proc)(c => ++global);
             Assert.AreEqual("1", t.ParseInternal("{{number}}", SyntaxCompatibility.DotLiquid22).Render());
             Assert.AreEqual("1", t.ParseInternal("{{number}}", SyntaxCompatibility.DotLiquid22).Render());
             Assert.AreEqual("1", t.Render());
@@ -119,7 +118,7 @@ namespace DotLiquid.Tests
         {
             Template t = new Template();
             int global = 0;
-            Hash assigns = Hash.FromAnonymousObject(new { number = (Proc) (c => ++global) });
+            Hash assigns = Hash.FromAnonymousObject(new { number = (Proc)(c => ++global) });
             Assert.AreEqual("1", t.ParseInternal("{{number}}", SyntaxCompatibility.DotLiquid22).Render(assigns));
             Assert.AreEqual("1", t.ParseInternal("{{number}}", SyntaxCompatibility.DotLiquid22).Render(assigns));
             Assert.AreEqual("1", t.Render(assigns));
@@ -153,7 +152,7 @@ namespace DotLiquid.Tests
 </ul>";
             Assert.AreEqual(
                 "<ul>\r\n    <li>foo</li>\r\n    <li>bar</li>\r\n    <li>baz</li>\r\n</ul>",
-                Template.Parse(template, SyntaxCompatibility.DotLiquid20).Render(Hash.FromAnonymousObject(new { tasks = new [] { "foo", "bar", "baz" } })));
+                Template.Parse(template, SyntaxCompatibility.DotLiquid20).Render(Hash.FromAnonymousObject(new { tasks = new[] { "foo", "bar", "baz" } })));
             Assert.AreEqual(
                 "<ul>\r\n<li>foo</li><li>bar</li><li>baz</li></ul>",
                 Template.Parse(template, SyntaxCompatibility.DotLiquid22).Render(Hash.FromAnonymousObject(new { tasks = new[] { "foo", "bar", "baz" } })));
@@ -304,7 +303,7 @@ namespace DotLiquid.Tests
         [Test]
         public void TestHtmlEncodingFilter()
         {
-            Template.RegisterValueTypeTransformer(typeof(string), m => WebUtility.HtmlEncode((string) m));
+            Template.RegisterValueTypeTransformer(typeof(string), m => WebUtility.HtmlEncode((string)m));
 
             Template template = Template.Parse("{{var1}} {{var2}}");
 
@@ -327,7 +326,7 @@ namespace DotLiquid.Tests
         public void TestRegisterSimpleTypeTransformIntoAnonymousType()
         {
             // specify a transform function
-            Template.RegisterSafeType(typeof(MySimpleType2), x => new { Name = ((MySimpleType2)x).Name } );
+            Template.RegisterSafeType(typeof(MySimpleType2), x => new { Name = ((MySimpleType2)x).Name });
             Template template = Template.Parse("{{context.Name}}");
 
             var output = template.Render(Hash.FromAnonymousObject(new { context = new MySimpleType2 { Name = "worked" } }));
@@ -339,7 +338,7 @@ namespace DotLiquid.Tests
         public void TestRegisterInterfaceTransformIntoAnonymousType()
         {
             // specify a transform function
-            Template.RegisterSafeType(typeof(IMySimpleInterface2), x => new { Name = ((IMySimpleInterface2) x).Name });
+            Template.RegisterSafeType(typeof(IMySimpleInterface2), x => new { Name = ((IMySimpleInterface2)x).Name });
             Template template = Template.Parse("{{context.Name}}");
 
             var output = template.Render(Hash.FromAnonymousObject(new { context = new MySimpleType2 { Name = "worked" } }));
@@ -422,7 +421,7 @@ namespace DotLiquid.Tests
 
                 // RenderParameters Applies Template Defaults 
                 Template.DefaultSyntaxCompatibilityLevel = SyntaxCompatibility.DotLiquid21;
-                var renderParamsDefault = new RenderParameters(CultureInfo.CurrentCulture); 
+                var renderParamsDefault = new RenderParameters(CultureInfo.CurrentCulture);
                 Assert.AreEqual(Template.DefaultSyntaxCompatibilityLevel, renderParamsDefault.SyntaxCompatibilityLevel);
 
                 // Context Applies Template Defaults

--- a/src/DotLiquid.Tests/TemplateTests.cs
+++ b/src/DotLiquid.Tests/TemplateTests.cs
@@ -9,38 +9,38 @@ namespace DotLiquid.Tests
     public class TemplateTests
     {
 
-        private System.Collections.Generic.List<string> Tokenize(string input)
+        private System.Collections.Generic.List<string> TokenizeValidateBackwardCompat(string input)
         {
             var v20 = Tokenizer.Tokenize(input, SyntaxCompatibility.DotLiquid20);
             var v22 = Tokenizer.Tokenize(input, SyntaxCompatibility.DotLiquid22);
-            Assert.AreEqual(v20, v22);
+            CollectionAssert.AreEqual(v20, v22);
             return v22;
         }
 
         [Test]
         public void TestTokenizeStrings()
         {
-            CollectionAssert.AreEqual(new[] { " " }, Tokenize(" "));
-            CollectionAssert.AreEqual(new[] { "hello world" }, Tokenize("hello world"));
+            CollectionAssert.AreEqual(new[] { " " }, TokenizeValidateBackwardCompat(" "));
+            CollectionAssert.AreEqual(new[] { "hello world" }, TokenizeValidateBackwardCompat("hello world"));
         }
 
         [Test]
         public void TestTokenizeVariables()
         {
-            CollectionAssert.AreEqual(new[] { "{{funk}}" }, Tokenize("{{funk}}"));
-            CollectionAssert.AreEqual(new[] { " ", "{{funk}}", " " }, Tokenize(" {{funk}} "));
-            CollectionAssert.AreEqual(new[] { " ", "{{funk}}", " ", "{{so}}", " ", "{{brother}}", " " }, Tokenize(" {{funk}} {{so}} {{brother}} "));
-            CollectionAssert.AreEqual(new[] { " ", "{{  funk  }}", " " }, Tokenize(" {{  funk  }} "));
+            CollectionAssert.AreEqual(new[] { "{{funk}}" }, TokenizeValidateBackwardCompat("{{funk}}"));
+            CollectionAssert.AreEqual(new[] { " ", "{{funk}}", " " }, TokenizeValidateBackwardCompat(" {{funk}} "));
+            CollectionAssert.AreEqual(new[] { " ", "{{funk}}", " ", "{{so}}", " ", "{{brother}}", " " }, TokenizeValidateBackwardCompat(" {{funk}} {{so}} {{brother}} "));
+            CollectionAssert.AreEqual(new[] { " ", "{{  funk  }}", " " }, TokenizeValidateBackwardCompat(" {{  funk  }} "));
         }
 
         [Test]
         public void TestTokenizeBlocks()
         {
-            CollectionAssert.AreEqual(new[] { "{%assign%}" }, Tokenize("{%assign%}"));
-            CollectionAssert.AreEqual(new[] { " ", "{%assign%}", " " }, Tokenize(" {%assign%} "));
+            CollectionAssert.AreEqual(new[] { "{%assign%}" }, TokenizeValidateBackwardCompat("{%assign%}"));
+            CollectionAssert.AreEqual(new[] { " ", "{%assign%}", " " }, TokenizeValidateBackwardCompat(" {%assign%} "));
 
-            CollectionAssert.AreEqual(new[] { " ", "{%comment%}", " ", "{%endcomment%}", " " }, Tokenize(" {%comment%} {%endcomment%} "));
-            CollectionAssert.AreEqual(new[] { "  ", "{% comment %}", " ", "{% endcomment %}", " " }, Tokenize("  {% comment %} {% endcomment %} "));
+            CollectionAssert.AreEqual(new[] { " ", "{%comment%}", " ", "{%endcomment%}", " " }, TokenizeValidateBackwardCompat(" {%comment%} {%endcomment%} "));
+            CollectionAssert.AreEqual(new[] { "  ", "{% comment %}", " ", "{% endcomment %}", " " }, TokenizeValidateBackwardCompat("  {% comment %} {% endcomment %} "));
         }
 
         [Test]

--- a/src/DotLiquid.Tests/TemplateTests.cs
+++ b/src/DotLiquid.Tests/TemplateTests.cs
@@ -8,38 +8,47 @@ namespace DotLiquid.Tests
     [TestFixture]
     public class TemplateTests
     {
+
+        private System.Collections.Generic.List<string> Tokenize(string input)
+        {
+            var v20 = Tokenizer.Tokenize(input, SyntaxCompatibility.DotLiquid20);
+            var v22 = Tokenizer.Tokenize(input, SyntaxCompatibility.DotLiquid22);
+            Assert.AreEqual(v20, v22);
+            return v22;
+        }
+
         [Test]
         public void TestTokenizeStrings()
         {
-            CollectionAssert.AreEqual(new[] { " " }, Template.Tokenize(" "));
-            CollectionAssert.AreEqual(new[] { "hello world" }, Template.Tokenize("hello world"));
+            CollectionAssert.AreEqual(new[] { " " }, Tokenize(" "));
+            CollectionAssert.AreEqual(new[] { "hello world" }, Tokenize("hello world"));
         }
 
         [Test]
         public void TestTokenizeVariables()
         {
-            CollectionAssert.AreEqual(new[] { "{{funk}}" }, Template.Tokenize("{{funk}}"));
-            CollectionAssert.AreEqual(new[] { " ", "{{funk}}", " " }, Template.Tokenize(" {{funk}} "));
-            CollectionAssert.AreEqual(new[] { " ", "{{funk}}", " ", "{{so}}", " ", "{{brother}}", " " }, Template.Tokenize(" {{funk}} {{so}} {{brother}} "));
-            CollectionAssert.AreEqual(new[] { " ", "{{  funk  }}", " " }, Template.Tokenize(" {{  funk  }} "));
+            CollectionAssert.AreEqual(new[] { "{{funk}}" }, Tokenize("{{funk}}"));
+            CollectionAssert.AreEqual(new[] { " ", "{{funk}}", " " }, Tokenize(" {{funk}} "));
+            CollectionAssert.AreEqual(new[] { " ", "{{funk}}", " ", "{{so}}", " ", "{{brother}}", " " }, Tokenize(" {{funk}} {{so}} {{brother}} "));
+            CollectionAssert.AreEqual(new[] { " ", "{{  funk  }}", " " }, Tokenize(" {{  funk  }} "));
         }
 
         [Test]
         public void TestTokenizeBlocks()
         {
-            CollectionAssert.AreEqual(new[] { "{%assign%}" }, Template.Tokenize("{%assign%}"));
-            CollectionAssert.AreEqual(new[] { " ", "{%assign%}", " " }, Template.Tokenize(" {%assign%} "));
+            CollectionAssert.AreEqual(new[] { "{%assign%}" }, Tokenize("{%assign%}"));
+            CollectionAssert.AreEqual(new[] { " ", "{%assign%}", " " }, Tokenize(" {%assign%} "));
 
-            CollectionAssert.AreEqual(new[] { " ", "{%comment%}", " ", "{%endcomment%}", " " }, Template.Tokenize(" {%comment%} {%endcomment%} "));
-            CollectionAssert.AreEqual(new[] { "  ", "{% comment %}", " ", "{% endcomment %}", " " }, Template.Tokenize("  {% comment %} {% endcomment %} "));
+            CollectionAssert.AreEqual(new[] { " ", "{%comment%}", " ", "{%endcomment%}", " " }, Tokenize(" {%comment%} {%endcomment%} "));
+            CollectionAssert.AreEqual(new[] { "  ", "{% comment %}", " ", "{% endcomment %}", " " }, Tokenize("  {% comment %} {% endcomment %} "));
         }
 
         [Test]
         public void TestInstanceAssignsPersistOnSameTemplateObjectBetweenParses()
         {
             Template t = new Template();
-            Assert.AreEqual("from instance assigns", t.ParseInternal("{% assign foo = 'from instance assigns' %}{{ foo }}").Render());
-            Assert.AreEqual("from instance assigns", t.ParseInternal("{{ foo }}").Render());
+            Assert.AreEqual("from instance assigns", t.ParseInternal("{% assign foo = 'from instance assigns' %}{{ foo }}", SyntaxCompatibility.DotLiquid22).Render());
+            Assert.AreEqual("from instance assigns", t.ParseInternal("{{ foo }}", SyntaxCompatibility.DotLiquid22).Render());
         }
 
         [Test]
@@ -47,8 +56,8 @@ namespace DotLiquid.Tests
         {
             Template t = new Template();
             t.MakeThreadSafe();
-            Assert.AreEqual("from instance assigns", t.ParseInternal("{% assign foo = 'from instance assigns' %}{{ foo }}").Render());
-            Assert.AreEqual("", t.ParseInternal("{{ foo }}").Render());
+            Assert.AreEqual("from instance assigns", t.ParseInternal("{% assign foo = 'from instance assigns' %}{{ foo }}", SyntaxCompatibility.DotLiquid22).Render());
+            Assert.AreEqual("", t.ParseInternal("{{ foo }}", SyntaxCompatibility.DotLiquid22).Render());
         }
 
         [Test]
@@ -72,16 +81,16 @@ namespace DotLiquid.Tests
         public void TestCustomAssignsDoNotPersistOnSameTemplate()
         {
             Template t = new Template();
-            Assert.AreEqual("from custom assigns", t.ParseInternal("{{ foo }}").Render(Hash.FromAnonymousObject(new { foo = "from custom assigns" })));
-            Assert.AreEqual("", t.ParseInternal("{{ foo }}").Render());
+            Assert.AreEqual("from custom assigns", t.ParseInternal("{{ foo }}", SyntaxCompatibility.DotLiquid22).Render(Hash.FromAnonymousObject(new { foo = "from custom assigns" })));
+            Assert.AreEqual("", t.ParseInternal("{{ foo }}", SyntaxCompatibility.DotLiquid22).Render());
         }
 
         [Test]
         public void TestCustomAssignsSquashInstanceAssigns()
         {
             Template t = new Template();
-            Assert.AreEqual("from instance assigns", t.ParseInternal("{% assign foo = 'from instance assigns' %}{{ foo }}").Render());
-            Assert.AreEqual("from custom assigns", t.ParseInternal("{{ foo }}").Render(Hash.FromAnonymousObject(new { foo = "from custom assigns" })));
+            Assert.AreEqual("from instance assigns", t.ParseInternal("{% assign foo = 'from instance assigns' %}{{ foo }}", SyntaxCompatibility.DotLiquid22).Render());
+            Assert.AreEqual("from custom assigns", t.ParseInternal("{{ foo }}", SyntaxCompatibility.DotLiquid22).Render(Hash.FromAnonymousObject(new { foo = "from custom assigns" })));
         }
 
         [Test]
@@ -89,9 +98,9 @@ namespace DotLiquid.Tests
         {
             Template t = new Template();
             Assert.AreEqual("from instance assigns",
-                t.ParseInternal("{% assign foo = 'from instance assigns' %}{{ foo }}").Render());
+                t.ParseInternal("{% assign foo = 'from instance assigns' %}{{ foo }}", SyntaxCompatibility.DotLiquid22).Render());
             t.Assigns["foo"] = "from persistent assigns";
-            Assert.AreEqual("from persistent assigns", t.ParseInternal("{{ foo }}").Render());
+            Assert.AreEqual("from persistent assigns", t.ParseInternal("{{ foo }}", SyntaxCompatibility.DotLiquid22).Render());
         }
 
         [Test]
@@ -100,8 +109,8 @@ namespace DotLiquid.Tests
             Template t = new Template();
             int global = 0;
             t.Assigns["number"] = (Proc) (c => ++global);
-            Assert.AreEqual("1", t.ParseInternal("{{number}}").Render());
-            Assert.AreEqual("1", t.ParseInternal("{{number}}").Render());
+            Assert.AreEqual("1", t.ParseInternal("{{number}}", SyntaxCompatibility.DotLiquid22).Render());
+            Assert.AreEqual("1", t.ParseInternal("{{number}}", SyntaxCompatibility.DotLiquid22).Render());
             Assert.AreEqual("1", t.Render());
         }
 
@@ -111,40 +120,43 @@ namespace DotLiquid.Tests
             Template t = new Template();
             int global = 0;
             Hash assigns = Hash.FromAnonymousObject(new { number = (Proc) (c => ++global) });
-            Assert.AreEqual("1", t.ParseInternal("{{number}}").Render(assigns));
-            Assert.AreEqual("1", t.ParseInternal("{{number}}").Render(assigns));
+            Assert.AreEqual("1", t.ParseInternal("{{number}}", SyntaxCompatibility.DotLiquid22).Render(assigns));
+            Assert.AreEqual("1", t.ParseInternal("{{number}}", SyntaxCompatibility.DotLiquid22).Render(assigns));
             Assert.AreEqual("1", t.Render(assigns));
         }
 
         [Test]
         public void TestErbLikeTrimmingLeadingWhitespace()
         {
-            Template t = Template.Parse("foo\n\t  {%- if true %}hi tobi{% endif %}");
-            Assert.AreEqual("foo\nhi tobi", t.Render());
+            string template = "foo\n\t  {%- if true %}hi tobi{% endif %}";
+            Assert.AreEqual("foo\nhi tobi", Template.Parse(template, SyntaxCompatibility.DotLiquid20).Render());
+            Assert.AreEqual("foohi tobi", Template.Parse(template, SyntaxCompatibility.DotLiquid22).Render());
         }
 
         [Test]
         public void TestErbLikeTrimmingTrailingWhitespace()
         {
-            Template t = Template.Parse("{% if true -%}\nhi tobi\n{% endif %}");
-            Assert.AreEqual("hi tobi\n", t.Render());
+            string template = "{% if true -%}\n hi tobi\n{% endif %}";
+            Assert.AreEqual(" hi tobi\n", Template.Parse(template, SyntaxCompatibility.DotLiquid20).Render());
+            Assert.AreEqual("hi tobi\n", Template.Parse(template, SyntaxCompatibility.DotLiquid22).Render());
         }
 
         [Test]
         public void TestErbLikeTrimmingLeadingAndTrailingWhitespace()
         {
-            Template t = Template.Parse(@"<ul>
+            string template = @"<ul>
 {% for item in tasks -%}
     {%- if true -%}
     <li>{{ item }}</li>
     {%- endif -%}
 {% endfor -%}
-</ul>");
-            Assert.AreEqual(@"<ul>
-    <li>foo</li>
-    <li>bar</li>
-    <li>baz</li>
-</ul>", t.Render(Hash.FromAnonymousObject(new { tasks = new [] { "foo", "bar", "baz" } })));
+</ul>";
+            Assert.AreEqual(
+                "<ul>\r\n    <li>foo</li>\r\n    <li>bar</li>\r\n    <li>baz</li>\r\n</ul>",
+                Template.Parse(template, SyntaxCompatibility.DotLiquid20).Render(Hash.FromAnonymousObject(new { tasks = new [] { "foo", "bar", "baz" } })));
+            Assert.AreEqual(
+                "<ul>\r\n<li>foo</li><li>bar</li><li>baz</li></ul>",
+                Template.Parse(template, SyntaxCompatibility.DotLiquid22).Render(Hash.FromAnonymousObject(new { tasks = new[] { "foo", "bar", "baz" } })));
         }
 
         [Test]

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -230,6 +230,9 @@ namespace DotLiquid
                 return Strainer.Invoke(method, args);
             }
 
+            if (SyntaxCompatibilityLevel >= SyntaxCompatibility.DotLiquid22)
+                throw new FilterNotFoundException(method); // this will be caught and rethrown in caller with correct message
+
             return args.First();
         }
 

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -438,16 +438,16 @@ namespace DotLiquid
         private bool TryFindVariable(string key, out object variable)
         {
             bool foundVariable = false;
+            object foundValue = null;
             Hash scope = Scopes.FirstOrDefault(s => s.ContainsKey(key));
-            object ret = null;
             if (scope == null)
             {
-                foreach (Hash e in Environments)
+                foreach (Hash environment in Environments)
                 {
-                    foundVariable = TryEvaluateHashOrArrayLikeObject(e, key, out ret);
+                    foundVariable = TryEvaluateHashOrArrayLikeObject(environment, key, out foundValue);
                     if (foundVariable)
                     {
-                        scope = e;
+                        scope = environment;
                         break;
                     }
                 }
@@ -455,15 +455,16 @@ namespace DotLiquid
                 if (scope == null)
                 {
                     scope = Environments.LastOrDefault() ?? Scopes.Last();
-                    foundVariable = TryEvaluateHashOrArrayLikeObject(scope, key, out ret);
+                    foundVariable = TryEvaluateHashOrArrayLikeObject(scope, key, out foundValue);
                 }
             }
             else
             {
-                foundVariable = TryEvaluateHashOrArrayLikeObject(scope, key, out ret);
+                foundVariable = TryEvaluateHashOrArrayLikeObject(scope, key, out foundValue);
             }
 
-            variable = Liquidize(ret);
+
+            variable = Liquidize(foundValue);
             if (variable is IContextAware contextAwareVariable)
             {
                 contextAwareVariable.Context = this;

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -18,7 +18,7 @@ namespace DotLiquid
     /// </summary>
     public class Context
     {
-        private static readonly HashSet<char> SpecialCharsSet =  new HashSet<char>() { '\'', '"', '(' , '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '-' };
+        private static readonly HashSet<char> SpecialCharsSet = new HashSet<char>() { '\'', '"', '(', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '-' };
         private static readonly Regex SingleQuotedRegex = R.C(R.Q(@"^'(.*)'$"));
         private static readonly Regex DoubleQuotedRegex = R.C(R.Q(@"^""(.*)""$"));
         private static readonly Regex IntegerRegex = R.C(R.Q(@"^([+-]?\d+)$"));
@@ -466,7 +466,6 @@ namespace DotLiquid
                 foundVariable = TryEvaluateHashOrArrayLikeObject(scope, key, out foundValue);
             }
 
-
             variable = Liquidize(foundValue);
             if (variable is IContextAware contextAwareVariable)
             {
@@ -619,7 +618,7 @@ namespace DotLiquid
 
             else
                 return false;
-        
+
             if (value is Proc procValue)
             {
                 object newValue = procValue.Invoke(this);
@@ -644,7 +643,7 @@ namespace DotLiquid
 
             return true;
         }
-        
+
         private static object Liquidize(object obj)
         {
             if (obj == null)

--- a/src/DotLiquid/ExtendedFilters.cs
+++ b/src/DotLiquid/ExtendedFilters.cs
@@ -1,0 +1,43 @@
+using System.Text.RegularExpressions;
+using System.Globalization;
+
+namespace DotLiquid
+{
+    /// <summary>
+    /// Extended DotLiquid Filters. Not registered by default.
+    /// </summary>
+    public static class ExtendedFilters
+    {
+        /// <summary>
+        /// Capitalize all the words in the input sentence
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static string Titleize(Context context, string input)
+        {
+            return input.IsNullOrWhiteSpace()
+                ? input
+#if CORE
+                : Regex.Replace(input, @"\b(\w)", m => m.Value.ToUpper(), RegexOptions.None, Template.RegexTimeOut);
+#else
+                : CultureInfo.CurrentCulture.TextInfo.ToTitleCase(input);
+#endif
+        }
+
+        /// <summary>
+        /// Converts just the first character to uppercase
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static string UpcaseFirst(Context context, string input)
+        {
+            if (input.IsNullOrWhiteSpace())
+                return input;
+
+            var trimmed = input.TrimStart();
+            return input.Substring(0, input.Length - trimmed.Length) + char.ToUpper(trimmed[0]) + trimmed.Substring(1);
+        }
+    }
+}

--- a/src/DotLiquid/Hash.cs
+++ b/src/DotLiquid/Hash.cs
@@ -159,7 +159,6 @@ namespace DotLiquid
                 _nestedDictionary[key] = otherValues[key];
         }
 
-
         /// <summary>
         /// Gets the value associated with the specified key.
         /// </summary>
@@ -182,7 +181,7 @@ namespace DotLiquid
         /// <summary>
         /// Provides strongly-typed access to each of the keys in the Hash
         /// </summary>
-        /// <typeparam name="T"> A generic parameter that specifies the return type of the column.</typeparam>
+        /// <typeparam name="T">A generic parameter that specifies the return type of the column.</typeparam>
         /// <param name="key">The key of the value to get.</param>
         /// <returns>The value, of type T, associated with the specified key.</returns>
         public T Get<T>(string key)
@@ -233,7 +232,7 @@ namespace DotLiquid
         /// <returns>true if the <see cref="DotLiquid.Hash">Hash</see> contains an element with the specified key or a default value; otherwise, false.</returns>
         public virtual bool Contains(object key)
         {
-            return _lambda != null || _defaultValue != null || ((IDictionary) _nestedDictionary).Contains(key);
+            return _lambda != null || _defaultValue != null || ((IDictionary)_nestedDictionary).Contains(key);
         }
 
         /// <inheritdoc/>

--- a/src/DotLiquid/Hash.cs
+++ b/src/DotLiquid/Hash.cs
@@ -286,9 +286,14 @@ namespace DotLiquid
             get { return ((IDictionary)_nestedDictionary).IsFixedSize; }
         }
 
+        /// <summary>
+        /// Determines whether the <see cref="DotLiquid.Hash">Hash</see> contains the specified key.
+        /// </summary>
+        /// <param name="key">The key to locate in the <see cref="DotLiquid.Hash">Hash</see></param>
+        /// <returns>true if the <see cref="DotLiquid.Hash">Hash</see> contains an element with the specified key or a default value; otherwise, false.</returns>
         public bool ContainsKey(string key)
         {
-            return _nestedDictionary.ContainsKey(key);
+            return _lambda != null || _defaultValue != null || _nestedDictionary.ContainsKey(key);
         }
 
         public void Add(string key, object value)

--- a/src/DotLiquid/Hash.cs
+++ b/src/DotLiquid/Hash.cs
@@ -7,6 +7,9 @@ using System.Reflection;
 
 namespace DotLiquid
 {
+    /// <summary>
+    /// Represents a collection of keys and values and is a DotLiquid safe type
+    /// </summary>
     public class Hash : IDictionary<string, object>, IDictionary
     {
         #region Static fields
@@ -25,11 +28,10 @@ namespace DotLiquid
         #region Static construction methods
 
         /// <summary>
-        /// 
+        /// Initializes a new instance of the <see cref="DotLiquid.Hash">Hash</see> class and populates it with the contents of an anonymous object
         /// </summary>
-        /// <param name="anonymousObject"></param>
+        /// <param name="anonymousObject">The anonymous object</param>
         /// <param name="includeBaseClassProperties">If this is set to true, method will map base class' properties too. </param>
-        /// <returns></returns>
         public static Hash FromAnonymousObject(object anonymousObject, bool includeBaseClassProperties = false)
         {
             Hash result = new Hash();
@@ -50,29 +52,7 @@ namespace DotLiquid
         {
             var cacheKey = type.FullName + "_" + (includeBaseClassProperties ? "WithBaseProperties" : "WithoutBaseProperties");
 
-            if (!mapperCache.TryGetValue(cacheKey, out Action<object, Hash> mapper))
-            {
-                /* Bogdan Mart: Note regarding concurrency:
-                 * This is concurrent dictionary, but if this will be called from two threads
-                 * this code would generate two same mappers, which will cause some CPU overhead.
-                 * But I have no idea on what I can lock here, first thought was to use lock(type),
-                 * but that could cause deadlock, if some outside code will lock Type.
-                 * Only correct solution would be to use ConcurrentDictionary<Type, Action<object, Hash>>
-                 * with some CAS race, and then locking, or Semaphore, but first will add complexity, 
-                 * second would add overhead in locking on Kernel-level named object.
-                 * 
-                 * So I assume tradeoff in not using locks here is better, 
-                 * we at most will waste some CPU cycles on code generation, 
-                 * but RAM would be collected, due to http://stackoverflow.com/questions/5340201/
-                 * 
-                 * If someone have conserns, than one can lock(mapperCache) but that would 
-                 * create bottleneck, as only one mapper could be generated at a time.
-                 */
-                mapper = GenerateMapper(type, includeBaseClassProperties);
-                mapperCache[cacheKey] = mapper;
-            }
-
-            return mapper;
+            return mapperCache.GetOrAdd(cacheKey, (key) => GenerateMapper(type, includeBaseClassProperties));
         }
 
         private static void AddBaseClassProperties(Type type, List<PropertyInfo> propertyList)
@@ -124,6 +104,10 @@ namespace DotLiquid
             return expr.Compile();
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DotLiquid.Hash">Hash</see> class and populates it with the contents of a dictionary
+        /// </summary>
+        /// <param name="dictionary">The Dictionary object</param>
         public static Hash FromDictionary(IDictionary<string, object> dictionary)
         {
             var hash = new Hash();
@@ -135,18 +119,29 @@ namespace DotLiquid
 
         #region Constructors
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DotLiquid.Hash">Hash</see> class that is empty and sets the default value
+        /// </summary>
+        /// <param name="defaultValue">The default value to return if the key lookup fails</param>
         public Hash(object defaultValue)
             : this()
         {
             _defaultValue = defaultValue;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DotLiquid.Hash">Hash</see> class that is empty and sets a method to return a default value
+        /// </summary>
+        /// <param name="lambda">The method to execute if the key lookup fails</param>
         public Hash(Func<Hash, string, object> lambda)
             : this()
         {
             _lambda = lambda;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DotLiquid.Hash">Hash</see> class that is empty
+        /// </summary>
         public Hash()
         {
             _nestedDictionary = new Dictionary<string, object>(Template.NamingConvention.StringComparer);
@@ -154,12 +149,22 @@ namespace DotLiquid
 
         #endregion
 
+        /// <summary>
+        /// Merges a dictionary object into the current <see cref="DotLiquid.Hash">Hash</see>.
+        /// </summary>
+        /// <param name="otherValues">The dictionary object to be merged into the Hash.</param>
         public void Merge(IDictionary<string, object> otherValues)
         {
             foreach (string key in otherValues.Keys)
                 _nestedDictionary[key] = otherValues[key];
         }
 
+
+        /// <summary>
+        /// Gets the value associated with the specified key.
+        /// </summary>
+        /// <param name="key">The key of the value to get.</param>
+        /// <returns>The value associated with the specified key. If key does not exist, returns the default value, default lambda expression return value, or null.</returns>
         protected virtual object GetValue(string key)
         {
             if (_nestedDictionary.ContainsKey(key))
@@ -174,6 +179,12 @@ namespace DotLiquid
             return null;
         }
 
+        /// <summary>
+        /// Provides strongly-typed access to each of the keys in the Hash
+        /// </summary>
+        /// <typeparam name="T"> A generic parameter that specifies the return type of the column.</typeparam>
+        /// <param name="key">The key of the value to get.</param>
+        /// <returns>The value, of type T, associated with the specified key.</returns>
         public T Get<T>(string key)
         {
             return (T)this[key];
@@ -181,11 +192,13 @@ namespace DotLiquid
 
         #region IDictionary<string, object>
 
+        /// <inheritdoc />
         public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
         {
             return _nestedDictionary.GetEnumerator();
         }
 
+        /// <inheritdoc/>
         public void Remove(object key)
         {
             ((IDictionary)_nestedDictionary).Remove(key);
@@ -207,21 +220,29 @@ namespace DotLiquid
             return _nestedDictionary.GetEnumerator();
         }
 
+        /// <inheritdoc/>
         public void Add(KeyValuePair<string, object> item)
         {
             ((IDictionary<string, object>)_nestedDictionary).Add(item);
         }
 
+        /// <summary>
+        /// Determines whether the <see cref="DotLiquid.Hash">Hash</see> contains the specified key.
+        /// </summary>
+        /// <param name="key">The key to locate in the <see cref="DotLiquid.Hash">Hash</see></param>
+        /// <returns>true if the <see cref="DotLiquid.Hash">Hash</see> contains an element with the specified key or a default value; otherwise, false.</returns>
         public virtual bool Contains(object key)
         {
-            return ((IDictionary)_nestedDictionary).Contains(key);
+            return _lambda != null || _defaultValue != null || ((IDictionary) _nestedDictionary).Contains(key);
         }
 
+        /// <inheritdoc/>
         public void Add(object key, object value)
         {
             ((IDictionary)_nestedDictionary).Add(key, value);
         }
 
+        /// <inheritdoc/>
         public void Clear()
         {
             _nestedDictionary.Clear();
@@ -232,16 +253,19 @@ namespace DotLiquid
             return ((IDictionary)_nestedDictionary).GetEnumerator();
         }
 
+        /// <inheritdoc/>
         public bool Contains(KeyValuePair<string, object> item)
         {
             return ((IDictionary<string, object>)_nestedDictionary).Contains(item);
         }
 
+        /// <inheritdoc/>
         public void CopyTo(KeyValuePair<string, object>[] array, int arrayIndex)
         {
             ((IDictionary<string, object>)_nestedDictionary).CopyTo(array, arrayIndex);
         }
 
+        /// <inheritdoc/>
         public bool Remove(KeyValuePair<string, object> item)
         {
             return ((IDictionary<string, object>)_nestedDictionary).Remove(item);
@@ -251,21 +275,25 @@ namespace DotLiquid
 
         #region IDictionary
 
+        /// <inheritdoc/>
         public void CopyTo(Array array, int index)
         {
             ((IDictionary)_nestedDictionary).CopyTo(array, index);
         }
 
+        /// <inheritdoc/>
         public int Count
         {
             get { return _nestedDictionary.Count; }
         }
 
+        /// <inheritdoc/>
         public object SyncRoot
         {
             get { return ((IDictionary)_nestedDictionary).SyncRoot; }
         }
 
+        /// <inheritdoc/>
         public bool IsSynchronized
         {
             get { return ((IDictionary)_nestedDictionary).IsSynchronized; }
@@ -276,11 +304,13 @@ namespace DotLiquid
             get { return ((IDictionary)_nestedDictionary).Values; }
         }
 
+        /// <inheritdoc />
         public bool IsReadOnly
         {
             get { return ((IDictionary<string, object>)_nestedDictionary).IsReadOnly; }
         }
 
+        /// <inheritdoc />
         public bool IsFixedSize
         {
             get { return ((IDictionary)_nestedDictionary).IsFixedSize; }
@@ -296,27 +326,32 @@ namespace DotLiquid
             return _lambda != null || _defaultValue != null || _nestedDictionary.ContainsKey(key);
         }
 
+        /// <inheritdoc/>
         public void Add(string key, object value)
         {
             _nestedDictionary.Add(key, value);
         }
 
+        /// <inheritdoc/>
         public bool Remove(string key)
         {
             return _nestedDictionary.Remove(key);
         }
 
+        /// <inheritdoc/>
         public bool TryGetValue(string key, out object value)
         {
             return _nestedDictionary.TryGetValue(key, out value);
         }
 
+        /// <inheritdoc/>
         public object this[string key]
         {
             get { return GetValue(key); }
             set { _nestedDictionary[key] = value; }
         }
 
+        /// <inheritdoc/>
         public ICollection<string> Keys
         {
             get { return _nestedDictionary.Keys; }
@@ -327,6 +362,7 @@ namespace DotLiquid
             get { return ((IDictionary)_nestedDictionary).Keys; }
         }
 
+        /// <inheritdoc/>
         public ICollection<object> Values
         {
             get { return _nestedDictionary.Values; }

--- a/src/DotLiquid/Liquid.cs
+++ b/src/DotLiquid/Liquid.cs
@@ -20,14 +20,11 @@ namespace DotLiquid
         public static readonly string VariableSegment = R.Q(@"[\w\-]");
         public static readonly string VariableStart = R.Q(@"\{\{");
         public static readonly string VariableEnd = R.Q(@"\}\}");
-        public static readonly string VariableIncompleteEnd = R.Q(@"\}\}?");
         public static readonly string QuotedString = R.Q(@"""[^""]*""|'[^']*'");
         public static readonly string QuotedFragment = string.Format(R.Q(@"{0}|(?:[^\s,\|'""]|{0})+"), QuotedString);
         public static readonly string QuotedAssignFragment = string.Format(R.Q(@"{0}|(?:[^\s\|'""]|{0})+"), QuotedString);
         public static readonly string TagAttributes = string.Format(R.Q(@"(\w+)\s*\:\s*({0})"), QuotedFragment);
         public static readonly string AnyStartingTag = R.Q(@"\{\{|\{\%");
-        public static readonly string PartialTemplateParser = string.Format(R.Q(@"{0}.*?{1}|{2}.*?{3}"), TagStart, TagEnd, VariableStart, VariableIncompleteEnd);
-        public static readonly string TemplateParser = string.Format(R.Q(@"({0}|{1})"), PartialTemplateParser, AnyStartingTag);
         public static readonly string VariableParser = string.Format(R.Q(@"\[[^\]]+\]|{0}+\??"), VariableSegment);
         public static readonly string LiteralShorthand = R.Q(@"^(?:\{\{\{\s?)(.*?)(?:\s*\}\}\})$");
         public static readonly string CommentShorthand = R.Q(@"^(?:\{\s?\#\s?)(.*?)(?:\s*\#\s?\})$");

--- a/src/DotLiquid/Properties/Resources.it.resx
+++ b/src/DotLiquid/Properties/Resources.it.resx
@@ -222,6 +222,9 @@
   <data name="VariableNotFoundException" xml:space="preserve">
     <value>Errore - La variabile '{0}' non è stata trovata</value>
   </data>
+  <data name="VariableNotTerminatedException" xml:space="preserve">
+    <value>La variable '{0}' non è stata terminata correttamente</value>
+  </data>
   <data name="WeakTableKeyNotFoundException" xml:space="preserve">
     <value>la chiave non è stata trovata</value>
   </data>

--- a/src/DotLiquid/Properties/Resources.resx
+++ b/src/DotLiquid/Properties/Resources.resx
@@ -222,6 +222,9 @@
   <data name="VariableNotFoundException" xml:space="preserve">
     <value>Error - Variable '{0}' could not be found</value>
   </data>
+  <data name="VariableNotTerminatedException" xml:space="preserve">
+    <value>Variable '{0}' was not properly terminated</value>
+  </data>
   <data name="WeakTableKeyNotFoundException" xml:space="preserve">
     <value>key could not be found</value>
   </data>

--- a/src/DotLiquid/StandardFilters.cs
+++ b/src/DotLiquid/StandardFilters.cs
@@ -117,22 +117,18 @@ namespace DotLiquid
         /// <returns></returns>
         public static string Capitalize(Context context, string input)
         {
+            if (context.SyntaxCompatibilityLevel < SyntaxCompatibility.DotLiquid22)
+            {
+                if (context.SyntaxCompatibilityLevel == SyntaxCompatibility.DotLiquid21)
+                    return ExtendedFilters.UpcaseFirst(context, input);
+                return ExtendedFilters.Titleize(context, input);
+            }
+
             if (input.IsNullOrWhiteSpace())
                 return input;
 
-            if (context.SyntaxCompatibilityLevel >= SyntaxCompatibility.DotLiquid21)
-            {
-                var trimmed = input.TrimStart();
-                return input.Substring(0, input.Length - trimmed.Length) + char.ToUpper(trimmed[0]) + trimmed.Substring(1);
-            }
-
-            return string.IsNullOrEmpty(input)
-                ? input
-#if CORE
-                : Regex.Replace(input, @"\b(\w)", m => m.Value.ToUpper(), RegexOptions.None, Template.RegexTimeOut);
-#else
-                : CultureInfo.CurrentCulture.TextInfo.ToTitleCase(input);
-#endif
+            var trimmed = input.TrimStart();
+            return input.Substring(0, input.Length - trimmed.Length) + char.ToUpper(trimmed[0]) + trimmed.Substring(1).ToLower();
         }
 
         /// <summary>

--- a/src/DotLiquid/SyntaxCompatibilityEnum.cs
+++ b/src/DotLiquid/SyntaxCompatibilityEnum.cs
@@ -14,5 +14,10 @@ namespace DotLiquid
         /// Behavior as of DotLiquid 2.1
         /// </summary>
         DotLiquid21 = 210,
+
+        /// <summary>
+        /// Behavior as of DotLiquid 2.2
+        /// </summary>
+        DotLiquid22 = 220,
     }
 }

--- a/src/DotLiquid/Tags/If.cs
+++ b/src/DotLiquid/Tags/If.cs
@@ -79,8 +79,8 @@ namespace DotLiquid.Tags
                 if (!syntaxMatch.Success)
                     throw new SyntaxException(SyntaxHelp);
 
-                Condition condition = new Condition(syntaxMatch.Groups[1].Value,
-                    syntaxMatch.Groups[2].Value, syntaxMatch.Groups[3].Value);
+                Condition condition = new Condition(syntaxMatch.Groups[1].Value.TrimStart('('),
+                    syntaxMatch.Groups[2].Value, syntaxMatch.Groups[3].Value.TrimEnd(')'));
 
                 var conditionCount = 1;
                 // continue to process remaining items in the list backwards, in pairs
@@ -97,8 +97,8 @@ namespace DotLiquid.Tags
                         throw new SyntaxException(TooMuchConditionsHelp);
                     }
 
-                    Condition newCondition = new Condition(expressionMatch.Groups[1].Value,
-                        expressionMatch.Groups[2].Value, expressionMatch.Groups[3].Value);
+                    Condition newCondition = new Condition(expressionMatch.Groups[1].Value.TrimStart('('),
+                        expressionMatch.Groups[2].Value, expressionMatch.Groups[3].Value.TrimEnd(')'));
                     switch (@operator)
                     {
                         case "and":

--- a/src/DotLiquid/Template.cs
+++ b/src/DotLiquid/Template.cs
@@ -319,9 +319,6 @@ namespace DotLiquid
         /// <returns>The template.</returns>
         internal Template ParseInternal(string source, SyntaxCompatibility syntaxCompatibilityLevel)
         {
-            source = DotLiquid.Tags.Literal.FromShortHand(source);
-            source = DotLiquid.Tags.Comment.FromShortHand(source);
-
             this.Root = new Document();
             this.Root.Initialize(tagName: null, markup: null, tokens: Tokenizer.Tokenize(source, syntaxCompatibilityLevel));
             return this;

--- a/src/DotLiquid/Template.cs
+++ b/src/DotLiquid/Template.cs
@@ -240,12 +240,23 @@ namespace DotLiquid
         /// <summary>
         /// Creates a new <tt>Template</tt> object from liquid source code
         /// </summary>
-        /// <param name="source"></param>
+        /// <param name="source">The Liquid Template string</param>
         /// <returns></returns>
         public static Template Parse(string source)
         {
+            return Parse(source, Template.DefaultSyntaxCompatibilityLevel);
+        }
+
+        /// <summary>
+        /// Creates a new <tt>Template</tt> object from liquid source code
+        /// </summary>
+        /// <param name="source">The Liquid Template string</param>
+        /// <param name="syntaxCompatibilityLevel">The Liquid syntax flag used for backward compatibility</param>
+        /// <returns></returns>
+        public static Template Parse(string source, SyntaxCompatibility syntaxCompatibilityLevel)
+        {
             Template template = new Template();
-            template.ParseInternal(source);
+            template.ParseInternal(source, syntaxCompatibilityLevel);
             return template;
         }
 
@@ -304,14 +315,15 @@ namespace DotLiquid
         /// Returns self for easy chaining
         /// </summary>
         /// <param name="source">The source code.</param>
+        /// <param name="syntaxCompatibilityLevel">The Liquid syntax flag used for backward compatibility</param>
         /// <returns>The template.</returns>
-        internal Template ParseInternal(string source)
+        internal Template ParseInternal(string source, SyntaxCompatibility syntaxCompatibilityLevel)
         {
             source = DotLiquid.Tags.Literal.FromShortHand(source);
             source = DotLiquid.Tags.Comment.FromShortHand(source);
 
             this.Root = new Document();
-            this.Root.Initialize(tagName: null, markup: null, tokens: Template.Tokenize(source));
+            this.Root.Initialize(tagName: null, markup: null, tokens: Tokenizer.Tokenize(source, syntaxCompatibilityLevel));
             return this;
         }
 
@@ -444,16 +456,6 @@ namespace DotLiquid
                 if (!IsThreadSafe)
                     _errors = context.Errors;
             }
-        }
-
-        /// <summary>
-        /// Uses the <tt>Liquid::TemplateParser</tt> regexp to tokenize the passed source
-        /// </summary>
-        /// <param name="source"></param>
-        /// <returns></returns>
-        internal static List<string> Tokenize(string source)
-        {
-            return Tokenizer.Tokenize(source);
         }
     }
 }

--- a/src/DotLiquid/Tokenizer.cs
+++ b/src/DotLiquid/Tokenizer.cs
@@ -39,7 +39,11 @@ namespace DotLiquid
 
             // Trim trailing whitespace - new lines or spaces/tabs but not both
             if (syntaxCompatibilityLevel < SyntaxCompatibility.DotLiquid22)
+            {
+                source = DotLiquid.Tags.Literal.FromShortHand(source);
+                source = DotLiquid.Tags.Comment.FromShortHand(source);
                 source = Regex.Replace(source, string.Format(@"-({0}|{1})(\n|\r\n|[ \t]+)?", Liquid.VariableEnd, Liquid.TagEnd), "$1", RegexOptions.None, Template.RegexTimeOut);
+            }
 
             var tokens = new List<string>();
 

--- a/src/DotLiquid/Tokenizer.cs
+++ b/src/DotLiquid/Tokenizer.cs
@@ -152,7 +152,7 @@ namespace DotLiquid
                             break;
                     }
 
-                    if (!isComplete) //Somehow we reached the end without finding the end character(s)
+                    if (!isComplete) // Somehow we reached the end without finding the end character(s)
                         throw new SyntaxException(Liquid.ResourceManager.GetString("VariableNotTerminatedException"), source, Liquid.VariableEnd);
 
                     if (markupEnumerator.HasNext() && markupEnumerator.Next == '.' && markupEnumerator.Remaining > 1)  // Don't include dot in tokens as it is a separator
@@ -224,7 +224,7 @@ namespace DotLiquid
                 }
             };
 
-            //Somehow we reached the end without finding the end character(s)
+            // Somehow we reached the end without finding the end character(s)
             return false;
         }
 
@@ -234,7 +234,7 @@ namespace DotLiquid
         /// <param name="sb">The StringBuilder to write to</param>
         /// <param name="markupEnumerator">The string enumerator</param>
         /// <param name="endChar">The character that indicates end of token</param>
-        /// <returns>True if reaches endChar, otherwise false</returns>
+        /// <returns><see langword="true"/> if reaches <paramref name="endChar"/>, otherwise <see langword="false"/></returns>
         private static bool ReadToChar(StringBuilder sb, CharEnumerator markupEnumerator, char endChar)
         {
             while (markupEnumerator.AppendNext(sb))
@@ -288,6 +288,5 @@ namespace DotLiquid
             markupEnumerator.AppendNext(sb);
             return true;
         }
-
     }
 }


### PR DESCRIPTION
This improves upon render time with a slew of under the hood changes. Notable changes:
For all versions:
- Removed regex parsing of variables that are clearly going to fail. For example, the variable doesn't need to be tested for literal if it doesn't start with a quote
- IsHashOrArrayLikeObject and LookupAndEvaluate had much of the same code - now it's combined into TryEvaluateHashOrArrayLikeObject - originally discussed with and developed by @robin-parker in #437 
- Resolves #445 originally found by @wouterjanson in #436
- Adds a way to get back other behaviors of Capitalize
- Implements SortNatural (originally reported in #330) - this is recommended EVEN IF not switching to DotLiquid 2.2 to future-proof your templates and maintain cross-compatibility

With an opt-in flag for DotLiquid 2.2 Syntax
- Variable segment parsing is no longer using Regex - this is for the parts between curly braces {{ }} as well as as if, case, and when tags. 
- Resolves #411 reported by @jolleekin
- Removes non-standard short-hand comments
- Updated Capitalize filters to be inline with Reference Library. Resolves #390 
- Resolves #413 
- Resolves #393 making the Sort filter case-sensitive. Coupled with the new SortNatural, provides a path forward compliant with the Liquid spec

It remains unknown how much this impacts the benchmarks on https://github.com/RicoSuter/NJsonSchema/pull/1346 ... would love to hear from that team