### PR TITLE
Feature partial cache

### DIFF
--- a/src/DotLiquid/PartialCache.cs
+++ b/src/DotLiquid/PartialCache.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using DotLiquid.FileSystems;
+
+namespace DotLiquid
+{
+    internal static class PartialCache
+    {
+        private const string PartialCacheKey = "cached_partials";
+        public static Template Load(string templateName, Context context)
+        {
+            var cachedPartials = context.Registers.Get<IDictionary<string, Template>>(PartialCacheKey);
+            if (cachedPartials == null)
+                context.Registers[PartialCacheKey] = cachedPartials = new Dictionary<string, Template>();
+            if (cachedPartials.TryGetValue(templateName, out var cached))
+                return cached;
+            Template partial = Fetch(templateName, context);
+            cachedPartials[templateName] = partial;
+            return partial;
+        }
+
+        public static Template Fetch(string templateNameExpr, Context context)
+        {
+            var fileSystem = context.Registers["file_system"] as IFileSystem ?? Template.FileSystem;
+            var templateFileSystem = fileSystem as ITemplateFileSystem;
+            Template partial = null;
+            if (templateFileSystem != null)
+            {
+                partial = templateFileSystem.GetTemplate(context, templateNameExpr);
+            }
+            if (partial == null)
+            {
+                var source = fileSystem.ReadTemplateFile(context, templateNameExpr);
+                partial = Template.Parse(source);
+            }
+            return partial;
+        }
+    }
+}

--- a/src/DotLiquid/Properties/Resources.it.resx
+++ b/src/DotLiquid/Properties/Resources.it.resx
@@ -246,4 +246,7 @@
   <data name="CultureNotFoundException" xml:space="preserve">
     <value>La cultura '{0}' non è supportata</value>
   </data>
+  <data name="TemplateNameArgumentException" xml:space="preserve">
+    <value>Errore di argomento nel tag '{0}' - Nome modello non valido</value>
+  </data>
 </root>

--- a/src/DotLiquid/Properties/Resources.resx
+++ b/src/DotLiquid/Properties/Resources.resx
@@ -207,6 +207,9 @@
   <data name="LocalFileSystemIllegalTemplatePathException" xml:space="preserve">
     <value>Error - Illegal template path '{0}'</value>
   </data>
+  <data name="TemplateNameArgumentException" xml:space="preserve">
+    <value>Argument error in tag '{0}' - Illegal template name</value>
+  </data>
   <data name="LocalFileSystemTemplateNotFoundException" xml:space="preserve">
     <value>Error - No such template '{0}'</value>
   </data>

--- a/src/DotLiquid/SyntaxCompatibilityEnum.cs
+++ b/src/DotLiquid/SyntaxCompatibilityEnum.cs
@@ -24,5 +24,10 @@ namespace DotLiquid
         /// Behavior as of DotLiquid 2.2a
         /// </summary>
         DotLiquid22a = 221,
+
+        /// <summary>
+        /// Behavior as of DotLiquid 2.2b
+        /// </summary>
+        DotLiquid22b = 222,
     }
 }

--- a/src/DotLiquid/Tags/Include.cs
+++ b/src/DotLiquid/Tags/Include.cs
@@ -61,9 +61,9 @@ namespace DotLiquid.Tags
                 foreach (var keyValue in _attributes)
                     context[keyValue.Key] = context[keyValue.Value];
 
-                if (variable is IEnumerable)
+                if (variable is IEnumerable enumerable && !(variable is string))
                 {
-                    ((IEnumerable) variable).Cast<object>().ToList().ForEach(v =>
+                    enumerable.Cast<object>().ToList().ForEach(v =>
                     {
                         context[shortenedTemplateName] = v;
                         partial.Render(result, RenderParameters.FromContext(context, result.FormatProvider));

--- a/src/DotLiquid/Tags/Include.cs
+++ b/src/DotLiquid/Tags/Include.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using DotLiquid.Exceptions;
-using DotLiquid.FileSystems;
 using DotLiquid.Util;
 
 namespace DotLiquid.Tags
@@ -40,22 +39,20 @@ namespace DotLiquid.Tags
 
         public override void Render(Context context, TextWriter result)
         {
-            IFileSystem fileSystem = context.Registers["file_system"] as IFileSystem ?? Template.FileSystem;
-            ITemplateFileSystem templateFileSystem = fileSystem as ITemplateFileSystem;
-            Template partial = null;
-            if (templateFileSystem != null)
+            Template partial;
+            if (context.SyntaxCompatibilityLevel >= SyntaxCompatibility.DotLiquid22b)
             {
-                partial = templateFileSystem.GetTemplate(context, _templateName);
+                if (!(context[_templateName] is string templateName))
+                    throw new Exceptions.ArgumentException(Liquid.ResourceManager.GetString("TemplateNameArgumentException"), TagName);
+                partial = PartialCache.Load(templateName, context);
             }
-            if (partial == null)
+            else
             {
-                string source = fileSystem.ReadTemplateFile(context, _templateName);
-                partial = Template.Parse(source);
+                partial = PartialCache.Fetch(_templateName, context);
             }
 
-            string shortenedTemplateName = _templateName.Substring(1, _templateName.Length - 2);
-            object variable = context[_variableName ?? shortenedTemplateName, _variableName != null];
-
+            var contextVariableName = _templateName.Substring(1, _templateName.Length - 2);;
+            object variable = context[_variableName ?? contextVariableName, _variableName != null];
             context.Stack(() =>
             {
                 foreach (var keyValue in _attributes)
@@ -65,14 +62,16 @@ namespace DotLiquid.Tags
                 {
                     enumerable.Cast<object>().ToList().ForEach(v =>
                     {
-                        context[shortenedTemplateName] = v;
+                        context[contextVariableName] = v;
                         partial.Render(result, RenderParameters.FromContext(context, result.FormatProvider));
                     });
-                    return;
+                }
+                else
+                {
+                    context[contextVariableName] = variable;
+                    partial.Render(result, RenderParameters.FromContext(context, result.FormatProvider));
                 }
 
-                context[shortenedTemplateName] = variable;
-                partial.Render(result, RenderParameters.FromContext(context, result.FormatProvider));
             });
         }
     }


### PR DESCRIPTION
- Partial cache template in include tag that request `ITemplateFileSystem#GetTemplate`, for example:
```liquid
{% include 'foo' %}
// do something
{% include 'foo' %} # Second call should be cached in local context
```
- introduce new break change in include tag. Current the `templateName` parameter passed into `ITemplateFileSystem` from include tag is actually template name expression - implementation of `ITemplateFileSystem` must call `context[templateName]` (`templateName = "'foo'"` for this example) to get final name, this change evaluate the expression before pass into `ITemplateFileSystem` (implementation of `ITemplateFileSystem` will be received`templateName = "foo"` for this example ).
- i know current we could implement this behavior by implementing ITemplateFileSystem, but it is nice if it is natural in lib and for render tag in feature