### PR TITLE
Feature render tag

### DIFF
--- a/src/DotLiquid.Tests/ContextTests.cs
+++ b/src/DotLiquid.Tests/ContextTests.cs
@@ -1051,5 +1051,43 @@ namespace DotLiquid.Tests
             Context context = new Context(CultureInfo.CurrentCulture.NumberFormat);
             Assert.AreSame(CultureInfo.CurrentCulture, context.CurrentCulture);
         }
+
+        [Test]
+        public void TestDisablesTagSpecified()
+        {
+            var context = new Context(CultureInfo.InvariantCulture);
+            context.WithDisabledTags(new [] { "foo", "bar" }, () =>
+            {
+                Assert.True(context.IsTagDisabled("foo"));
+                Assert.True(context.IsTagDisabled("bar"));
+                Assert.False(context.IsTagDisabled("unknown"));
+            });
+        }
+
+        [Test]
+        public void TestDisablesNestedTags()
+        {
+            var context = new Context(CultureInfo.InvariantCulture);
+            context.WithDisabledTags(new [] { "foo" }, () =>
+            {
+                context.WithDisabledTags(new [] { "foo" }, () =>
+                {
+                    Assert.True(context.IsTagDisabled("foo"));
+                    Assert.False(context.IsTagDisabled("bar"));
+                });
+                context.WithDisabledTags(new [] { "bar" }, () =>
+                {
+                    Assert.True(context.IsTagDisabled("foo"));
+                    Assert.True(context.IsTagDisabled("bar"));
+                    context.WithDisabledTags(new [] { "foo" }, () =>
+                    {
+                        Assert.True(context.IsTagDisabled("foo"));
+                        Assert.True(context.IsTagDisabled("bar"));
+                    });
+                });
+                Assert.True(context.IsTagDisabled("foo"));
+                Assert.False(context.IsTagDisabled("bar"));
+            });
+        }
     }
 }

--- a/src/DotLiquid.Tests/DisableTagTests.cs
+++ b/src/DotLiquid.Tests/DisableTagTests.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using NUnit.Framework;
+
+namespace DotLiquid.Tests
+{
+    [TestFixture]
+    public class DisableTagTests
+    {
+        internal class CustomTag : Tag
+        {
+            public override void Render(Context context, TextWriter result) => result.Write(TagName);
+        }
+        internal class Custom2Tag : Tag
+        {
+            public override void Render(Context context, TextWriter result) => result.Write(TagName);
+        }
+
+        internal class NoNameTag : Tag
+        {
+            public override void Initialize(string tagName, string markup, List<string> tokens)
+            {
+                // ignore base, so tag name is not be set
+            }
+
+            public override void Render(Context context, TextWriter result) => result.Write($"from no name: {TagName}");
+        }
+
+        [Test]
+        public void TestDisableTag()
+        {
+            Helper.WithCustomTag<CustomTag>("custom", () =>
+            {
+                var context = new Context(CultureInfo.InvariantCulture);
+                context.WithDisabledTags(new[] { "custom" }, () =>
+                {
+                    Assert.AreEqual("Liquid error: custom usage is not allowed in this context", Template.Parse("{% custom %}").Render(RenderParameters.FromContext(context, context.FormatProvider)));
+                });
+            });
+        }
+
+        [Test]
+        public void TestDisableNestedTag()
+        {
+            Helper.WithCustomTag<CustomTag>("custom", () =>
+            {
+                Helper.WithCustomTag<Custom2Tag>("custom2", () =>
+                {
+                    var context = new Context(CultureInfo.InvariantCulture);
+                    context.WithDisabledTags(new[] { "custom" }, () =>
+                    {
+                        Assert.AreEqual("Liquid error: custom usage is not allowed in this context;custom2",
+                            Template.Parse("{% custom %};{% custom2 %}").Render(RenderParameters.FromContext(context, context.FormatProvider)));
+                    });
+                });
+            });
+        }
+
+        [Test]
+        public void TestDisableMultipleNestedTag()
+        {
+            Helper.WithCustomTag<CustomTag>("custom", () =>
+            {
+                Helper.WithCustomTag<Custom2Tag>("custom2", () =>
+                {
+                    var context = new Context(CultureInfo.InvariantCulture);
+                    context.WithDisabledTags(new[] { "custom", "custom2" }, () =>
+                    {
+                        Assert.AreEqual("Liquid error: custom usage is not allowed in this context;Liquid error: custom2 usage is not allowed in this context",
+                            Template.Parse("{% custom %};{% custom2 %}").Render(RenderParameters.FromContext(context, context.FormatProvider)));
+                    });
+                });
+            });
+        }
+
+        [Test]
+        public void TestIgnoreTagWithoutTagName()
+        {
+            Helper.WithCustomTag<NoNameTag>("no_name", () =>
+            {
+                var context = new Context(CultureInfo.InvariantCulture);
+                context.WithDisabledTags(new[] { "no_name" }, () =>
+                {
+                    Assert.AreEqual("from no name: ", Template.Parse("{% no_name %}").Render(RenderParameters.FromContext(context, context.FormatProvider)));
+                });
+            });
+        }
+    }
+}

--- a/src/DotLiquid.Tests/ExceptionHandlingTests.cs
+++ b/src/DotLiquid.Tests/ExceptionHandlingTests.cs
@@ -21,10 +21,6 @@ namespace DotLiquid.Tests
                 throw new SyntaxException("syntax exception");
             }
 
-            public void InterruptException()
-            {
-                throw new InterruptException("interrupted");
-            }
         }
 
         [Test]
@@ -66,17 +62,6 @@ namespace DotLiquid.Tests
 
             Assert.AreEqual(1, template.Errors.Count);
             Assert.IsInstanceOf<ArgumentException>(template.Errors[0]);
-        }
-
-        [Test]
-        public void TestInterruptException()
-        {
-            Template template = null;
-            Assert.DoesNotThrow(() => { template = Template.Parse(" {{ errors.interrupt_exception }} "); });
-            var localVariables = Hash.FromAnonymousObject(new { errors = new ExceptionDrop() });
-            var exception = Assert.Throws<InterruptException>(() => template.Render(localVariables));
-
-            Assert.AreEqual("interrupted", exception.Message);
         }
 
         [Test]

--- a/src/DotLiquid.Tests/Tags/RenderTagTests.cs
+++ b/src/DotLiquid.Tests/Tags/RenderTagTests.cs
@@ -1,0 +1,416 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using DotLiquid.Exceptions;
+using DotLiquid.FileSystems;
+using NUnit.Framework;
+
+namespace DotLiquid.Tests.Tags
+{
+    [TestFixture]
+    public class RenderTagTests
+    {
+        private class CountingFileSystem : IFileSystem
+        {
+            public int Count { get; private set; }
+
+            public string ReadTemplateFile(Context context, string templateName)
+            {
+                Count++;
+                return "from CountingFileSystem";
+            }
+        }
+
+        private class TestEnumerable : Drop, IEnumerable<IDictionary<string, int>>
+        {
+            private readonly IList<IDictionary<string, int>> _data = new List<IDictionary<string, int>>
+            {
+                new Dictionary<string, int> { { "foo", 1 }, { "bar", 2 } },
+                new Dictionary<string, int> { { "foo", 2 }, { "bar", 1 } },
+                new Dictionary<string, int> { { "foo", 3 }, { "bar", 3 } },
+            };
+
+            public IEnumerator<IDictionary<string, int>> GetEnumerator() => _data.GetEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            public string Name => nameof(TestEnumerable);
+        }
+
+        [Test]
+        public void TestRenderWithNoArguments()
+        {
+            Helper.WithDictionaryFileSystem(new Dictionary<string, string>
+            {
+                ["source"] = "rendered content"
+            }, () =>
+            {
+                Helper.AssertTemplateResult("rendered content", "{% render 'source' %}");
+            });
+        }
+
+        [Test]
+        public void TestRenderTagLookForFileSystemInRegisterFirst()
+        {
+            Helper.WithDictionaryFileSystem(new Dictionary<string, string>
+            {
+                ["pick_a_source"] = "from global file system"
+            }, () =>
+            {
+                var context = new Context(CultureInfo.InvariantCulture);
+                context.Registers["file_system"] = new Helper.DictionaryFileSystem(new Dictionary<string, string>
+                {
+                    ["pick_a_source"] = "from register file system"
+                });
+                Assert.AreEqual("from register file system", Template.Parse("{% render 'pick_a_source' %}").Render(RenderParameters.FromContext(context, context.FormatProvider)));
+            });
+        }
+
+        [Test]
+        public void TestRenderPassesNamedArgumentsIntoInnerScope()
+        {
+            Helper.WithDictionaryFileSystem(new Dictionary<string, string>
+            {
+                ["product"] = "{{ inner_product.title }}"
+            }, () =>
+            {
+                Helper.AssertTemplateResult("My Product", "{% render 'product', inner_product: outer_product %}", Hash.FromAnonymousObject(new
+                {
+                    outer_product = new { title = "My Product" }
+                }));
+            });
+        }
+
+        [Test]
+        public void TestRenderAcceptsLiteralsAsArguments()
+        {
+            Helper.WithDictionaryFileSystem(new Dictionary<string, string>
+            {
+                ["snippet"] = "{{ price }}"
+            }, () =>
+            {
+                Helper.AssertTemplateResult("123", "{% render 'snippet', price: 123 %}");
+            });
+        }
+
+        [Test]
+        public void TestRenderAcceptsMultipleNamedArguments()
+        {
+            Helper.WithDictionaryFileSystem(new Dictionary<string, string>
+            {
+                ["snippet"] = "{{ one }} {{ two }}"
+            }, () =>
+            {
+                Helper.AssertTemplateResult("1 2", "{% render 'snippet', one: 1, two: 2 %}");
+            });
+        }
+
+        [Test]
+        public void TestRenderDoesNotInheritParentScopeVariables()
+        {
+            Helper.WithDictionaryFileSystem(new Dictionary<string, string>
+            {
+                ["snippet"] = "{{ outer_variable }}"
+            }, () =>
+            {
+                Helper.AssertTemplateResult("", "{% assign outer_variable = 'should not be visible' %}{% render 'snippet' %}");
+            });
+        }
+
+        [Test]
+        public void TestRenderDoesNotInheritVariableWithSameNameAsSnippet()
+        {
+            Helper.WithDictionaryFileSystem(new Dictionary<string, string>
+            {
+                ["snippet"] = "{{ outer_variable }}"
+            }, () =>
+            {
+                Helper.AssertTemplateResult("", "{% assign snippet = 'should not be visible' %}{% render 'snippet' %}");
+            });
+        }
+
+        [Test]
+        public void TestRenderDoesNotMutateParentScope()
+        {
+            Helper.WithDictionaryFileSystem(new Dictionary<string, string>
+            {
+                ["snippet"] = "{% assign inner = 1 %}"
+            }, () =>
+            {
+                Helper.AssertTemplateResult("", "{% render 'snippet' %}{{ inner }}");
+            });
+        }
+
+        [Test]
+        public void TestNestedRenderTag()
+        {
+            Helper.WithDictionaryFileSystem(new Dictionary<string, string>
+            {
+                ["one"] = "one {% render 'two' %}",
+                ["two"] = "two"
+            }, () =>
+            {
+                Helper.AssertTemplateResult("one two", "{% render 'one' %}");
+            });
+        }
+
+        [Test]
+        public void TestRecursivelyRenderedTemplateDoesNotProduceEndlessLoop()
+        {
+            Helper.WithDictionaryFileSystem(new Dictionary<string, string>
+            {
+                ["loop"] = "{% render 'loop' %}",
+            }, () =>
+            {
+                Assert.Throws<StackLevelException>(() => Template.Parse("{% render 'loop' %}").Render(new RenderParameters(CultureInfo.InvariantCulture)
+                {
+                    ErrorsOutputMode = ErrorsOutputMode.Rethrow
+                }));
+            });
+        }
+
+        [Test]
+        public void TestDynamicallyChoosenTemplatesAreNotAllowed()
+        {
+            Assert.Throws<SyntaxException>(() => Template.Parse("{% assign name = 'snippet' %}{% render name %}"));
+        }
+
+        [Test]
+        public void TestIncludeTagCachesSecondReadOfSamePartial()
+        {
+            var fs = new CountingFileSystem();
+            Helper.WithFileSystem(fs, () =>
+            {
+                Helper.AssertTemplateResult("from CountingFileSystemfrom CountingFileSystem", "{% render 'snippet' %}{% render 'snippet' %}");
+                Assert.AreEqual(1, fs.Count);
+            });
+        }
+
+        [Test]
+        public void TestRenderTagDoesntCachePartialsAcrossRenders()
+        {
+            var fs = new CountingFileSystem();
+            Helper.WithFileSystem(fs, () =>
+            {
+                Helper.AssertTemplateResult("from CountingFileSystem", "{% include 'pick_a_source' %}");
+                Assert.AreEqual(1, fs.Count);
+                Helper.AssertTemplateResult("from CountingFileSystem", "{% include 'pick_a_source' %}");
+                Assert.AreEqual(2, fs.Count);
+            });
+        }
+
+        [Test]
+        public void TestRenderTagWithinIfStatement()
+        {
+            Helper.WithDictionaryFileSystem(new Dictionary<string, string>
+            {
+                ["snippet"] = "my message",
+            }, () =>
+            {
+                Helper.AssertTemplateResult("my message", "{% if true %}{% render 'snippet' %}{% endif %}");
+            });
+        }
+
+        [Test]
+        public void TestBreakThroughRender()
+        {
+            Helper.WithDictionaryFileSystem(new Dictionary<string, string>
+            {
+                ["break"] = "{% break %}",
+            }, () =>
+            {
+                Helper.AssertTemplateResult("1", "{% for i in (1..3) %}{{ i }}{% break %}{{ i }}{% endfor %}");
+                Helper.AssertTemplateResult("112233", "{% for i in (1..3) %}{{ i }}{% render 'break' %}{{ i }}{% endfor %}");
+            });
+        }
+
+        [Test]
+        public void TestIncrementIsIsolatedBetweenRenders()
+        {
+            Helper.WithDictionaryFileSystem(new Dictionary<string, string>
+            {
+                ["incr"] = "{% increment foo %}",
+            }, () =>
+            {
+                Helper.AssertTemplateResult("010", "{% increment foo %}{% increment foo %}{% render 'incr' %}");
+            });
+        }
+
+        [Test]
+        public void TestDecrementIsIsolatedBetweenRenders()
+        {
+            Helper.WithDictionaryFileSystem(new Dictionary<string, string>
+            {
+                ["decr"] = "{% decrement foo %}",
+            }, () =>
+            {
+                Helper.AssertTemplateResult("-1-2-1", "{% decrement foo %}{% decrement foo %}{% render 'decr' %}");
+            });
+        }
+
+        [Test]
+        public void TestIncludesWillNotRenderInsideRenderTag()
+        {
+            Helper.WithDictionaryFileSystem(new Dictionary<string, string>
+            {
+                ["test_include"] = "{% include 'foo' %}",
+                ["foo"] = "bar",
+            }, () =>
+            {
+                Helper.AssertTemplateResult("Liquid error: include usage is not allowed in this context", "{% render 'test_include' %}");
+            });
+        }
+
+        [Test]
+        public void TestIncludesWillNotRenderInsideNestedSiblingTags()
+        {
+            Helper.WithDictionaryFileSystem(new Dictionary<string, string>
+            {
+                ["nested_render_with_sibling_include"] = "{% render 'test_include' %}{% include 'foo' %}",
+                ["test_include"] = "{% include 'foo' %}",
+                ["foo"] = "bar",
+            }, () =>
+            {
+                Helper.AssertTemplateResult("Liquid error: include usage is not allowed in this context" +
+                    "Liquid error: include usage is not allowed in this context",
+                    "{% render 'nested_render_with_sibling_include' %}");
+            });
+        }
+
+        [Test]
+        public void TestRenderTagWith()
+        {
+            Helper.WithDictionaryFileSystem(new Dictionary<string, string>
+            {
+                ["product"] = "Product: {{ product.title }} ",
+                ["product_alias"] = "Product: {{ product.title }} ",
+            }, () =>
+            {
+                var vars = Hash.FromAnonymousObject(new
+                {
+                    products = new[]
+                    {
+                        new { title = "Draft 151cm" },
+                        new { title = "Element 155cm" },
+                    }
+                });
+                Helper.AssertTemplateResult("Product: Draft 151cm ", "{% render 'product' with products[0] %}", vars);
+            });
+        }
+
+        [Test]
+        public void TestRenderTagWithAlias()
+        {
+            Helper.WithDictionaryFileSystem(new Dictionary<string, string>
+            {
+                ["product"] = "Product: {{ product.title }} ",
+                ["product_alias"] = "Product: {{ product.title }} ",
+            }, () =>
+            {
+                var vars = Hash.FromAnonymousObject(new
+                {
+                    products = new[]
+                    {
+                        new { title = "Draft 151cm" },
+                        new { title = "Element 155cm" },
+                    }
+                });
+                Helper.AssertTemplateResult("Product: Draft 151cm ", "{% render 'product_alias' with products[0] as product %}", vars);
+            });
+        }
+
+        [Test]
+        public void TestRenderTagForAlias()
+        {
+            Helper.WithDictionaryFileSystem(new Dictionary<string, string>
+            {
+                ["product"] = "Product: {{ product.title }} ",
+                ["product_alias"] = "Product: {{ product.title }} ",
+            }, () =>
+            {
+                var vars = Hash.FromAnonymousObject(new
+                {
+                    products = new[]
+                    {
+                        new { title = "Draft 151cm" },
+                        new { title = "Element 155cm" },
+                    }
+                });
+                Helper.AssertTemplateResult("Product: Draft 151cm Product: Element 155cm ", "{% render 'product_alias' for products as product %}", vars);
+            });
+        }
+
+        [Test]
+        public void TestRenderTagFor()
+        {
+            Helper.WithDictionaryFileSystem(new Dictionary<string, string>
+            {
+                ["product"] = "Product: {{ product.title }} ",
+                ["product_alias"] = "Product: {{ product.title }} ",
+            }, () =>
+            {
+                var vars = Hash.FromAnonymousObject(new
+                {
+                    products = new[]
+                    {
+                        new { title = "Draft 151cm" },
+                        new { title = "Element 155cm" },
+                    }
+                });
+                Helper.AssertTemplateResult("Product: Draft 151cm Product: Element 155cm ", "{% render 'product' for products %}", vars);
+            });
+        }
+
+        [Test]
+        public void TestRenderTagForloop()
+        {
+            Helper.WithDictionaryFileSystem(new Dictionary<string, string>
+            {
+                ["product"] = "Product: {{ product.title }} {% if forloop.first %}first{% endif %} {% if forloop.last %}last{% endif %} index:{{ forloop.index }} ",
+            }, () =>
+            {
+                var vars = Hash.FromAnonymousObject(new
+                {
+                    products = new[]
+                    {
+                        new { title = "Draft 151cm" },
+                        new { title = "Element 155cm" },
+                    }
+                });
+                Helper.AssertTemplateResult("Product: Draft 151cm first  index:1 Product: Element 155cm  last index:2 ","{% render 'product' for products %}", vars);
+            });
+        }
+
+        [Test]
+        public void TestRenderTagForDrop()
+        {
+            Helper.WithDictionaryFileSystem(new Dictionary<string, string>
+            {
+                ["loop"] = "{{ value.foo }}",
+            }, () =>
+            {
+                var vars = Hash.FromAnonymousObject(new
+                {
+                    loop = new TestEnumerable()
+                });
+                Helper.AssertTemplateResult("123","{% render 'loop' for loop as value %}", vars);
+            });
+        }
+
+        [Test]
+        public void TestRenderTagWithDrop()
+        {
+            Helper.WithDictionaryFileSystem(new Dictionary<string, string>
+            {
+                ["loop"] = "{{ value.Name }}",
+            }, () =>
+            {
+                var vars = Hash.FromAnonymousObject(new
+                {
+                    loop = new TestEnumerable()
+                });
+                Helper.AssertTemplateResult("TestEnumerable","{% render 'loop' with loop as value %}", vars);
+            });
+        }
+    }
+}

--- a/src/DotLiquid.Tests/Tags/StandardTagTests.cs
+++ b/src/DotLiquid.Tests/Tags/StandardTagTests.cs
@@ -722,6 +722,18 @@ Maths 2: Eric Schmidt (ID3), Bruce Banner (ID4),
                 expected: "0 0 1 2 1",
                 template: "{%increment port %} {%increment starboard%} {%increment port %} {%increment port%} {%increment starboard %}");
             Helper.AssertTemplateResult(expected: "1 2", template: "{%increment port %} {%increment port %}", localVariables: Hash.FromAnonymousObject(new { port = 1 }));
+
+            Helper.AssertTemplateResult(expected: "0", template: "{%increment port %}");
+
+            var context = new Context(CultureInfo.InvariantCulture);
+            Assert.AreEqual("0", Template.Parse("{%increment port %}").Render(RenderParameters.FromContext(context, context.FormatProvider)));
+        }
+
+        [Test]
+        public void TestIncrementRenderWithContext()
+        {
+            var context = new Context(CultureInfo.InvariantCulture);
+            Assert.AreEqual("0", Template.Parse("{%increment port %}").Render(RenderParameters.FromContext(context, context.FormatProvider)));
         }
 
         [Test]
@@ -774,6 +786,13 @@ Maths 2: Eric Schmidt (ID3), Bruce Banner (ID4),
                 expected: "1 5 2 2 5",
                 template: "{%increment port %} {%increment starboard%} {%increment port %} {%decrement port%} {%decrement starboard %}",
                 localVariables: Hash.FromAnonymousObject(new { port = 1, starboard = 5 }));
+        }
+
+        [Test]
+        public void TestDecrementRenderWithContext()
+        {
+            var context = new Context(CultureInfo.InvariantCulture);
+            Assert.AreEqual("-1", Template.Parse("{%decrement port %}").Render(RenderParameters.FromContext(context, context.FormatProvider)));
         }
 
         [Test]

--- a/src/DotLiquid/Block.cs
+++ b/src/DotLiquid/Block.cs
@@ -177,6 +177,10 @@ namespace DotLiquid
                     if (token is IRenderable renderableToken)
                     {
                         renderableToken.Render(context, result);
+                        if (context.IsInterrupt())
+                        {
+                            return;
+                        }
                     }
                     else
                     {

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -65,6 +65,30 @@ namespace DotLiquid
         internal InterruptException PopInterrupt() => _interrupted.Pop();
         internal bool IsInterrupt() => _interrupted.Any();
 
+        private readonly IDictionary<string, int> _disabledTags = new Dictionary<string, int>();
+        internal bool IsTagDisabled(string tagName) => _disabledTags.TryGetValue(tagName, out var cnt) && cnt > 0;
+        public void WithDisabledTags(string[] tagNames, Action action)
+        {
+            try
+            {
+                foreach (var tagName in tagNames)
+                {
+                    if (!_disabledTags.TryGetValue(tagName, out var cnt))
+                        cnt = 0;
+                    _disabledTags[tagName] = cnt + 1;
+                }
+                action();
+            }
+            finally
+            {
+                foreach (var tagName in tagNames)
+                {
+                    if (_disabledTags.TryGetValue(tagName, out var cnt))
+                        _disabledTags[tagName] = cnt - 1;
+                }
+            }
+        }
+
         private readonly int _maxIterations;
 
         public int MaxIterations

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -59,6 +59,12 @@ namespace DotLiquid
             }
         }
 
+        private readonly Stack<InterruptException> _interrupted = new Stack<InterruptException>();
+
+        internal void PushInterrupt(InterruptException e) => _interrupted.Push(e);
+        internal InterruptException PopInterrupt() => _interrupted.Pop();
+        internal bool IsInterrupt() => _interrupted.Any();
+
         private readonly int _maxIterations;
 
         public int MaxIterations

--- a/src/DotLiquid/Document.cs
+++ b/src/DotLiquid/Document.cs
@@ -1,6 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.IO;
-using DotLiquid.Exceptions;
 
 namespace DotLiquid
 {
@@ -33,26 +31,5 @@ namespace DotLiquid
         /// </summary>
         protected override void AssertMissingDelimitation()
         { }
-
-        /// <summary>
-        /// Renders the Document
-        /// </summary>
-        /// <param name="context"></param>
-        /// <param name="result"></param>
-        public override void Render(Context context, TextWriter result)
-        {
-            try
-            {
-                base.Render(context, result);
-            }
-            catch (BreakInterrupt)
-            {
-                // BreakInterrupt exceptions are used to interrupt a rendering
-            }
-            catch (ContinueInterrupt)
-            {
-                // ContinueInterrupt exceptions are used to interrupt a rendering
-            }
-        }
     }
 }

--- a/src/DotLiquid/Exceptions/DisabledException.cs
+++ b/src/DotLiquid/Exceptions/DisabledException.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace DotLiquid.Exceptions
+{
+    public class DisabledException : LiquidException
+    {
+        public DisabledException(string message, params string[] args)
+            : base(string.Format(message, args))
+        {
+        }
+
+        public DisabledException()
+        {
+        }
+    }
+}

--- a/src/DotLiquid/Exceptions/InterruptException.cs
+++ b/src/DotLiquid/Exceptions/InterruptException.cs
@@ -10,6 +10,7 @@ namespace DotLiquid.Exceptions
 
     public class BreakInterrupt : InterruptException
     {
+        public static readonly BreakInterrupt Instance = new BreakInterrupt();
         public BreakInterrupt()
             : base("Misplaced 'break' statement")
         {
@@ -18,6 +19,7 @@ namespace DotLiquid.Exceptions
 
     public class ContinueInterrupt : InterruptException
     {
+        public static readonly ContinueInterrupt Instance = new ContinueInterrupt();
         public ContinueInterrupt()
             : base("Misplaced 'continue' statement")
         {

--- a/src/DotLiquid/Liquid.cs
+++ b/src/DotLiquid/Liquid.cs
@@ -67,6 +67,7 @@ namespace DotLiquid
             Template.RegisterTag<Tags.Param>("param");
 
             Template.RegisterTag<Tags.Html.TableRow>("tablerow");
+            Template.RegisterTag<Tags.RenderTag>("render");
 
             Template.RegisterFilter(typeof(StandardFilters));
 

--- a/src/DotLiquid/PartialCache.cs
+++ b/src/DotLiquid/PartialCache.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using DotLiquid.FileSystems;
+
+namespace DotLiquid
+{
+    internal static class PartialCache
+    {
+        private const string PartialCacheKey = "cached_partials";
+        public static Template Load(string templateName, Context context)
+        {
+            var cachedPartials = context.Registers.Get<IDictionary<string, Template>>(PartialCacheKey);
+            if (cachedPartials == null)
+                context.Registers[PartialCacheKey] = cachedPartials = new Dictionary<string, Template>();
+            if (cachedPartials.TryGetValue(templateName, out var cached))
+                return cached;
+            Template partial = Fetch(templateName, context);
+            cachedPartials[templateName] = partial;
+            return partial;
+        }
+
+        public static Template Fetch(string templateNameExpr, Context context)
+        {
+            var fileSystem = context.Registers["file_system"] as IFileSystem ?? Template.FileSystem;
+            var templateFileSystem = fileSystem as ITemplateFileSystem;
+            Template partial = null;
+            if (templateFileSystem != null)
+            {
+                partial = templateFileSystem.GetTemplate(context, templateNameExpr);
+            }
+            if (partial == null)
+            {
+                var source = fileSystem.ReadTemplateFile(context, templateNameExpr);
+                partial = Template.Parse(source);
+            }
+            return partial;
+        }
+    }
+}

--- a/src/DotLiquid/Properties/Resources.it.resx
+++ b/src/DotLiquid/Properties/Resources.it.resx
@@ -201,6 +201,9 @@
   <data name="IncludeTagSyntaxException" xml:space="preserve">
     <value>Errore di sintassi nel tag 'include' - La sintassi corretta è: include [template]</value>
   </data>
+  <data name="RenderTagSyntaxException" xml:space="preserve">
+    <value>Errore di sintassi nel tag 'render' - La sintassi corretta è: render '[template]'</value>
+  </data>
   <data name="LocalFileSystemIllegalTemplateNameException" xml:space="preserve">
     <value>Errore - Nome di template non valido '{0}'</value>
   </data>

--- a/src/DotLiquid/Properties/Resources.it.resx
+++ b/src/DotLiquid/Properties/Resources.it.resx
@@ -246,4 +246,7 @@
   <data name="CultureNotFoundException" xml:space="preserve">
     <value>La cultura '{0}' non è supportata</value>
   </data>
+  <data name="TemplateNameArgumentException" xml:space="preserve">
+    <value>Errore di argomento nel tag '{0}' - Nome modello non valido</value>
+  </data>
 </root>

--- a/src/DotLiquid/Properties/Resources.resx
+++ b/src/DotLiquid/Properties/Resources.resx
@@ -201,6 +201,9 @@
   <data name="IncludeTagSyntaxException" xml:space="preserve">
     <value>Syntax Error in 'include' tag - Valid syntax: include [template]</value>
   </data>
+  <data name="RenderTagSyntaxException" xml:space="preserve">
+    <value>Syntax Error in 'render' tag - Valid syntax: render '[template]'</value>
+  </data>
   <data name="LocalFileSystemIllegalTemplateNameException" xml:space="preserve">
     <value>Error - Illegal template name '{0}'</value>
   </data>

--- a/src/DotLiquid/Properties/Resources.resx
+++ b/src/DotLiquid/Properties/Resources.resx
@@ -207,6 +207,9 @@
   <data name="LocalFileSystemIllegalTemplatePathException" xml:space="preserve">
     <value>Error - Illegal template path '{0}'</value>
   </data>
+  <data name="TemplateNameArgumentException" xml:space="preserve">
+    <value>Argument error in tag '{0}' - Illegal template name</value>
+  </data>
   <data name="LocalFileSystemTemplateNotFoundException" xml:space="preserve">
     <value>Error - No such template '{0}'</value>
   </data>

--- a/src/DotLiquid/Properties/Resources.resx
+++ b/src/DotLiquid/Properties/Resources.resx
@@ -255,4 +255,7 @@
   <data name="IncrementSyntaxException" xml:space="preserve">
     <value>Syntax Error in 'increment' tag - Valid syntax: increment [var]</value>
   </data>
+  <data name="DisabledTagException" xml:space="preserve">
+    <value>{0} usage is not allowed in this context</value>
+  </data>
 </root>

--- a/src/DotLiquid/SyntaxCompatibilityEnum.cs
+++ b/src/DotLiquid/SyntaxCompatibilityEnum.cs
@@ -24,5 +24,10 @@ namespace DotLiquid
         /// Behavior as of DotLiquid 2.2a
         /// </summary>
         DotLiquid22a = 221,
+
+        /// <summary>
+        /// Behavior as of DotLiquid 2.2b
+        /// </summary>
+        DotLiquid22b = 222,
     }
 }

--- a/src/DotLiquid/Tag.cs
+++ b/src/DotLiquid/Tag.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using DotLiquid.Exceptions;
 
 namespace DotLiquid
 {
@@ -73,6 +74,25 @@ namespace DotLiquid
         /// <param name="result"></param>
         public virtual void Render(Context context, TextWriter result)
         {
+        }
+
+        /// <summary>
+        /// Renders the tag
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="result"></param>
+        void IRenderable.Render(Context context, TextWriter result)
+        {
+            DoRender(context, result);
+        }
+
+        private void DoRender(Context context, TextWriter result)
+        {
+            if (TagName != null && context.IsTagDisabled(TagName))
+            {
+                throw new DisabledException(Liquid.ResourceManager.GetString("DisabledTagException"), TagName);
+            }
+            Render(context, result);
         }
 
         /// <summary>

--- a/src/DotLiquid/Tags/Break.cs
+++ b/src/DotLiquid/Tags/Break.cs
@@ -7,7 +7,7 @@ namespace DotLiquid.Tags
     {
         public override void Render(Context context, TextWriter result)
         {
-            throw new BreakInterrupt();
+            context.PushInterrupt(BreakInterrupt.Instance);
         }
     }
 }

--- a/src/DotLiquid/Tags/Continue.cs
+++ b/src/DotLiquid/Tags/Continue.cs
@@ -7,7 +7,7 @@ namespace DotLiquid.Tags
     {
         public override void Render(Context context, TextWriter result)
         {
-            throw new ContinueInterrupt();
+            context.PushInterrupt(ContinueInterrupt.Instance);
         }
     }
 }

--- a/src/DotLiquid/Tags/For.cs
+++ b/src/DotLiquid/Tags/For.cs
@@ -182,17 +182,12 @@ namespace DotLiquid.Tags
                         ["last"] = (index == length - 1)
                     };
 
-                    try
+                    RenderAll(ForBlock, context, result);
+                    if (context.IsInterrupt())
                     {
-                        RenderAll(ForBlock, context, result);
-                    }
-                    catch (BreakInterrupt)
-                    {
-                        break;
-                    }
-                    catch (ContinueInterrupt)
-                    {
-                        // ContinueInterrupt is used only to skip the current value but not to stop the iteration
+                        var interrupt = context.PopInterrupt();
+                        if (interrupt is BreakInterrupt)
+                            break;
                     }
                 }
             });

--- a/src/DotLiquid/Tags/For.cs
+++ b/src/DotLiquid/Tags/For.cs
@@ -170,16 +170,9 @@ namespace DotLiquid.Tags
 
                     // Ensure the 'for-loop' object is available to templates.
                     // See: https://shopify.dev/api/liquid/objects/for-loops
-                    context["forloop"] = new Dictionary<string, object>
+                    context["forloop"] = new ForloopDrop(length, index)
                     {
-                        ["name"] = _name,
-                        ["length"] = length,
-                        ["index"] = index + 1,
-                        ["index0"] = index,
-                        ["rindex"] = length - index,
-                        ["rindex0"] = length - index - 1,
-                        ["first"] = (index == 0),
-                        ["last"] = (index == length - 1)
+                        Name = _name
                     };
 
                     RenderAll(ForBlock, context, result);

--- a/src/DotLiquid/Tags/ForloopDrop.cs
+++ b/src/DotLiquid/Tags/ForloopDrop.cs
@@ -1,0 +1,24 @@
+﻿namespace DotLiquid.Tags
+{
+    public class ForloopDrop : Drop
+    {
+        public ForloopDrop(int length, int index)
+        {
+            Length = length;
+            Index = index + 1;
+            Index0 = index;
+            Rindex = length - index;
+            Rindex0 = length - index - 1;
+            First = index == 0;
+            Last = index == length - 1;
+        }
+        public int Length { get; }
+        public int Index { get; }
+        public int Index0 { get; }
+        public int Rindex { get; }
+        public int Rindex0 { get; }
+        public bool First { get; }
+        public bool Last { get; }
+        public string Name { get; set; }
+    }
+}

--- a/src/DotLiquid/Tags/Include.cs
+++ b/src/DotLiquid/Tags/Include.cs
@@ -61,9 +61,9 @@ namespace DotLiquid.Tags
                 foreach (var keyValue in _attributes)
                     context[keyValue.Key] = context[keyValue.Value];
 
-                if (variable is IEnumerable)
+                if (variable is IEnumerable enumerable && !(variable is string))
                 {
-                    ((IEnumerable) variable).Cast<object>().ToList().ForEach(v =>
+                    enumerable.Cast<object>().ToList().ForEach(v =>
                     {
                         context[shortenedTemplateName] = v;
                         partial.Render(result, RenderParameters.FromContext(context, result.FormatProvider));

--- a/src/DotLiquid/Tags/Include.cs
+++ b/src/DotLiquid/Tags/Include.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using DotLiquid.Exceptions;
-using DotLiquid.FileSystems;
 using DotLiquid.Util;
 
 namespace DotLiquid.Tags
@@ -40,22 +39,20 @@ namespace DotLiquid.Tags
 
         public override void Render(Context context, TextWriter result)
         {
-            IFileSystem fileSystem = context.Registers["file_system"] as IFileSystem ?? Template.FileSystem;
-            ITemplateFileSystem templateFileSystem = fileSystem as ITemplateFileSystem;
-            Template partial = null;
-            if (templateFileSystem != null)
+            Template partial;
+            if (context.SyntaxCompatibilityLevel >= SyntaxCompatibility.DotLiquid22b)
             {
-                partial = templateFileSystem.GetTemplate(context, _templateName);
+                if (!(context[_templateName] is string templateName))
+                    throw new Exceptions.ArgumentException(Liquid.ResourceManager.GetString("TemplateNameArgumentException"), TagName);
+                partial = PartialCache.Load(templateName, context);
             }
-            if (partial == null)
+            else
             {
-                string source = fileSystem.ReadTemplateFile(context, _templateName);
-                partial = Template.Parse(source);
+                partial = PartialCache.Fetch(_templateName, context);
             }
 
-            string shortenedTemplateName = _templateName.Substring(1, _templateName.Length - 2);
-            object variable = context[_variableName ?? shortenedTemplateName, _variableName != null];
-
+            var contextVariableName = _templateName.Substring(1, _templateName.Length - 2);;
+            object variable = context[_variableName ?? contextVariableName, _variableName != null];
             context.Stack(() =>
             {
                 foreach (var keyValue in _attributes)
@@ -65,14 +62,16 @@ namespace DotLiquid.Tags
                 {
                     enumerable.Cast<object>().ToList().ForEach(v =>
                     {
-                        context[shortenedTemplateName] = v;
+                        context[contextVariableName] = v;
                         partial.Render(result, RenderParameters.FromContext(context, result.FormatProvider));
                     });
-                    return;
+                }
+                else
+                {
+                    context[contextVariableName] = variable;
+                    partial.Render(result, RenderParameters.FromContext(context, result.FormatProvider));
                 }
 
-                context[shortenedTemplateName] = variable;
-                partial.Render(result, RenderParameters.FromContext(context, result.FormatProvider));
             });
         }
     }

--- a/src/DotLiquid/Tags/RenderTag.cs
+++ b/src/DotLiquid/Tags/RenderTag.cs
@@ -1,0 +1,86 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using DotLiquid.Exceptions;
+using DotLiquid.Util;
+
+namespace DotLiquid.Tags
+{
+    public class RenderTag : DotLiquid.Block
+    {
+        private const string For = "for";
+        private static readonly Regex Syntax = R.B(@"({0}+)(\s+(with|{1})\s+({2}+)(?:\s+as\s+({3}+))?)?", Liquid.QuotedString, For, Liquid.QuotedFragment, Liquid.VariableSegment);
+        private static readonly string[] DisabledTags = { "include" };
+
+        private string _templateNameExpr, _variableNameExpr, _aliasName;
+        private Dictionary<string, string> _attributes;
+        private bool IsForLoop { get; set; }
+
+        public override void Initialize(string tagName, string markup, List<string> tokens)
+        {
+            var syntaxMatch = Syntax.Match(markup);
+            if (syntaxMatch.Success)
+            {
+                _templateNameExpr = syntaxMatch.Groups[1].Value;
+                var withOrFor = syntaxMatch.Groups[3].Value;
+                _variableNameExpr = syntaxMatch.Groups[4].Value;
+                _aliasName = syntaxMatch.Groups[5].Value;
+                if (_variableNameExpr == string.Empty)
+                    _variableNameExpr = null;
+                if (_aliasName == string.Empty)
+                    _aliasName = null;
+                if (withOrFor == string.Empty)
+                    withOrFor = null;
+                IsForLoop = withOrFor == For;
+                _attributes = new Dictionary<string, string>(Template.NamingConvention.StringComparer);
+                R.Scan(markup, Liquid.TagAttributes, (key, value) => _attributes[key] = value);
+            }
+            else
+                throw new SyntaxException(Liquid.ResourceManager.GetString("RenderTagSyntaxException"));
+
+            base.Initialize(tagName, markup, tokens);
+        }
+
+        protected override void Parse(List<string> tokens)
+        {
+        }
+
+        public override void Render(Context context, TextWriter result)
+        {
+            if (!(context[_templateNameExpr] is string templateName))
+                throw new Exceptions.ArgumentException(Liquid.ResourceManager.GetString("TemplateNameArgumentException"), TagName);
+            var partial = PartialCache.Load(templateName, context);
+            var contextVariableName = _aliasName ?? templateName;
+            var variable = _variableNameExpr != null ? context[_variableNameExpr] : null;
+
+            context.WithDisabledTags(DisabledTags, () =>
+            {
+                if (IsForLoop && variable is IEnumerable c && !(variable is string))
+                {
+                    var items = c.Cast<object>().ToList();
+                    var length = items.Count;
+                    for (var index = 0; index < length; index++)
+                        RenderPartial(items[index], new ForloopDrop(length, index));
+                }
+                else
+                {
+                    RenderPartial(variable, null);
+                }
+            });
+
+            void RenderPartial(object var, ForloopDrop forloop)
+            {
+                var innerContext = context.NewIsolatedContext();
+                if (forloop != null)
+                    innerContext["forloop"] = forloop;
+                foreach (var keyValue in _attributes)
+                    innerContext[keyValue.Key] = context[keyValue.Value];
+                if (var != null)
+                    innerContext[contextVariableName] = var;
+                partial.Render(result, RenderParameters.FromContext(innerContext, result.FormatProvider));
+            }
+        }
+    }
+}

--- a/src/DotLiquid/Template.cs
+++ b/src/DotLiquid/Template.cs
@@ -49,7 +49,7 @@ namespace DotLiquid
         /// </summary>
         public static bool DefaultIsThreadSafe { get; set; }
 
-        private static Dictionary<string, Tuple<ITagFactory, Type>> Tags { get; set; }
+        internal static Dictionary<string, Tuple<ITagFactory, Type>> Tags { get; set; }
 
         /// <summary>
         /// TimeOut used for all Regex in DotLiquid


### PR DESCRIPTION
- port render tag from ruby implementation. Render tag like include tag but more strict in term scope. for more detail here https://shopify.github.io/liquid/tags/template#render
- this PR include extra feature: the ability to disable tags. for example:
```csharp
var context = new Context(CultureInfo.InvariantCulture);
context.WithDisabledTags(new [] { "include" }, () =>
{
    Assert.AreEqual("include usage is not allowed in this context", Template.Parse("{% include 'foo' %}").Render(RenderParameters.FromContext(context, context.FormatProvider)))
});
```