### PR TITLE
Allow filters with same name and different number of parameters from different classes

### DIFF
--- a/src/DotLiquid.Tests/ConditionTests.cs
+++ b/src/DotLiquid.Tests/ConditionTests.cs
@@ -657,7 +657,7 @@ namespace DotLiquid.Tests
         public void TestCSharp_LowerCaseAccepted()
         {
             Helper.AssertTemplateResult("", "{% if 'bob' startswith 'B' %} YES {% endif %}", null, new CSharpNamingConvention());
-            Helper.AssertTemplateResult(" YES ", "{% if 'Bob' startswith 'B' %} YES {% endif %}", null, new CSharpNamingConvention());
+            Helper. AssertTemplateResult(" YES ", "{% if 'Bob' startswith 'B' %} YES {% endif %}", null, new CSharpNamingConvention());
         }
 
         [Test]

--- a/src/DotLiquid.Tests/ConditionTests.cs
+++ b/src/DotLiquid.Tests/ConditionTests.cs
@@ -657,7 +657,7 @@ namespace DotLiquid.Tests
         public void TestCSharp_LowerCaseAccepted()
         {
             Helper.AssertTemplateResult("", "{% if 'bob' startswith 'B' %} YES {% endif %}", null, new CSharpNamingConvention());
-            Helper. AssertTemplateResult(" YES ", "{% if 'Bob' startswith 'B' %} YES {% endif %}", null, new CSharpNamingConvention());
+            Helper.AssertTemplateResult(" YES ", "{% if 'Bob' startswith 'B' %} YES {% endif %}", null, new CSharpNamingConvention());
         }
 
         [Test]

--- a/src/DotLiquid.Tests/FilterTests.cs
+++ b/src/DotLiquid.Tests/FilterTests.cs
@@ -336,7 +336,7 @@ namespace DotLiquid.Tests
         [Test]
         // When two methods with the same name and method signature are registered, the method that is added last is preferred.
         // This allows overriding any existing methods, including methods defined in the DotLiqid library.
-        // This is useful in contexts where a defined method may need to have a different behavior.
+        // This is useful in cases where a defined method may need to have a different behavior in certain context.
         public void TestFilterOverridesMethodWithSameMethodSignaturesDifferentClasses()
         {
             Template.RegisterFilter(typeof(FilterWithSameMethodSignatureDifferentClassTwo));

--- a/src/DotLiquid.Tests/FilterTests.cs
+++ b/src/DotLiquid.Tests/FilterTests.cs
@@ -363,7 +363,7 @@ namespace DotLiquid.Tests
                            expected: "ABClass One",
                            template: "{{'A' | concatenate : 'B'}}",
                            localVariables: null,
-                           localFilters: new[] {  typeof(FilterWithSameMethodSignatureDifferentClassTwo), typeof(FilterWithSameMethodSignatureDifferentClassOne) });
+                           localFilters: new[] { typeof(FilterWithSameMethodSignatureDifferentClassTwo), typeof(FilterWithSameMethodSignatureDifferentClassOne) });
         }
 
         /*/// <summary>

--- a/src/DotLiquid.Tests/FilterTests.cs
+++ b/src/DotLiquid.Tests/FilterTests.cs
@@ -336,7 +336,7 @@ namespace DotLiquid.Tests
         [Test]
         // When two methods with the same name and method signature are registered, the method that is added last is preferred.
         // This allows overriding any existing methods, including methods defined in the DotLiqid library.
-        // This is useful in cases where a defined method may need to have a different behavior in certain context.
+        // This is useful in cases where a defined method may need to have a different behavior in certain contexts.
         public void TestFilterOverridesMethodWithSameMethodSignaturesDifferentClasses()
         {
             Template.RegisterFilter(typeof(FilterWithSameMethodSignatureDifferentClassTwo));

--- a/src/DotLiquid.Tests/FilterTests.cs
+++ b/src/DotLiquid.Tests/FilterTests.cs
@@ -297,7 +297,19 @@ namespace DotLiquid.Tests
         }
 
         [Test]
-        public void TestFilterWithMultipleMethodSignaturesAndContextParamInDifferentClasse()
+        public void TestFilterAsLocalFilterWithMultipleMethodSignaturesDifferentClasses()
+        {
+
+            Helper.AssertTemplateResult(
+                expected: "AB // ABC",
+                template: "{{'A' | concatenate : 'B'}} // {{'A' | concatenate : 'B', 'C'}}",
+                localVariables: null,
+                localFilters: new[] { typeof(FiltersWithMultipleMethodSignaturesDifferentClassesOne), typeof(FiltersWithMultipleMethodSignaturesDifferentClassesTwo) });
+        }
+
+
+        [Test]
+        public void TestFilterWithMultipleMethodSignaturesAndContextParamInDifferentClasses()
         {
             Template.RegisterFilter(typeof(FiltersWithMultipleMethodSignaturesDifferentClassesWithContextParamOne));
             Template.RegisterFilter(typeof(FiltersWithMultipleMethodSignaturesDifferentClassesWithContextParamTwo));
@@ -306,9 +318,20 @@ namespace DotLiquid.Tests
             Assert.AreEqual("ABC", Template.Parse("{{'A' | concat_with_context : 'B', 'C'}}").Render());
         }
 
+        [Test]
+        public void TestFilterAsLocalFilterWithMultipleMethodSignaturesAndContextDifferentClasses()
+        {
+
+            Helper.AssertTemplateResult(
+                expected: "AB // ABC",
+                template: "{{'A' | concat_with_context : 'B'}} // {{'A' | concat_with_context : 'B', 'C'}}",
+                localVariables: null,
+                localFilters: new[] { typeof(FiltersWithMultipleMethodSignaturesDifferentClassesWithContextParamOne), typeof(FiltersWithMultipleMethodSignaturesDifferentClassesWithContextParamTwo) });
+        }
+
 
         [Test]
-        public void TestFilterInContextWithMultipleMethodSignaturesAndContextParamInDifferentClasse()
+        public void TestFilterInContextWithMultipleMethodSignaturesAndContextParamInDifferentClasses()
         {
             _context.AddFilters(typeof(FiltersWithMultipleMethodSignaturesDifferentClassesWithContextParamOne));
             _context.AddFilters(typeof(FiltersWithMultipleMethodSignaturesDifferentClassesWithContextParamTwo));
@@ -336,6 +359,18 @@ namespace DotLiquid.Tests
             Assert.AreEqual("ABClass Two", new Variable("'A' | concatenate : 'B'").Render(_context));
             Assert.AreNotEqual("ABClass One", new Variable("'A' | concatenate : 'B'").Render(_context));
         }
+
+
+        [Test]
+        public void TestFilterAsLocalOverridesMethodWithSameMethodSignaturesDifferentClasses()
+        {
+            Helper.AssertTemplateResult(
+                           expected: "ABClass Two",
+                           template: "{{'A' | concatenate : 'B'}}",
+                           localVariables: null,
+                           localFilters: new[] { typeof(FilterWithSameMethodSignatureDifferentClassOne), typeof(FilterWithSameMethodSignatureDifferentClassTwo) });
+        }
+
 
         /*/// <summary>
         /// ATM the trailing value is silently ignored. Should raise an exception?

--- a/src/DotLiquid.Tests/FilterTests.cs
+++ b/src/DotLiquid.Tests/FilterTests.cs
@@ -334,6 +334,9 @@ namespace DotLiquid.Tests
         }
 
         [Test]
+        // When two methods with the same name and method signature are registered, the method that is added last is preferred.
+        // This allows overriding any existing methods, including methods defined in the DotLiqid library.
+        // This is useful in contexts where a defined method may need to have a different behavior.
         public void TestFilterOverridesMethodWithSameMethodSignaturesDifferentClasses()
         {
             Template.RegisterFilter(typeof(FilterWithSameMethodSignatureDifferentClassTwo));

--- a/src/DotLiquid.Tests/FilterTests.cs
+++ b/src/DotLiquid.Tests/FilterTests.cs
@@ -306,9 +306,8 @@ namespace DotLiquid.Tests
         [Test]
         public void TestFilterWithMultipleMethodSignaturesAndContextParamInDifferentClasses()
         {
-            Template.RegisterFilter(typeof(FiltersWithMultipleMethodSignaturesDifferentClassesWithContextParamOne));
             Template.RegisterFilter(typeof(FiltersWithMultipleMethodSignaturesDifferentClassesWithContextParamTwo));
-
+            Template.RegisterFilter(typeof(FiltersWithMultipleMethodSignaturesDifferentClassesWithContextParamOne));
             Assert.AreEqual("AB", Template.Parse("{{'A' | concat_with_context : 'B'}}").Render());
             Assert.AreEqual("ABC", Template.Parse("{{'A' | concat_with_context : 'B', 'C'}}").Render());
         }
@@ -337,11 +336,11 @@ namespace DotLiquid.Tests
         [Test]
         public void TestFilterOverridesMethodWithSameMethodSignaturesDifferentClasses()
         {
-            Template.RegisterFilter(typeof(FilterWithSameMethodSignatureDifferentClassOne));
             Template.RegisterFilter(typeof(FilterWithSameMethodSignatureDifferentClassTwo));
+            Template.RegisterFilter(typeof(FilterWithSameMethodSignatureDifferentClassOne));
 
-            Assert.AreEqual("ABClass Two", Template.Parse("{{'A' | concatenate : 'B'}}").Render());
-            Assert.AreNotEqual("ABClass One", Template.Parse("{{'A' | concatenate : 'B'}}").Render());
+            Assert.AreEqual("ABClass One", Template.Parse("{{'A' | concatenate : 'B'}}").Render());
+            Assert.AreNotEqual("ABClass Two", Template.Parse("{{'A' | concatenate : 'B'}}").Render());
         }
 
         [Test]
@@ -358,10 +357,10 @@ namespace DotLiquid.Tests
         public void TestFilterAsLocalOverridesMethodWithSameMethodSignaturesDifferentClasses()
         {
             Helper.AssertTemplateResult(
-                           expected: "ABClass Two",
+                           expected: "ABClass One",
                            template: "{{'A' | concatenate : 'B'}}",
                            localVariables: null,
-                           localFilters: new[] { typeof(FilterWithSameMethodSignatureDifferentClassOne), typeof(FilterWithSameMethodSignatureDifferentClassTwo) });
+                           localFilters: new[] {  typeof(FilterWithSameMethodSignatureDifferentClassTwo), typeof(FilterWithSameMethodSignatureDifferentClassOne) });
         }
 
         /*/// <summary>

--- a/src/DotLiquid.Tests/FilterTests.cs
+++ b/src/DotLiquid.Tests/FilterTests.cs
@@ -57,7 +57,7 @@ namespace DotLiquid.Tests
             }
         }
 
-        private static class FiltersWithMulitpleMethodSignatures
+        private static class FiltersWithMultipleMethodSignatures
         {
             public static string Concatenate(string one, string two)
             {
@@ -83,7 +83,7 @@ namespace DotLiquid.Tests
             }
         }
 
-        private static class FiltersWithMulitpleMethodSignaturesDifferentClassesOne
+        private static class FiltersWithMultipleMethodSignaturesDifferentClassesOne
         {
             public static string Concatenate(string one, string two)
             {
@@ -108,7 +108,7 @@ namespace DotLiquid.Tests
             }
         }
 
-        private static class FiltersWithMulitpleMethodSignaturesDifferentClassesTwo
+        private static class FiltersWithMultipleMethodSignaturesDifferentClassesTwo
         {
             public static string Concatenate(Context context, string one, string two, string three)
             {
@@ -116,7 +116,7 @@ namespace DotLiquid.Tests
             }
         }
 
-        private static class FiltersWithMulitpleMethodSignaturesDifferentClassesWithContextParamTwo
+        private static class FiltersWithMultipleMethodSignaturesDifferentClassesWithContextParamTwo
         {
             public static string ConcatWithContext(Context context, string one, string two, string three)
             {
@@ -124,7 +124,7 @@ namespace DotLiquid.Tests
             }
         }
 
-        private static class FiltersWithMulitpleMethodSignaturesDifferentClassesWithContextParamOne
+        private static class FiltersWithMultipleMethodSignaturesDifferentClassesWithContextParamOne
         {
             public static string ConcatWithContext(Context context, string one, string two)
             {
@@ -241,7 +241,7 @@ namespace DotLiquid.Tests
         [Test]
         public void TestFilterWithMultipleMethodSignatures()
         {
-            Template.RegisterFilter(typeof(FiltersWithMulitpleMethodSignatures));
+            Template.RegisterFilter(typeof(FiltersWithMultipleMethodSignatures));
 
             Assert.AreEqual("AB", Template.Parse("{{'A' | concatenate : 'B'}}").Render());
             Assert.AreEqual("ABC", Template.Parse("{{'A' | concatenate : 'B', 'C'}}").Render());
@@ -259,8 +259,8 @@ namespace DotLiquid.Tests
         [Test]
         public void TestFilterWithMultipleMethodSignaturesDifferentClasses()
         {
-            Template.RegisterFilter(typeof(FiltersWithMulitpleMethodSignaturesDifferentClassesOne));
-            Template.RegisterFilter(typeof(FiltersWithMulitpleMethodSignaturesDifferentClassesTwo));
+            Template.RegisterFilter(typeof(FiltersWithMultipleMethodSignaturesDifferentClassesOne));
+            Template.RegisterFilter(typeof(FiltersWithMultipleMethodSignaturesDifferentClassesTwo));
 
             Assert.AreEqual("AB", Template.Parse("{{'A' | concatenate : 'B'}}").Render());
             Assert.AreEqual("ABC", Template.Parse("{{'A' | concatenate : 'B', 'C'}}").Render());
@@ -269,8 +269,8 @@ namespace DotLiquid.Tests
         [Test]
         public void TestFilterWithMultipleMethodSignaturesAndContextParamInDifferentClasse()
         {
-            Template.RegisterFilter(typeof(FiltersWithMulitpleMethodSignaturesDifferentClassesWithContextParamOne));
-            Template.RegisterFilter(typeof(FiltersWithMulitpleMethodSignaturesDifferentClassesWithContextParamTwo));
+            Template.RegisterFilter(typeof(FiltersWithMultipleMethodSignaturesDifferentClassesWithContextParamOne));
+            Template.RegisterFilter(typeof(FiltersWithMultipleMethodSignaturesDifferentClassesWithContextParamTwo));
 
             Assert.AreEqual("AB", Template.Parse("{{'A' | concat_with_context : 'B'}}").Render());
             Assert.AreEqual("ABC", Template.Parse("{{'A' | concat_with_context : 'B', 'C'}}").Render());

--- a/src/DotLiquid.Tests/FilterTests.cs
+++ b/src/DotLiquid.Tests/FilterTests.cs
@@ -83,6 +83,56 @@ namespace DotLiquid.Tests
             }
         }
 
+        private static class FiltersWithMulitpleMethodSignaturesDifferentClassesOne
+        {
+            public static string Concatenate(string one, string two)
+            {
+                return string.Concat(one, two);
+            }
+        }
+
+
+        private static class FilterWithSameMethodSignatureDifferentClassOne
+        {
+            public static string Concatenate(string one, string two)
+            {
+                return string.Concat(one, two, "Class One");
+            }
+        }
+
+        private static class FilterWithSameMethodSignatureDifferentClassTwo
+        {
+            public static string Concatenate(string one, string two)
+            {
+                return string.Concat(one, two, "Class Two");
+            }
+        }
+
+        private static class FiltersWithMulitpleMethodSignaturesDifferentClassesTwo
+        {
+            public static string Concatenate(Context context, string one, string two, string three)
+            {
+                return string.Concat(one, two, three);
+            }
+        }
+
+        private static class FiltersWithMulitpleMethodSignaturesDifferentClassesWithContextParamTwo
+        {
+            public static string ConcatWithContext(Context context, string one, string two, string three)
+            {
+                return string.Concat(one, two, three);
+            }
+        }
+
+        private static class FiltersWithMulitpleMethodSignaturesDifferentClassesWithContextParamOne
+        {
+            public static string ConcatWithContext(Context context, string one, string two)
+            {
+                return string.Concat(one, two);
+            }
+
+        }
+
         private static class ContextFilters
         {
             public static string BankStatement(Context context, object input)
@@ -204,6 +254,36 @@ namespace DotLiquid.Tests
 
             Assert.AreEqual("AB", Template.Parse("{{'A' | concat_with_context : 'B'}}").Render());
             Assert.AreEqual("ABC", Template.Parse("{{'A' | concat_with_context : 'B', 'C'}}").Render());
+        }
+
+        [Test]
+        public void TestFilterWithMultipleMethodSignaturesDifferentClasses()
+        {
+            Template.RegisterFilter(typeof(FiltersWithMulitpleMethodSignaturesDifferentClassesOne));
+            Template.RegisterFilter(typeof(FiltersWithMulitpleMethodSignaturesDifferentClassesTwo));
+
+            Assert.AreEqual("AB", Template.Parse("{{'A' | concatenate : 'B'}}").Render());
+            Assert.AreEqual("ABC", Template.Parse("{{'A' | concatenate : 'B', 'C'}}").Render());
+        }
+
+        [Test]
+        public void TestFilterWithMultipleMethodSignaturesAndContextParamInDifferentClasse()
+        {
+            Template.RegisterFilter(typeof(FiltersWithMulitpleMethodSignaturesDifferentClassesWithContextParamOne));
+            Template.RegisterFilter(typeof(FiltersWithMulitpleMethodSignaturesDifferentClassesWithContextParamTwo));
+
+            Assert.AreEqual("AB", Template.Parse("{{'A' | concat_with_context : 'B'}}").Render());
+            Assert.AreEqual("ABC", Template.Parse("{{'A' | concat_with_context : 'B', 'C'}}").Render());
+        }
+
+        [Test]
+        public void TestFilterOverridesMethodWithSameMethodSignaturesDifferentClasses()
+        {
+            Template.RegisterFilter(typeof(FilterWithSameMethodSignatureDifferentClassOne));
+            Template.RegisterFilter(typeof(FilterWithSameMethodSignatureDifferentClassTwo));
+
+            Assert.AreEqual("ABClass Two", Template.Parse("{{'A' | concatenate : 'B'}}").Render());
+            Assert.AreNotEqual("ABClass One", Template.Parse("{{'A' | concatenate : 'B'}}").Render());
         }
 
         /*/// <summary>

--- a/src/DotLiquid.Tests/FilterTests.cs
+++ b/src/DotLiquid.Tests/FilterTests.cs
@@ -238,6 +238,7 @@ namespace DotLiquid.Tests
             Assert.AreEqual("[1150]", new Variable("var | add_sub: 200, 50").Render(_context));
         }
 
+
         [Test]
         public void TestFilterWithMultipleMethodSignatures()
         {
@@ -247,6 +248,16 @@ namespace DotLiquid.Tests
             Assert.AreEqual("ABC", Template.Parse("{{'A' | concatenate : 'B', 'C'}}").Render());
         }
 
+
+        [Test]
+        public void TestFilterInContextWithMultipleMethodSignatures()
+        {
+            _context.AddFilters(typeof(FiltersWithMultipleMethodSignatures));
+
+            Assert.AreEqual("AB", new Variable("'A' | concatenate : 'B'").Render(_context));
+            Assert.AreEqual("ABC", new Variable("'A' | concatenate : 'B', 'C'").Render(_context));
+        }
+
         [Test]
         public void TestFilterWithMultipleMethodSignaturesAndContextParam()
         {
@@ -254,6 +265,15 @@ namespace DotLiquid.Tests
 
             Assert.AreEqual("AB", Template.Parse("{{'A' | concat_with_context : 'B'}}").Render());
             Assert.AreEqual("ABC", Template.Parse("{{'A' | concat_with_context : 'B', 'C'}}").Render());
+        }
+
+        [Test]
+        public void TestFilterInContextWithMultipleMethodSignaturesAndContextParam()
+        {
+            _context.AddFilters(typeof(FiltersWithMultipleMethodSignaturesAndContextParam));
+
+            Assert.AreEqual("AB", new Variable("'A' | concat_with_context : 'B'").Render(_context));
+            Assert.AreEqual("ABC", new Variable("'A' | concat_with_context : 'B', 'C'").Render(_context));
         }
 
         [Test]
@@ -267,6 +287,16 @@ namespace DotLiquid.Tests
         }
 
         [Test]
+        public void TestFilterInContextWithMultipleMethodSignaturesDifferentClasses()
+        {
+            _context.AddFilters(typeof(FiltersWithMultipleMethodSignaturesDifferentClassesOne));
+            _context.AddFilters(typeof(FiltersWithMultipleMethodSignaturesDifferentClassesTwo));
+
+            Assert.AreEqual("AB", new Variable("'A' | concatenate : 'B'").Render(_context));
+            Assert.AreEqual("ABC", new Variable("'A' | concatenate : 'B', 'C'").Render(_context));
+        }
+
+        [Test]
         public void TestFilterWithMultipleMethodSignaturesAndContextParamInDifferentClasse()
         {
             Template.RegisterFilter(typeof(FiltersWithMultipleMethodSignaturesDifferentClassesWithContextParamOne));
@@ -274,6 +304,17 @@ namespace DotLiquid.Tests
 
             Assert.AreEqual("AB", Template.Parse("{{'A' | concat_with_context : 'B'}}").Render());
             Assert.AreEqual("ABC", Template.Parse("{{'A' | concat_with_context : 'B', 'C'}}").Render());
+        }
+
+
+        [Test]
+        public void TestFilterInContextWithMultipleMethodSignaturesAndContextParamInDifferentClasse()
+        {
+            _context.AddFilters(typeof(FiltersWithMultipleMethodSignaturesDifferentClassesWithContextParamOne));
+            _context.AddFilters(typeof(FiltersWithMultipleMethodSignaturesDifferentClassesWithContextParamTwo));
+
+            Assert.AreEqual("AB", new Variable("'A' | concat_with_context : 'B'").Render(_context));
+            Assert.AreEqual("ABC", new Variable("'A' | concat_with_context : 'B', 'C'").Render(_context));
         }
 
         [Test]
@@ -284,6 +325,16 @@ namespace DotLiquid.Tests
 
             Assert.AreEqual("ABClass Two", Template.Parse("{{'A' | concatenate : 'B'}}").Render());
             Assert.AreNotEqual("ABClass One", Template.Parse("{{'A' | concatenate : 'B'}}").Render());
+        }
+
+        [Test]
+        public void TestFilterInContextOverridesMethodWithSameMethodSignaturesDifferentClasses()
+        {
+            _context.AddFilters(typeof(FilterWithSameMethodSignatureDifferentClassOne));
+            _context.AddFilters(typeof(FilterWithSameMethodSignatureDifferentClassTwo));
+
+            Assert.AreEqual("ABClass Two", new Variable("'A' | concatenate : 'B'").Render(_context));
+            Assert.AreNotEqual("ABClass One", new Variable("'A' | concatenate : 'B'").Render(_context));
         }
 
         /*/// <summary>

--- a/src/DotLiquid.Tests/FilterTests.cs
+++ b/src/DotLiquid.Tests/FilterTests.cs
@@ -130,7 +130,6 @@ namespace DotLiquid.Tests
             {
                 return string.Concat(one, two);
             }
-
         }
 
         private static class ContextFilters
@@ -238,7 +237,6 @@ namespace DotLiquid.Tests
             Assert.AreEqual("[1150]", new Variable("var | add_sub: 200, 50").Render(_context));
         }
 
-
         [Test]
         public void TestFilterWithMultipleMethodSignatures()
         {
@@ -247,7 +245,6 @@ namespace DotLiquid.Tests
             Assert.AreEqual("AB", Template.Parse("{{'A' | concatenate : 'B'}}").Render());
             Assert.AreEqual("ABC", Template.Parse("{{'A' | concatenate : 'B', 'C'}}").Render());
         }
-
 
         [Test]
         public void TestFilterInContextWithMultipleMethodSignatures()
@@ -299,14 +296,12 @@ namespace DotLiquid.Tests
         [Test]
         public void TestFilterAsLocalFilterWithMultipleMethodSignaturesDifferentClasses()
         {
-
             Helper.AssertTemplateResult(
                 expected: "AB // ABC",
                 template: "{{'A' | concatenate : 'B'}} // {{'A' | concatenate : 'B', 'C'}}",
                 localVariables: null,
                 localFilters: new[] { typeof(FiltersWithMultipleMethodSignaturesDifferentClassesOne), typeof(FiltersWithMultipleMethodSignaturesDifferentClassesTwo) });
         }
-
 
         [Test]
         public void TestFilterWithMultipleMethodSignaturesAndContextParamInDifferentClasses()
@@ -328,7 +323,6 @@ namespace DotLiquid.Tests
                 localVariables: null,
                 localFilters: new[] { typeof(FiltersWithMultipleMethodSignaturesDifferentClassesWithContextParamOne), typeof(FiltersWithMultipleMethodSignaturesDifferentClassesWithContextParamTwo) });
         }
-
 
         [Test]
         public void TestFilterInContextWithMultipleMethodSignaturesAndContextParamInDifferentClasses()
@@ -360,7 +354,6 @@ namespace DotLiquid.Tests
             Assert.AreNotEqual("ABClass One", new Variable("'A' | concatenate : 'B'").Render(_context));
         }
 
-
         [Test]
         public void TestFilterAsLocalOverridesMethodWithSameMethodSignaturesDifferentClasses()
         {
@@ -370,7 +363,6 @@ namespace DotLiquid.Tests
                            localVariables: null,
                            localFilters: new[] { typeof(FilterWithSameMethodSignatureDifferentClassOne), typeof(FilterWithSameMethodSignatureDifferentClassTwo) });
         }
-
 
         /*/// <summary>
         /// ATM the trailing value is silently ignored. Should raise an exception?

--- a/src/DotLiquid/Strainer.cs
+++ b/src/DotLiquid/Strainer.cs
@@ -110,9 +110,6 @@ namespace DotLiquid
             } // foreach
         }
 
-
-
-
         public void AddFunction<TIn, TOut>(string rawName, Func<TIn, TOut> func)
         {
             AddMethodInfo(rawName, func.Target, func.GetMethodInfo());

--- a/src/DotLiquid/Strainer.cs
+++ b/src/DotLiquid/Strainer.cs
@@ -4,40 +4,10 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using DotLiquid.Exceptions;
+using DotLiquid.Util;
 
 namespace DotLiquid
 {
-    static class DictionaryExtensions
-    {
-        public static V TryAdd<K, V>(this IDictionary<K, V> dic, K key, Func<V> factory)
-        {
-            if (!dic.TryGetValue(key, out V found))
-                return dic[key] = factory();
-            return found;
-        }
-    }
-
-    static class MethodInfoExtensions
-    {
-        public static int GetNonContextParameterCount(this MethodInfo method)
-        {
-            return method.GetParameters().Count(p => p.ParameterType != typeof(Context));
-        }
-
-        public static bool MatchesMethod(this MethodInfo method, KeyValuePair<string, IList<Tuple<object, MethodInfo>>> compareMethod)
-        {
-            string methodName = Template.NamingConvention.GetMemberName(method.Name);
-            if (compareMethod.Key != methodName)
-            {
-                return false;
-            }
-
-            var methodParamCount = method.GetNonContextParameterCount();
-
-            return compareMethod.Value.Any(m => m.Item2.GetNonContextParameterCount() == methodParamCount);
-        }
-    }
-
     /// <summary>
     /// Strainer is the parent class for the filters system.
     /// New filters are mixed into the strainer class which is then instanciated for each liquid template render run.

--- a/src/DotLiquid/Strainer.cs
+++ b/src/DotLiquid/Strainer.cs
@@ -64,7 +64,7 @@ namespace DotLiquid
         /// <param name="type"></param>
         public void Extend(Type type)
         {
-            // Calls to Extend should replace existing filters with the same number of params.
+            // Calls to Extend replace existing filters with the same number of params.
             var methods = type.GetRuntimeMethods().Where(m => m.IsPublic && m.IsStatic);
             foreach (var method in methods)
             {

--- a/src/DotLiquid/Strainer.cs
+++ b/src/DotLiquid/Strainer.cs
@@ -15,7 +15,6 @@ namespace DotLiquid
                 return dic[key] = factory();
             return found;
         }
-
     }
 
     static class MethodInfoExtensions
@@ -32,7 +31,8 @@ namespace DotLiquid
             {
                 return false;
             }
-            int methodParamCount = method.GetNonContextParameterCount();
+
+            var methodParamCount = method.GetNonContextParameterCount();
 
             return compareMethod.Value.Any(m => m.Item2.GetNonContextParameterCount() == methodParamCount);
         }
@@ -86,7 +86,6 @@ namespace DotLiquid
         {
             _context = context;
         }
-
 
         /// <summary>
         /// In this C# implementation, we can't use mixins. So we grab all the static

--- a/src/DotLiquid/Strainer.cs
+++ b/src/DotLiquid/Strainer.cs
@@ -64,6 +64,7 @@ namespace DotLiquid
         /// <param name="type"></param>
         public void Extend(Type type)
         {
+            // Calls to Extend should replace existing filters with the same number of params.
             var methods = type.GetRuntimeMethods().Where(m => m.IsPublic && m.IsStatic);
             foreach (var method in methods)
             {

--- a/src/DotLiquid/Strainer.cs
+++ b/src/DotLiquid/Strainer.cs
@@ -94,7 +94,6 @@ namespace DotLiquid
         /// <param name="type"></param>
         public void Extend(Type type)
         {
-            // From what I can tell, calls to Extend should replace existing filters with the same number of params. So be it.
             var methods = type.GetRuntimeMethods().Where(m => m.IsPublic && m.IsStatic);
             foreach (var method in methods)
             {

--- a/src/DotLiquid/Util/DictionaryExtensionMethods.cs
+++ b/src/DotLiquid/Util/DictionaryExtensionMethods.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+
+namespace DotLiquid.Util
+{
+    /// <summary>
+    /// Extensions for Dictionary
+    /// </summary>
+    public static class DictionaryExtensionMethods
+    {
+        /// <summary>
+        /// Try to add value to dictionary by Func
+        /// </summary>
+        /// <typeparam name="K"></typeparam>
+        /// <typeparam name="V"></typeparam>
+        /// <param name="dic"></param>
+        /// <param name="key"></param>
+        /// <param name="factory"></param>
+        /// <returns></returns>
+        public static V TryAdd<K, V>(this IDictionary<K, V> dic, K key, Func<V> factory)
+        {
+            if (!dic.TryGetValue(key, out V found))
+                return dic[key] = factory();
+            return found;
+        }
+    }
+}

--- a/src/DotLiquid/Util/MethodInfoExtensionMethods.cs
+++ b/src/DotLiquid/Util/MethodInfoExtensionMethods.cs
@@ -17,7 +17,7 @@ namespace DotLiquid.Util
         /// <returns></returns>
         public static int GetNonContextParameterCount(this MethodInfo method)
         {
-            return method.GetParameters().Count(p => p.ParameterType != typeof(Context));
+            return method.GetParameters().Count(parameter => parameter.ParameterType != typeof(Context));
         }
         /// <summary>
         /// Check if current method matches compareMethod in name and in parameters

--- a/src/DotLiquid/Util/MethodInfoExtensionMethods.cs
+++ b/src/DotLiquid/Util/MethodInfoExtensionMethods.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace DotLiquid.Util
+{
+    /// <summary>
+    /// Extend System.Reflection.MethodInfo
+    /// </summary>
+    public static class MethodInfoExtensionMethods
+    {
+        /// <summary>
+        /// Get count of parameters in method that are not the Context
+        /// </summary>
+        /// <param name="method"></param>
+        /// <returns></returns>
+        public static int GetNonContextParameterCount(this MethodInfo method)
+        {
+            return method.GetParameters().Count(p => p.ParameterType != typeof(Context));
+        }
+        /// <summary>
+        /// Check if current method matches compareMethod in name and in parameters
+        /// </summary>
+        /// <param name="method"></param>
+        /// <param name="compareMethod"></param>
+        /// <returns></returns>
+        public static bool MatchesMethod(this MethodInfo method, KeyValuePair<string, IList<Tuple<object, MethodInfo>>> compareMethod)
+        {
+            if (compareMethod.Key != Template.NamingConvention.GetMemberName(method.Name))
+            {
+                return false;
+            }
+
+            var methodParamCount = method.GetNonContextParameterCount();
+
+            return compareMethod.Value.Any(m => m.Item2.GetNonContextParameterCount() == methodParamCount);
+        }
+    }
+}


### PR DESCRIPTION
Prior to this change, if a class implemented a filter with the same name as another filter method in another class, yet the filter had a different number of parameters, that filter would be ignored.

So say that a class has the filter `| DoThing: 1`. and another class has a filter `| DoThing`. If the methods were added from the first filter's class before the second filter's class was added, only `| DoThing` would work. Trying to use `| DoThing: 1` would result in an error.

This also allows the extension of DotLIquid's StandardFilters.

- Changed `Strainer.Extend()` to check the name and number of parameters for existing filters before removing methods from `_methods`.
- Refactored check for count of non Context method parameters to extension method.
- Added test case for different methods with the same name and number of parameters in different classes.
- Added test case for different methods with the same name and number of parameters in different classes with the context parameter.
- Added test case for overriding methods that have the same name and the same number of parameters with the last class to be added to Filters.