### PR TITLE
Handling Nulls in Currency Filter

### DIFF
--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -715,6 +715,21 @@ PaulGeorge",
         }
 
         [Test]
+        public void TestNullInputCurrency()
+        {
+            // Set the thread culture and test for backward compatibility
+            using (CultureHelper.SetCulture("en-US"))
+            {
+                Helper.AssertTemplateResult(
+                    expected: string.Empty,
+                    template: "{{ null | currency: 'de-DE' }}");
+            }
+
+            // _contextV20 is initialized with InvariantCulture
+            Assert.AreEqual(null, StandardFilters.Currency(context: _contextV20, input: null, languageTag: "de-DE"));
+        }
+
+        [Test]
         public void TestMalformedCurrency()
         {
             // Set the thread culture and test for backward compatibility

--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -715,19 +715,23 @@ PaulGeorge",
         }
 
         [Test]
-        public void TestNullInputCurrency()
+        [TestCase(null)]
+        [TestCase("")]
+        public void TestNullOrEmptyInputCurrency(string input)
         {
             // Set the thread culture and test for backward compatibility
             using (CultureHelper.SetCulture("en-US"))
             {
                 Helper.AssertTemplateResult(
                     expected: string.Empty,
-                    template: "{{ null | currency: 'de-DE' }}");
+                    template: "{{ input | currency: 'de-DE' }}");
             }
 
             // _contextV20 is initialized with InvariantCulture
-            Assert.AreEqual(null, StandardFilters.Currency(context: _contextV20, input: null, languageTag: "de-DE"));
-        }
+            Assert.AreEqual(
+                expected: input,
+                actual: StandardFilters.Currency(context: _contextV20, input: input, languageTag: "de-DE"));
+        }        
 
         [Test]
         public void TestMalformedCurrency()

--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -724,7 +724,8 @@ PaulGeorge",
             {
                 Helper.AssertTemplateResult(
                     expected: string.Empty,
-                    template: "{{ input | currency: 'de-DE' }}");
+                    template: "{{ input | currency: 'de-DE' }}",
+                    localVariables: Hash.FromAnonymousObject(new { input = input }));
             }
 
             // _contextV20 is initialized with InvariantCulture

--- a/src/DotLiquid/StandardFilters.cs
+++ b/src/DotLiquid/StandardFilters.cs
@@ -359,6 +359,9 @@ namespace DotLiquid
         /// <seealso href="https://shopify.dev/api/liquid/filters/money-filters#money">Shopify Money filter</seealso>
         public static string Currency(Context context, object input, string languageTag = null)
         {
+            // Check for null input, return null
+            if (input == null) return null;
+
             // Check for null only, allow an empty string as it represent the InvariantCulture
             var culture = languageTag == null ? context.CurrentCulture : new CultureInfo(languageTag.Trim());
 


### PR DESCRIPTION
This PR is to add a quick null check for input in the Currency filter and added an associated testcase. 

Without this check a null reference exception is thrown whenever the input is null(which is a quite common scenario if we pass in a property of a model) and stopping the render of the entire template.

PS: Tried to create an issue first but couldn't for some reason. hence opened the PR directly. Please let me know if I have to follow a different process for the same. Here is my issue notes:

### Dotliquid version 2.1.457

### Expected behavior To render null if the input is null for a currency filter

### Actual behavior It is throwing a null reference exception if I pass in a null property(which is highly possible)

### Steps to reproduce the Problem (you can add files)

1. Create a customer object with a property named Amount.
2. Instantiate the object with a null value for Amount
3. Use DotLiquid syntax with currency filter `{{Customer.Amount | currency:'fr-CA'}}`

or 

 Use DotLiquid syntax with currency filter `{{null | currency:'fr-CA'}}`