### PR TITLE
Add public cancellation token to Context

### DIFF
--- a/src/DotLiquid.Tests/DropTests.cs
+++ b/src/DotLiquid.Tests/DropTests.cs
@@ -375,18 +375,9 @@ namespace DotLiquid.Tests
         {
             using (var cancellationTokenSource = new CancellationTokenSource())
             {
-                var cancellationToken = cancellationTokenSource.Token;
-                var context = new Context(
-                    environments: new List<Hash>(),
-                    outerScope: Hash.FromAnonymousObject(new { context = new CancellationDrop() }),
-                    registers: new Hash(),
-                    errorsOutputMode: ErrorsOutputMode.Display,
-                    maxIterations: 0,
-                    formatProvider: CultureInfo.InvariantCulture,
-                    cancellationToken: cancellationToken);
                 var renderParameters = new RenderParameters(CultureInfo.InvariantCulture)
                 {
-                    Context = context
+                    CancellationToken = cancellationTokenSource.Token
                 };
                 cancellationTokenSource.Cancel();
                 Assert.Throws<OperationCanceledException>(() => Template.Parse("{{ context.halt }}").Render(renderParameters));
@@ -399,7 +390,8 @@ namespace DotLiquid.Tests
             var cancellationDrop = new CancellationDrop();
             var renderParameters = new RenderParameters(CultureInfo.InvariantCulture)
             {
-                LocalVariables = Hash.FromAnonymousObject(new { context = cancellationDrop, dummy = new[] { 1, 2, 3 } })
+                LocalVariables = Hash.FromAnonymousObject(new { context = cancellationDrop, dummy = new[] { 1, 2, 3 } }),
+                CancellationToken = new CancellationToken(canceled: false)
             };
             cancellationDrop.Signal.Set();
             Assert.AreEqual("HaltHaltHalt", Template.Parse("{% for a in dummy %}{{ context.halt }}{% endfor %}").Render(renderParameters));

--- a/src/DotLiquid.Tests/DropTests.cs
+++ b/src/DotLiquid.Tests/DropTests.cs
@@ -376,13 +376,14 @@ namespace DotLiquid.Tests
             using (var cancellationTokenSource = new CancellationTokenSource())
             {
                 var cancellationToken = cancellationTokenSource.Token;
-                var context = new Context(new List<Hash>(),
-                    Hash.FromAnonymousObject(new { context = new CancellationDrop() }),
-                    new Hash(),
-                    ErrorsOutputMode.Display,
-                    0,
-                    CultureInfo.InvariantCulture,
-                    cancellationToken);
+                var context = new Context(
+                    environments: new List<Hash>(),
+                    outerScope: Hash.FromAnonymousObject(new { context = new CancellationDrop() }),
+                    registers: new Hash(),
+                    errorsOutputMode: ErrorsOutputMode.Display,
+                    maxIterations: 0,
+                    formatProvider: CultureInfo.InvariantCulture,
+                    cancellationToken: cancellationToken);
                 var renderParameters = new RenderParameters(CultureInfo.InvariantCulture)
                 {
                     Context = context

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -43,6 +43,11 @@ namespace DotLiquid
         private Strainer _strainer;
 
         /// <summary>
+        /// A cancellation token which indicates if the template render has been cancelled
+        /// </summary>
+        public CancellationToken CancellationToken => _cancellationToken;
+
+        /// <summary>
         /// Environments
         /// </summary>
         public List<Hash> Environments { get; private set; }

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -86,10 +86,8 @@ namespace DotLiquid
              , int maxIterations
              , int timeout
              , IFormatProvider formatProvider)
-            : this(environments, outerScope, registers, errorsOutputMode, maxIterations, formatProvider, CancellationToken.None)
+            : this(environments, outerScope, registers, errorsOutputMode, maxIterations, formatProvider, timeout, CancellationToken.None)
         {
-            _timeout = timeout;
-            RestartTimeout();
         }
 
         /// <summary>
@@ -110,6 +108,27 @@ namespace DotLiquid
              , int maxIterations
              , IFormatProvider formatProvider
              , CancellationToken cancellationToken)
+            : this(environments, outerScope, registers, errorsOutputMode, maxIterations, formatProvider, null, cancellationToken)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new rendering context
+        /// </summary>
+        public Context(IFormatProvider formatProvider)
+            : this(new List<Hash>(), new Hash(), new Hash(), ErrorsOutputMode.Display, 0, 0, formatProvider)
+        {
+        }
+
+        internal Context
+            (List<Hash> environments
+             , Hash outerScope
+             , Hash registers
+             , ErrorsOutputMode errorsOutputMode
+             , int maxIterations
+             , IFormatProvider formatProvider
+             , int? timeout
+             , CancellationToken cancellationToken)
         {
             Environments = environments;
 
@@ -127,14 +146,12 @@ namespace DotLiquid
             SyntaxCompatibilityLevel = Template.DefaultSyntaxCompatibilityLevel;
 
             SquashInstanceAssignsWithEnvironments();
-        }
 
-        /// <summary>
-        /// Creates a new rendering context
-        /// </summary>
-        public Context(IFormatProvider formatProvider)
-            : this(new List<Hash>(), new Hash(), new Hash(), ErrorsOutputMode.Display, 0, 0, formatProvider)
-        {
+            if (timeout.HasValue)
+            {
+                _timeout = timeout.Value;
+                RestartTimeout();
+            }
         }
 
         /// <summary>

--- a/src/DotLiquid/RenderParameters.cs
+++ b/src/DotLiquid/RenderParameters.cs
@@ -113,7 +113,7 @@ namespace DotLiquid
                 environments.Add(LocalVariables);
             if (template.IsThreadSafe)
             {
-                context = new Context(environments, new Hash(), new Hash(), ErrorsOutputMode, MaxIterations, FormatProvider, CancellationToken)
+                context = new Context(environments, new Hash(), new Hash(), ErrorsOutputMode, MaxIterations, FormatProvider, Timeout, CancellationToken)
                 {
                     SyntaxCompatibilityLevel = this.SyntaxCompatibilityLevel
                 };
@@ -121,7 +121,7 @@ namespace DotLiquid
             else
             {
                 environments.Add(template.Assigns);
-                context = new Context(environments, template.InstanceAssigns, template.Registers, ErrorsOutputMode, MaxIterations, FormatProvider, CancellationToken)
+                context = new Context(environments, template.InstanceAssigns, template.Registers, ErrorsOutputMode, MaxIterations, FormatProvider, Timeout, CancellationToken)
                 {
                     SyntaxCompatibilityLevel = this.SyntaxCompatibilityLevel
                 };

--- a/src/DotLiquid/RenderParameters.cs
+++ b/src/DotLiquid/RenderParameters.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 
 namespace DotLiquid
 {
@@ -9,6 +10,11 @@ namespace DotLiquid
     /// </summary>
     public class RenderParameters
     {
+        /// <summary>
+        /// A cancellation token that can be used to abort the render
+        /// </summary>
+        public CancellationToken CancellationToken { get; set; }
+
         /// <summary>
         /// If you provide a Context object, you do not need to set any other parameters.
         /// </summary>
@@ -107,7 +113,7 @@ namespace DotLiquid
                 environments.Add(LocalVariables);
             if (template.IsThreadSafe)
             {
-                context = new Context(environments, new Hash(), new Hash(), ErrorsOutputMode, MaxIterations, Timeout, FormatProvider)
+                context = new Context(environments, new Hash(), new Hash(), ErrorsOutputMode, MaxIterations, FormatProvider, CancellationToken)
                 {
                     SyntaxCompatibilityLevel = this.SyntaxCompatibilityLevel
                 };
@@ -115,7 +121,7 @@ namespace DotLiquid
             else
             {
                 environments.Add(template.Assigns);
-                context = new Context(environments, template.InstanceAssigns, template.Registers, ErrorsOutputMode, MaxIterations, Timeout, FormatProvider)
+                context = new Context(environments, template.InstanceAssigns, template.Registers, ErrorsOutputMode, MaxIterations, FormatProvider, CancellationToken)
                 {
                     SyntaxCompatibilityLevel = this.SyntaxCompatibilityLevel
                 };


### PR DESCRIPTION
Address #456 by adding a publicly accessible cancellation token. This can be used by subclasses of `IContextAware`, or `Drop`