### PR TITLE
Unix epoch string support

### DIFF
--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -753,12 +753,13 @@ namespace DotLiquid.Tests
         [TestCase("978307200", "2001-01-01T12:00:00+00:00")] // seconds, the millennium
         [TestCase("2147483648", "2038-01-19T03:14:08+00:00")] // seconds, Int32.MaxValue (32-bit overflow)
         [TestCase("-2147483648", "1901-12-13T08:45:52+00:00")] // seconds, Int32.MinValue (32-bit overflow)
-        [TestCase("62135596800", "3939-01-01T12:00:00+00:00")] // seconds, longest int interpreted as seconds (31-Dec-3938)
-        [TestCase("-62135596800", "0001-01-01T12:00:00+00:00")] // seconds, lowest value interpreted as seconds (01-Jan-0000)
-        [TestCase("62135596801", "1971-12-21T03:53:16+00:00")] // milliseconds, shortest int interpreted as milliseconds
+        [TestCase("-62135596800", "0001-01-01T12:00:00+00:00")] // seconds, lower range supported by DateTimeOffset.FromUnixTimeSeconds (01-Jan-0000)
+        [TestCase("253402300799", "9999-12-31T11:59:59+00:00")] // seconds, upper range supported by DateTimeOffset.FromUnixTimeSeconds (31-Dec-9999)
+        [TestCase("-62135596801", "1968-01-12T08:06:43+00:00")] // milliseconds, less than range supported by DateTimeOffset.FromUnixTimeSeconds
+        [TestCase("253402300800", "1978-01-11T09:31:40+00:00")] // milliseconds, more than range supported by DateTimeOffset.FromUnixTimeSeconds
         [TestCase("1582967411000", "2020-02-29T09:10:11+00:00")] // milliseconds, leap day in 2020
         [TestCase("1.0", "1.0")] // decimals are ignored
-        [TestCase("1,000", "1,000")] // currency or number with separators are ignored.
+        [TestCase("1,000", "1,000")] // number with separators are ignored.
         public void TestDate_UnixEpochTimestampStrings(string timestampString, string expectedValue)
         {
             Helper.LockTemplateStaticVars(Template.NamingConvention, () =>

--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -753,9 +753,9 @@ namespace DotLiquid.Tests
         [TestCase("978307200", "2001-01-01T12:00:00+00:00")] // seconds, the millennium
         [TestCase("2147483648", "2038-01-19T03:14:08+00:00")] // seconds, Int32.MaxValue (32-bit overflow)
         [TestCase("-2147483648", "1901-12-13T08:45:52+00:00")] // seconds, Int32.MinValue (32-bit overflow)
-        [TestCase("62135596799", "3938-12-31T11:59:59+00:00")] // seconds, longest int interpreted as seconds (31-Dec-3938)
-        [TestCase("-62135596799", "0001-01-01T12:00:01+00:00")] // seconds, lowest value interpreted as seconds (01-Jan-0000)
-        [TestCase("62135596800", "1971-12-21T03:53:16+00:00")] // milliseconds, shortest int interpreted as milliseconds
+        [TestCase("62135596800", "3939-01-01T12:00:00+00:00")] // seconds, longest int interpreted as seconds (31-Dec-3938)
+        [TestCase("-62135596800", "0001-01-01T12:00:00+00:00")] // seconds, lowest value interpreted as seconds (01-Jan-0000)
+        [TestCase("62135596801", "1971-12-21T03:53:16+00:00")] // milliseconds, shortest int interpreted as milliseconds
         [TestCase("1582967411000", "2020-02-29T09:10:11+00:00")] // milliseconds, leap day in 2020
         [TestCase("1.0", "1.0")] // decimals are ignored
         [TestCase("1,000", "1,000")] // currency or number with separators are ignored.

--- a/src/DotLiquid/StandardFilters.cs
+++ b/src/DotLiquid/StandardFilters.cs
@@ -659,7 +659,17 @@ namespace DotLiquid
                 }
                 else if (!DateTimeOffset.TryParse(value, out dateTimeOffset))
                 {
-                    return value;
+                    // As a final role of the dice, check if the string holds an integer that can be treated as a UNIX timestamp
+                    if (!long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var timestamp))
+                    {
+                        return value;
+                    }
+
+                    // Integers from -62_135_596_800 (01-Jan-0000) through +62_135_596_800 (31-Dec-3938) are treated as seconds,
+                    // anything outside this range is treated as milliseconds
+                    dateTimeOffset = (Math.Abs(timestamp) < 62_135_596_800 ?
+                        DateTimeOffset.FromUnixTimeSeconds(timestamp) :
+                        DateTimeOffset.FromUnixTimeMilliseconds(timestamp)).ToLocalTime();
                 }
             }
 

--- a/src/DotLiquid/StandardFilters.cs
+++ b/src/DotLiquid/StandardFilters.cs
@@ -651,10 +651,11 @@ namespace DotLiquid
             }
             else if (input is string stringInput && long.TryParse(stringInput, NumberStyles.Integer, CultureInfo.InvariantCulture, out var unixTimestamp))
             {
-                // If the timestamp is outside the range of the DateTimeOffset.FromUnixTimeSeconds() method, treat it as milliseconds
-                if (unixTimestamp < 62_135_596_800 || unixTimestamp > 253_402_300_799)
+                // If the timestamp is outside the range of the DateTimeOffset.FromUnixTimeSeconds() method, treat it as seconds
+                if (unixTimestamp < -62_135_596_800 || unixTimestamp > 253_402_300_799)
                     dateTimeOffset = DateTimeOffset.FromUnixTimeMilliseconds(unixTimestamp).ToLocalTime();
                 else
+                    dateTimeOffset = DateTimeOffset.FromUnixTimeSeconds(unixTimestamp).ToLocalTime();
             }
             else
             {

--- a/src/DotLiquid/StandardFilters.cs
+++ b/src/DotLiquid/StandardFilters.cs
@@ -665,9 +665,9 @@ namespace DotLiquid
                         return value;
                     }
 
-                    // Integers from -62_135_596_800 (01-Jan-0000) through +62_135_596_800 (31-Dec-3938) are treated as seconds,
+                    // Integers from -62_135_596_800 (01-Jan-0000) through +62_135_596_800 (01-Jan-3939) are treated as seconds,
                     // anything outside this range is treated as milliseconds
-                    dateTimeOffset = (Math.Abs(timestamp) < 62_135_596_800 ?
+                    dateTimeOffset = (Math.Abs(timestamp) <= 62_135_596_800 ?
                         DateTimeOffset.FromUnixTimeSeconds(timestamp) :
                         DateTimeOffset.FromUnixTimeMilliseconds(timestamp)).ToLocalTime();
                 }

--- a/src/DotLiquid/StandardFilters.cs
+++ b/src/DotLiquid/StandardFilters.cs
@@ -649,6 +649,13 @@ namespace DotLiquid
                 dateTimeOffset = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero).AddSeconds(Convert.ToDouble(input)).ToLocalTime();
 #endif
             }
+            else if (input is string stringInput && long.TryParse(stringInput, NumberStyles.Integer, CultureInfo.InvariantCulture, out var unixTimestamp))
+            {
+                // If the timestamp is outside the range of the DateTimeOffset.FromUnixTimeSeconds() method, treat it as milliseconds
+                if (unixTimestamp < 62_135_596_800 || unixTimestamp > 253_402_300_799)
+                    dateTimeOffset = DateTimeOffset.FromUnixTimeMilliseconds(unixTimestamp).ToLocalTime();
+                else
+            }
             else
             {
                 string value = input.ToString();
@@ -659,17 +666,7 @@ namespace DotLiquid
                 }
                 else if (!DateTimeOffset.TryParse(value, out dateTimeOffset))
                 {
-                    // As a final role of the dice, check if the string holds an integer that can be treated as a UNIX timestamp
-                    if (!long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var timestamp))
-                    {
-                        return value;
-                    }
-
-                    // Integers from -62_135_596_800 (01-Jan-0000) through +62_135_596_800 (01-Jan-3939) are treated as seconds,
-                    // anything outside this range is treated as milliseconds
-                    dateTimeOffset = (Math.Abs(timestamp) <= 62_135_596_800 ?
-                        DateTimeOffset.FromUnixTimeSeconds(timestamp) :
-                        DateTimeOffset.FromUnixTimeMilliseconds(timestamp)).ToLocalTime();
+                    return value;
                 }
             }
 


### PR DESCRIPTION
Adds support for UNIX Epoch timestamps as strings - resolves #457.

Also adds support for millisecond timestamps when a timestamp value lies outside the range supported by `DateTimeOffset.FromUnixTimeSeconds` (which is 01-Jan-0000 through 31-Dec-9999)