### PR TITLE
Support Numeric Indexer Values

### DIFF
--- a/src/DotLiquid.Tests/ContextTests.cs
+++ b/src/DotLiquid.Tests/ContextTests.cs
@@ -863,6 +863,40 @@ namespace DotLiquid.Tests
             Assert.AreEqual(expected: "State Is:Texas", actual: Template.Parse(template).Render(modelHash));
         }
 
+        /// <summary>
+        /// Test case for [Issue #474](https://github.com/dotliquid/dotliquid/issues/474)
+        /// </summary>
+        [Test]
+        public void TestDecimalIndexer_Issue474()
+        {
+
+            var template = @"{% assign idx = fraction | minus: 0.01 -%}
+{{ arr[0] }}
+{{ arr[idx] }}";
+
+            var modelHash = Hash.FromAnonymousObject(new { arr = new[] { "Zero", "One" }, fraction = 0.01 });
+            Assert.AreEqual(expected: "Zero\r\nZero", actual: Template.Parse(template).Render(modelHash));
+        }
+
+        /// <summary>
+        /// Test case for [Issue #474](https://github.com/dotliquid/dotliquid/issues/474)
+        /// </summary>
+        [Test]
+        public void TestAllTypesIndexer_Issue474()
+        {
+            var zero = 0;
+            var typesToTest = Util.ExpressionUtilityTest.GetNumericCombinations().Select(item => item.Item1).Distinct().ToList();
+            var arrayOfZeroTypes = typesToTest.Select(type => Convert.ChangeType(zero, type)).ToList();
+
+            var template = @"{% for idx in numerics -%}
+{{ arr[idx] }}
+{% endfor %}";
+
+            var modelHash = Hash.FromAnonymousObject(new { arr = new[] { "Zero", "One" }, numerics = arrayOfZeroTypes });
+            Assert.AreEqual(expected: string.Join("", Enumerable.Repeat("Zero\r\n", arrayOfZeroTypes.Count)), actual: Template.Parse(template).Render(modelHash));
+
+        }
+
         [Test]
         public void TestProcAsVariable()
         {

--- a/src/DotLiquid.Tests/ContextTests.cs
+++ b/src/DotLiquid.Tests/ContextTests.cs
@@ -869,7 +869,6 @@ namespace DotLiquid.Tests
         [Test]
         public void TestDecimalIndexer_Issue474()
         {
-
             var template = @"{% assign idx = fraction | minus: 0.01 -%}
 {{ arr[0] }}
 {{ arr[idx] }}";
@@ -893,8 +892,7 @@ namespace DotLiquid.Tests
 {% endfor %}";
 
             var modelHash = Hash.FromAnonymousObject(new { arr = new[] { "Zero", "One" }, numerics = arrayOfZeroTypes });
-            Assert.AreEqual(expected: string.Join("", Enumerable.Repeat("Zero\r\n", arrayOfZeroTypes.Count)), actual: Template.Parse(template).Render(modelHash));
-
+            Assert.AreEqual(expected: string.Join(String.Empty, Enumerable.Repeat("Zero\r\n", arrayOfZeroTypes.Count)), actual: Template.Parse(template).Render(modelHash));
         }
 
         [Test]

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -621,7 +621,8 @@ namespace DotLiquid
             else if (obj is IDictionary<string, object> dictionaryObject && dictionaryObject.ContainsKey(key.ToString()))
                 value = dictionaryObject[key.ToString()];
 
-            else if ((obj is IList listObj) && (key is int || key is long))
+            else if ((obj is IList listObj) && (key is int || key is uint || key is long || key is ulong || key is short || key is ushort || key is byte || key is sbyte
+                || (key is decimal dec && Math.Truncate(dec) == dec) || (key is double dbl && Math.Truncate(dbl) == dbl) || (key is float flt && Math.Truncate(flt) == flt)))
                 value = listObj[Convert.ToInt32(key)];
 
             else if (TypeUtility.IsAnonymousType(obj.GetType()) && obj.GetType().GetRuntimeProperty((string)key) != null)


### PR DESCRIPTION
Resolves #474. 
This works in Ruby Liquid, see https://replit.com/@microalps/LiquidMathStrings