### PR TITLE
Feature add more shopify filter

### DIFF
--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -131,6 +131,24 @@ namespace DotLiquid.Tests
         }
 
         [Test]
+        public void TestTruncatewords()
+        {
+            Assert.AreEqual(null, StandardFilters.Truncatewords(null));
+            Assert.AreEqual("", StandardFilters.Truncatewords(""));
+            Assert.AreEqual("one two three", StandardFilters.Truncatewords("one two three", 4));
+            Assert.AreEqual("one two...", StandardFilters.Truncatewords("one two three", 2));
+            Assert.AreEqual("one two three", StandardFilters.Truncatewords("one two three"));
+            Assert.AreEqual("Two small (13&#8221; x 5.5&#8221; x 10&#8221; high) baskets fit inside one large basket (13&#8221;...", StandardFilters.Truncatewords("Two small (13&#8221; x 5.5&#8221; x 10&#8221; high) baskets fit inside one large basket (13&#8221; x 16&#8221; x 10.5&#8221; high) with cover.", 15));
+
+            Helper.AssertTemplateResult(expected: "Ground control to...", template: "{{ \"Ground control to Major Tom.\" | truncatewords: 3}}");
+            Helper.AssertTemplateResult(expected: "Ground control to--", template: "{{ \"Ground control to Major Tom.\" | truncatewords: 3, \"--\"}}");
+            Helper.AssertTemplateResult(expected: "Ground control to", template: "{{ \"Ground control to Major Tom.\" | truncatewords: 3, \"\"}}");
+            Helper.AssertTemplateResult(expected: "...", template: "{{ \"Ground control to Major Tom.\" | truncatewords: 0}}");
+            Helper.AssertTemplateResult(expected: "...", template: "{{ \"Ground control to Major Tom.\" | truncatewords: -1}}");
+            Helper.AssertTemplateResult(expected: "Liquid error: Value was either too large or too small for an Int32.", template: $"{{{{ \"Ground control to Major Tom.\" | truncatewords: {((long)int.MaxValue) + 1}}}}}");
+        }
+
+        [Test]
         public void TestSplit()
         {
             CollectionAssert.AreEqual(new[] { "This", "is", "a", "sentence" }, StandardFilters.Split("This is a sentence", " "));

--- a/src/DotLiquid/StandardFilters.cs
+++ b/src/DotLiquid/StandardFilters.cs
@@ -289,6 +289,17 @@ namespace DotLiquid
         }
 
         /// <summary>
+        /// Truncate a string down to x words
+        /// </summary>
+        /// <param name="input">Input to be transformed by this filter</param>
+        /// <param name="words">optional maximum number of words in returned string, defaults to 15</param>
+        /// <param name="truncateString">Optional suffix to append when string is truncated, defaults to ellipsis(...)</param>
+        public static string Truncatewords(string input, int words = 15, string truncateString = "...")
+        {
+            return TruncateWords(input, words, truncateString);
+        }
+
+        /// <summary>
         /// Split input string into an array of substrings separated by given pattern.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
- Add `truncatewords` filter to standard filters. Existing filter `truncate_words` is not liquid standard filter like shopify docs: https://shopify.github.io/liquid/filters/truncatewords/ 
- Add more shopify filters: `camelize`, `pluralize`, `url_escape`, `base64_encode`, `base64_url_safe_encode`, `base64_url_safe_decode`