### PR TITLE
Fix floating numbers parse and respect culture

### DIFF
--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -1735,9 +1735,6 @@ PaulGeorge",
             Helper.AssertTemplateResult(
                 expected: "4",
                 template: "{{ 4 | abs }}");
-            Helper.AssertTemplateResult(
-                expected: "19,86",
-                template: "{{ '-19,86' | abs }}");
         }
 
         [Test]

--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -1407,7 +1407,7 @@ PaulGeorge",
 
                 Assert.Null(StandardFilters.Ceil(_contextV20, ""));
                 Assert.Null(StandardFilters.Ceil(_contextV20, "two"));
-                Assert.AreEqual(4, StandardFilters.Ceil(_contextGreekCultureV20, 3.5));
+                Assert.AreEqual(4, StandardFilters.Ceil(_contextGreekCultureV20, "3,5"));
             }
         }
 
@@ -1438,7 +1438,7 @@ PaulGeorge",
 
                 Assert.Null(StandardFilters.Floor(_contextV20, ""));
                 Assert.Null(StandardFilters.Floor(_contextV20, "two"));
-                Assert.AreEqual(3, StandardFilters.Floor(_contextGreekCultureV20, 3.5));
+                Assert.AreEqual(3, StandardFilters.Floor(_contextGreekCultureV20, "3,5"));
             }
         }
 
@@ -1726,15 +1726,19 @@ PaulGeorge",
             Assert.AreEqual(30.60, StandardFilters.Abs(_contextGreekCultureV20, "30,60"));
             Assert.AreEqual(0, StandardFilters.Abs(_contextGreekCultureV20, "30,60a"));
 
-            Helper.AssertTemplateResult(
-                expected: "17",
-                template: "{{ -17 | abs }}");
-            Helper.AssertTemplateResult(
-                expected: "17",
-                template: "{{ 17 | abs }}");
-            Helper.AssertTemplateResult(
-                expected: "4",
-                template: "{{ 4 | abs }}");
+            using (CultureHelper.SetCulture("el-GR"))
+            {
+                Helper.AssertTemplateResult(
+                    expected: "17,5",
+                    template: "{{ -17,5 | abs }}");
+                Helper.AssertTemplateResult(
+                    expected: "17,5",
+                    template: "{{ 17,5 | abs }}");
+                Helper.AssertTemplateResult(
+                    expected: "4,5",
+                    template: "{{ 4,5 | abs }}");
+            }
+            
         }
 
         [Test]
@@ -1775,12 +1779,38 @@ PaulGeorge",
             Assert.AreEqual("10a", StandardFilters.AtLeast(_contextGreekCultureV20, "10a", 5));
             Assert.AreEqual("4b", StandardFilters.AtLeast(_contextGreekCultureV20, "4b", 5));
 
-            Helper.AssertTemplateResult(
+            using (CultureHelper.SetCulture("el-GR"))
+            {
+                Helper.AssertTemplateResult(
                 expected: "5",
-                template: "{{ 4 | at_least: 5 }}");
+                template: "{{ 4,5 | at_least: 5 }}");
+                Helper.AssertTemplateResult(
+                    expected: "4,5",
+                    template: "{{ 4,5 | at_least: 3 }}");
+            }
+        }
+
+        [Test]
+        public void TestAtMost()
+        {
+            Assert.AreEqual("notNumber", StandardFilters.AtMost(_contextV20, "notNumber", 5));
+            Assert.AreEqual(5, StandardFilters.AtMost(_contextV20, 5, 5));
+            Assert.AreEqual(3, StandardFilters.AtMost(_contextV20, 3, 5));
+            Assert.AreEqual(5, StandardFilters.AtMost(_contextV20, 6, 5));
+            Assert.AreEqual(5, StandardFilters.AtMost(_contextV20, 10, 5));
+            Assert.AreEqual(5, StandardFilters.AtMost(_contextV20, 9.85, 5));
+            Assert.AreEqual(3.56, StandardFilters.AtMost(_contextV20, 3.56, 5));
+            Assert.AreEqual(5, StandardFilters.AtMost(_contextV20, "10", 5));
+            Assert.AreEqual(4, StandardFilters.AtMost(_contextV20, "4", 5));
+            Assert.AreEqual("4a", StandardFilters.AtMost(_contextV20, "4a", 5));
+            Assert.AreEqual("10b", StandardFilters.AtMost(_contextV20, "10b", 5));
+
             Helper.AssertTemplateResult(
                 expected: "4",
-                template: "{{ 4 | at_least: 3 }}");
+                template: "{{ 4 | at_most: 5 }}");
+            Helper.AssertTemplateResult(
+                expected: "3",
+                template: "{{ 4 | at_most: 3 }}");
         }
 
         [Test]
@@ -1798,12 +1828,15 @@ PaulGeorge",
             Assert.AreEqual("4a", StandardFilters.AtMost(_contextGreekCultureV20, "4a", 5));
             Assert.AreEqual("10b", StandardFilters.AtMost(_contextGreekCultureV20, "10b", 5));
 
-            Helper.AssertTemplateResult(
-                expected: "4",
-                template: "{{ 4 | at_most: 5 }}");
-            Helper.AssertTemplateResult(
-                expected: "3",
-                template: "{{ 4 | at_most: 3 }}");
+            using (CultureHelper.SetCulture("el-GR"))
+            {
+                Helper.AssertTemplateResult(
+                expected: "4,5",
+                template: "{{ 4,5 | at_most: 5 }}");
+                Helper.AssertTemplateResult(
+                    expected: "3",
+                    template: "{{ 4,5 | at_most: 3 }}");
+            }
         }
 
         [Test]

--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -13,6 +13,7 @@ namespace DotLiquid.Tests
     public class StandardFilterTests
     {
         private Context _contextV20;
+        private Context _contextGreekCultureV20;
         private Context _contextV21;
         private Context _contextV22;
         private Context _contextV22a;
@@ -35,6 +36,10 @@ namespace DotLiquid.Tests
             _contextV22a = new Context(CultureInfo.InvariantCulture)
             {
                 SyntaxCompatibilityLevel = SyntaxCompatibility.DotLiquid22a
+            };
+            _contextGreekCultureV20 = new Context(new CultureInfo("el-GR"))
+            {
+                SyntaxCompatibilityLevel = SyntaxCompatibility.DotLiquid20
             };
         }
 
@@ -1389,6 +1394,23 @@ PaulGeorge",
             }
         }
 
+
+        [Test]
+        public void TestCeil_DifferentCultureDecimalSeparator()
+        {
+            using (CultureHelper.SetCulture("el-GR"))
+            {
+                Helper.AssertTemplateResult("2", "{{ 1,2 | ceil }}");
+                Helper.AssertTemplateResult("2", "{{ 2,0 | ceil }}");
+                Helper.AssertTemplateResult("184", "{{ 183,357 | ceil }}");
+                Helper.AssertTemplateResult("4", "{{ \"3,5\" | ceil }}");
+
+                Assert.Null(StandardFilters.Ceil(_contextV20, ""));
+                Assert.Null(StandardFilters.Ceil(_contextV20, "two"));
+                Assert.AreEqual(4, StandardFilters.Ceil(_contextGreekCultureV20, 3.5));
+            }
+        }
+
         [Test]
         public void TestFloor()
         {
@@ -1401,6 +1423,22 @@ PaulGeorge",
 
                 Assert.Null(StandardFilters.Floor(_contextV20, ""));
                 Assert.Null(StandardFilters.Floor(_contextV20, "two"));
+            }
+        }
+
+        [Test]
+        public void TestFloor_DifferentCultureDecimalSeparator()
+        {
+            using (CultureHelper.SetCulture("el-GR"))
+            {
+                Helper.AssertTemplateResult("1", "{{ 1,2 | floor }}");
+                Helper.AssertTemplateResult("2", "{{ 2,0 | floor }}");
+                Helper.AssertTemplateResult("183", "{{ 183,357 | floor }}");
+                Helper.AssertTemplateResult("3", "{{ \"3,5\" | floor }}");
+
+                Assert.Null(StandardFilters.Floor(_contextV20, ""));
+                Assert.Null(StandardFilters.Floor(_contextV20, "two"));
+                Assert.AreEqual(3, StandardFilters.Floor(_contextGreekCultureV20, 3.5));
             }
         }
 
@@ -1676,6 +1714,33 @@ PaulGeorge",
         }
 
         [Test]
+        public void TestAbs_DifferentCultureDecimalSeparator()
+        {
+            Assert.AreEqual(0, StandardFilters.Abs(_contextGreekCultureV20, "notNumber"));
+            Assert.AreEqual(10, StandardFilters.Abs(_contextGreekCultureV20, 10));
+            Assert.AreEqual(5, StandardFilters.Abs(_contextGreekCultureV20, -5));
+            Assert.AreEqual(19.86, StandardFilters.Abs(_contextGreekCultureV20, 19.86));
+            Assert.AreEqual(19.86, StandardFilters.Abs(_contextGreekCultureV20, -19.86));
+            Assert.AreEqual(10, StandardFilters.Abs(_contextGreekCultureV20, "10"));
+            Assert.AreEqual(5, StandardFilters.Abs(_contextGreekCultureV20, "-5"));
+            Assert.AreEqual(30.60, StandardFilters.Abs(_contextGreekCultureV20, "30,60"));
+            Assert.AreEqual(0, StandardFilters.Abs(_contextGreekCultureV20, "30,60a"));
+
+            Helper.AssertTemplateResult(
+                expected: "17",
+                template: "{{ -17 | abs }}");
+            Helper.AssertTemplateResult(
+                expected: "17",
+                template: "{{ 17 | abs }}");
+            Helper.AssertTemplateResult(
+                expected: "4",
+                template: "{{ 4 | abs }}");
+            Helper.AssertTemplateResult(
+                expected: "19,86",
+                template: "{{ '-19,86' | abs }}");
+        }
+
+        [Test]
         public void TestAtLeast()
         {
             Assert.AreEqual("notNumber", StandardFilters.AtLeast(_contextV20, "notNumber", 5));
@@ -1699,19 +1764,42 @@ PaulGeorge",
         }
 
         [Test]
-        public void TestAtMost()
+        public void TestAtLeast_DifferentCultureDecimalSeparator()
         {
-            Assert.AreEqual("notNumber", StandardFilters.AtMost(_contextV20, "notNumber", 5));
-            Assert.AreEqual(5, StandardFilters.AtMost(_contextV20, 5, 5));
-            Assert.AreEqual(3, StandardFilters.AtMost(_contextV20, 3, 5));
-            Assert.AreEqual(5, StandardFilters.AtMost(_contextV20, 6, 5));
-            Assert.AreEqual(5, StandardFilters.AtMost(_contextV20, 10, 5));
-            Assert.AreEqual(5, StandardFilters.AtMost(_contextV20, 9.85, 5));
-            Assert.AreEqual(3.56, StandardFilters.AtMost(_contextV20, 3.56, 5));
-            Assert.AreEqual(5, StandardFilters.AtMost(_contextV20, "10", 5));
+            Assert.AreEqual("notNumber", StandardFilters.AtLeast(_contextGreekCultureV20, "notNumber", 5));
+            Assert.AreEqual(5, StandardFilters.AtLeast(_contextGreekCultureV20, 5, 5));
+            Assert.AreEqual(5, StandardFilters.AtLeast(_contextGreekCultureV20, 3, 5));
+            Assert.AreEqual(6, StandardFilters.AtLeast(_contextGreekCultureV20, 6, 5));
+            Assert.AreEqual(10, StandardFilters.AtLeast(_contextGreekCultureV20, 10, 5));
+            Assert.AreEqual(9.85, StandardFilters.AtLeast(_contextGreekCultureV20, 9.85, 5));
+            Assert.AreEqual(5, StandardFilters.AtLeast(_contextGreekCultureV20, 3.56, 5));
+            Assert.AreEqual(10, StandardFilters.AtLeast(_contextGreekCultureV20, "10", 5));
+            Assert.AreEqual(5, StandardFilters.AtLeast(_contextGreekCultureV20, "4", 5));
+            Assert.AreEqual("10a", StandardFilters.AtLeast(_contextGreekCultureV20, "10a", 5));
+            Assert.AreEqual("4b", StandardFilters.AtLeast(_contextGreekCultureV20, "4b", 5));
+
+            Helper.AssertTemplateResult(
+                expected: "5",
+                template: "{{ 4 | at_least: 5 }}");
+            Helper.AssertTemplateResult(
+                expected: "4",
+                template: "{{ 4 | at_least: 3 }}");
+        }
+
+        [Test]
+        public void TestAtMost_DifferentCultureDecimalSeparator()
+        {
+            Assert.AreEqual("notNumber", StandardFilters.AtMost(_contextGreekCultureV20, "notNumber", 5));
+            Assert.AreEqual(5, StandardFilters.AtMost(_contextGreekCultureV20, 5, 5));
+            Assert.AreEqual(3, StandardFilters.AtMost(_contextGreekCultureV20, 3, 5));
+            Assert.AreEqual(5, StandardFilters.AtMost(_contextGreekCultureV20, 6, 5));
+            Assert.AreEqual(5, StandardFilters.AtMost(_contextGreekCultureV20, 10, 5));
+            Assert.AreEqual(5, StandardFilters.AtMost(_contextGreekCultureV20, 9.85, 5));
+            Assert.AreEqual(3.56, StandardFilters.AtMost(_contextGreekCultureV20, 3.56, 5));
+            Assert.AreEqual(5, StandardFilters.AtMost(_contextGreekCultureV20, "10", 5));
             Assert.AreEqual(4, StandardFilters.AtMost(_contextV20, "4", 5));
-            Assert.AreEqual("4a", StandardFilters.AtMost(_contextV20, "4a", 5));
-            Assert.AreEqual("10b", StandardFilters.AtMost(_contextV20, "10b", 5));
+            Assert.AreEqual("4a", StandardFilters.AtMost(_contextGreekCultureV20, "4a", 5));
+            Assert.AreEqual("10b", StandardFilters.AtMost(_contextGreekCultureV20, "10b", 5));
 
             Helper.AssertTemplateResult(
                 expected: "4",

--- a/src/DotLiquid/StandardFilters.cs
+++ b/src/DotLiquid/StandardFilters.cs
@@ -783,7 +783,7 @@ namespace DotLiquid
         /// <returns>The rounded value; null if an exception have occurred</returns>
         public static object Ceil(Context context, object input)
         {
-            if (decimal.TryParse(input.ToString(), NumberStyles.Any, context.CurrentCulture, out decimal d))
+            if (decimal.TryParse(Convert.ToString(input, context.CurrentCulture), NumberStyles.Any, context.CurrentCulture, out decimal d))
                 return Math.Ceiling(d);
             else
                 return null;
@@ -797,7 +797,7 @@ namespace DotLiquid
         /// <returns>The rounded value; null if an exception have occurred</returns>
         public static object Floor(Context context, object input)
         {
-            if (decimal.TryParse(input.ToString(), NumberStyles.Any, context.CurrentCulture, out decimal d))
+            if (decimal.TryParse(Convert.ToString(input, context.CurrentCulture), NumberStyles.Any, context.CurrentCulture, out decimal d))
                 return Math.Floor(d);
             else
                 return null;
@@ -915,7 +915,7 @@ namespace DotLiquid
         public static double Abs(Context context, object input)
         {
             Double n;
-            return Double.TryParse(input.ToString(), NumberStyles.Number, context.CurrentCulture, out n) ? Math.Abs(n) : 0;
+            return Double.TryParse(Convert.ToString(input, context.CurrentCulture), NumberStyles.Number, context.CurrentCulture, out n) ? Math.Abs(n) : 0;
         }
 
         /// <summary>
@@ -927,10 +927,10 @@ namespace DotLiquid
         public static object AtLeast(Context context, object input, object atLeast)
         {
             double n;
-            var inputNumber = Double.TryParse(input.ToString(), NumberStyles.Number, context.CurrentCulture, out n);
+            var inputNumber = Double.TryParse(Convert.ToString(input, context.CurrentCulture), NumberStyles.Number, context.CurrentCulture, out n);
 
             double min;
-            var atLeastNumber = Double.TryParse(atLeast.ToString(), NumberStyles.Number, context.CurrentCulture, out min);
+            var atLeastNumber = Double.TryParse(Convert.ToString(atLeast, context.CurrentCulture), NumberStyles.Number, context.CurrentCulture, out min);
 
             if (inputNumber && atLeastNumber)
             {
@@ -951,10 +951,10 @@ namespace DotLiquid
         public static object AtMost(Context context, object input, object atMost)
         {
             double n;
-            var inputNumber = Double.TryParse(input.ToString(), NumberStyles.Number, context.CurrentCulture, out n);
+            var inputNumber = Double.TryParse(Convert.ToString(input,context.CurrentCulture), NumberStyles.Number, context.CurrentCulture, out n);
 
             double max;
-            var atMostNumber = Double.TryParse(atMost.ToString(), NumberStyles.Number, context.CurrentCulture, out max);
+            var atMostNumber = Double.TryParse(Convert.ToString(atMost, context.CurrentCulture), NumberStyles.Number, context.CurrentCulture, out max);
 
             if (inputNumber && atMostNumber)
             {


### PR DESCRIPTION
Fix StandardFilters methods that parses object to string, that fixes floating point numbers with current that has different decimal separator such as comma.