### PR TITLE
Added xml escaping as a function with replace function

### DIFF
--- a/src/DotLiquid/RubyFilters.cs
+++ b/src/DotLiquid/RubyFilters.cs
@@ -1,0 +1,19 @@
+﻿namespace DotLiquid
+{
+    public class RubyFilters
+    {
+        public static string Xml_escape(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+                return input;
+            try
+            {
+                return input.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;").Replace("&#34;", "&quot;").Replace("'", "&apos;");
+            }
+            catch
+            {
+                return input;
+            }
+        }
+    }
+}


### PR DESCRIPTION
We found out the dotliquid does not support the xml escaping yet like in [ruby ]([url](https://www.rubydoc.info/gems/spreefinery_themes/Liquid%2FFilters:xml_escape)). Therefore I implemented the function with only replace functions like shown [here](https://weblogs.sqlteam.com/mladenp/2008/10/21/different-ways-how-to-escape-an-xml-string-in-c/). I used the replace function because of the discussion found on this stackoverflow [post](https://stackoverflow.com/questions/1132494/string-escape-into-xml)