### PR TITLE
Add Errors collection to render parameters

### DIFF
--- a/src/DotLiquid.Tests/ExceptionHandlingTests.cs
+++ b/src/DotLiquid.Tests/ExceptionHandlingTests.cs
@@ -168,5 +168,20 @@ namespace DotLiquid.Tests
             });
             Assert.IsNotEmpty(output);
         }
+
+        [Test]
+        public void CollectRenderErrors()
+        {
+            var template = Template.Parse("{{nope.nope}}");
+            var parameters = new RenderParameters(CultureInfo.InvariantCulture)
+            {
+                ErrorsOutputMode = ErrorsOutputMode.Suppress
+            };
+
+            var output = template.Render(parameters);
+
+            Assert.IsEmpty(output);
+            CollectionAssert.IsNotEmpty(parameters.Errors);
+        }
     }
 }

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -81,10 +81,8 @@ namespace DotLiquid
              , int maxIterations
              , int timeout
              , IFormatProvider formatProvider)
-            : this(environments, outerScope, registers, errorsOutputMode, maxIterations, formatProvider, CancellationToken.None)
+            : this(environments, outerScope, registers, errorsOutputMode, maxIterations, timeout, formatProvider, new List<Exception>(), CancellationToken.None)
         {
-            _timeout = timeout;
-            RestartTimeout();
         }
 
         /// <summary>
@@ -105,6 +103,28 @@ namespace DotLiquid
              , int maxIterations
              , IFormatProvider formatProvider
              , CancellationToken cancellationToken)
+            : this(environments, outerScope,registers, errorsOutputMode, maxIterations, null, formatProvider, new List<Exception>(), cancellationToken)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new rendering context
+        /// </summary>
+        public Context(IFormatProvider formatProvider)
+            : this(new List<Hash>(), new Hash(), new Hash(), ErrorsOutputMode.Display, 0, 0, formatProvider)
+        {
+        }
+
+        internal Context
+            (List<Hash> environments
+             , Hash outerScope
+             , Hash registers
+             , ErrorsOutputMode errorsOutputMode
+             , int maxIterations
+             , int? timeout
+             , IFormatProvider formatProvider
+             , List<Exception> errors
+             , CancellationToken cancellationToken)
         {
             Environments = environments;
 
@@ -114,7 +134,7 @@ namespace DotLiquid
 
             Registers = registers;
 
-            Errors = new List<Exception>();
+            Errors = errors;
             _errorsOutputMode = errorsOutputMode;
             _maxIterations = maxIterations;
             _cancellationToken = cancellationToken;
@@ -122,14 +142,12 @@ namespace DotLiquid
             SyntaxCompatibilityLevel = Template.DefaultSyntaxCompatibilityLevel;
 
             SquashInstanceAssignsWithEnvironments();
-        }
 
-        /// <summary>
-        /// Creates a new rendering context
-        /// </summary>
-        public Context(IFormatProvider formatProvider)
-            : this(new List<Hash>(), new Hash(), new Hash(), ErrorsOutputMode.Display, 0, 0, formatProvider)
-        {
+            if (timeout.HasValue)
+            {
+                _timeout = timeout.Value;
+                RestartTimeout();
+            }
         }
 
         /// <summary>

--- a/src/DotLiquid/ErrorsOutputModeEnum.cs
+++ b/src/DotLiquid/ErrorsOutputModeEnum.cs
@@ -16,7 +16,7 @@ namespace DotLiquid
         Suppress,
 
         /// <summary>
-        /// DIsplay the errors
+        /// Display the errors
         /// </summary>
         Display
     }

--- a/src/DotLiquid/RenderParameters.cs
+++ b/src/DotLiquid/RenderParameters.cs
@@ -12,7 +12,7 @@ namespace DotLiquid
         /// <summary>
         /// A list of errors that occurred during render
         /// </summary>
-        public IList<Exception> Errors => _errors;
+        public IReadOnlyList<Exception> Errors => _errors;
 
         /// <summary>
         /// If you provide a Context object, you do not need to set any other parameters.

--- a/src/DotLiquid/RenderParameters.cs
+++ b/src/DotLiquid/RenderParameters.cs
@@ -10,6 +10,11 @@ namespace DotLiquid
     public class RenderParameters
     {
         /// <summary>
+        /// A list of errors that occurred during render
+        /// </summary>
+        public IList<Exception> Errors => _errors;
+
+        /// <summary>
         /// If you provide a Context object, you do not need to set any other parameters.
         /// </summary>
         public Context Context { get; set; }
@@ -73,6 +78,7 @@ namespace DotLiquid
             set { _maxIterations = value; }
         }
 
+        private readonly List<Exception> _errors = new List<Exception>();
         private int _timeout = 0;
         public IFormatProvider FormatProvider { get; }
 
@@ -105,21 +111,24 @@ namespace DotLiquid
             List<Hash> environments = new List<Hash>();
             if (LocalVariables != null)
                 environments.Add(LocalVariables);
+            Hash instanceAssigns, contextRegisters;
             if (template.IsThreadSafe)
             {
-                context = new Context(environments, new Hash(), new Hash(), ErrorsOutputMode, MaxIterations, Timeout, FormatProvider)
-                {
-                    SyntaxCompatibilityLevel = this.SyntaxCompatibilityLevel
-                };
+                instanceAssigns = new Hash();
+                contextRegisters = new Hash();
+                
             }
             else
             {
+                instanceAssigns = template.InstanceAssigns;
+                contextRegisters = template.Registers;
                 environments.Add(template.Assigns);
-                context = new Context(environments, template.InstanceAssigns, template.Registers, ErrorsOutputMode, MaxIterations, Timeout, FormatProvider)
-                {
-                    SyntaxCompatibilityLevel = this.SyntaxCompatibilityLevel
-                };
             }
+
+            context = new Context(environments, instanceAssigns, contextRegisters, ErrorsOutputMode, MaxIterations, Timeout, FormatProvider, _errors, default)
+            {
+                SyntaxCompatibilityLevel = this.SyntaxCompatibilityLevel
+            };
             registers = Registers;
             filters = Filters;
         }

--- a/src/DotLiquid/RenderParameters.cs
+++ b/src/DotLiquid/RenderParameters.cs
@@ -12,12 +12,20 @@ namespace DotLiquid
         /// <summary>
         /// A list of errors that occurred during render
         /// </summary>
-        public IReadOnlyList<Exception> Errors => _errors;
+        public IReadOnlyList<Exception> Errors => _errors ?? (_errors = new List<Exception>());
 
         /// <summary>
         /// If you provide a Context object, you do not need to set any other parameters.
         /// </summary>
-        public Context Context { get; set; }
+        public Context Context
+        {
+            get => _context;
+            set
+            {
+                _errors = value.Errors;
+                _context = value;
+            }
+        }
 
         /// <summary>
         /// Hash of local variables used during rendering
@@ -78,7 +86,8 @@ namespace DotLiquid
             set { _maxIterations = value; }
         }
 
-        private readonly List<Exception> _errors = new List<Exception>();
+        private Context _context;
+        private List<Exception> _errors;
         private int _timeout = 0;
         public IFormatProvider FormatProvider { get; }
 
@@ -125,7 +134,7 @@ namespace DotLiquid
                 environments.Add(template.Assigns);
             }
 
-            context = new Context(environments, instanceAssigns, contextRegisters, ErrorsOutputMode, MaxIterations, Timeout, FormatProvider, _errors, default)
+            context = new Context(environments, instanceAssigns, contextRegisters, ErrorsOutputMode, MaxIterations, Timeout, FormatProvider, _errors ?? (_errors = new List<Exception>()), default)
             {
                 SyntaxCompatibilityLevel = this.SyntaxCompatibilityLevel
             };

--- a/src/DotLiquid/RenderParameters.cs
+++ b/src/DotLiquid/RenderParameters.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 
 namespace DotLiquid
 {
@@ -134,7 +135,7 @@ namespace DotLiquid
                 environments.Add(template.Assigns);
             }
 
-            context = new Context(environments, instanceAssigns, contextRegisters, ErrorsOutputMode, MaxIterations, Timeout, FormatProvider, _errors ?? (_errors = new List<Exception>()), default)
+            context = new Context(environments, instanceAssigns, contextRegisters, ErrorsOutputMode, MaxIterations, Timeout, FormatProvider, _errors ?? (_errors = new List<Exception>()), CancellationToken.None)
             {
                 SyntaxCompatibilityLevel = this.SyntaxCompatibilityLevel
             };

--- a/src/DotLiquid/Template.cs
+++ b/src/DotLiquid/Template.cs
@@ -410,7 +410,7 @@ namespace DotLiquid
         {
             // Can't dispose this new StreamWriter, because it would close the
             // passed-in stream, which isn't up to us.
-            StreamWriter streamWriter = new StreamWriterWithFormatProvider(stream, parameters.FormatProvider);
+            StreamWriter streamWriter = new StreamWriterWithFormatProvider( stream, parameters.FormatProvider );
             RenderInternal(streamWriter, parameters);
             streamWriter.Flush();
         }

--- a/src/DotLiquid/Template.cs
+++ b/src/DotLiquid/Template.cs
@@ -410,9 +410,10 @@ namespace DotLiquid
         {
             // Can't dispose this new StreamWriter, because it would close the
             // passed-in stream, which isn't up to us.
-            StreamWriter streamWriter = new StreamWriterWithFormatProvider( stream, parameters.FormatProvider );
-            RenderInternal(streamWriter, parameters);
-            streamWriter.Flush();
+            using (StreamWriter streamWriter = new StreamWriterWithFormatProvider(stream, parameters.FormatProvider))
+            {
+                RenderInternal(streamWriter, parameters); streamWriter.Flush();
+            }
         }
 
         /// <summary>

--- a/src/DotLiquid/Template.cs
+++ b/src/DotLiquid/Template.cs
@@ -410,10 +410,9 @@ namespace DotLiquid
         {
             // Can't dispose this new StreamWriter, because it would close the
             // passed-in stream, which isn't up to us.
-            using (StreamWriter streamWriter = new StreamWriterWithFormatProvider(stream, parameters.FormatProvider))
-            {
-                RenderInternal(streamWriter, parameters); streamWriter.Flush();
-            }
+            StreamWriter streamWriter = new StreamWriterWithFormatProvider(stream, parameters.FormatProvider);
+            RenderInternal(streamWriter, parameters);
+            streamWriter.Flush();
         }
 
         /// <summary>


### PR DESCRIPTION
This PR adds an `Errors` collection to the `RenderParameters` object. It contains the same errors as `Context.Errors`. This allows clients of `template.Render(renderParameters)` to get hold of errors in a thread safe way.