### PR TITLE
Fix Condition when right operand is null (contains, startswith, endswith)

### DIFF
--- a/src/DotLiquid.Tests/ConditionTests.cs
+++ b/src/DotLiquid.Tests/ConditionTests.cs
@@ -128,6 +128,8 @@ namespace DotLiquid.Tests
             AssertEvaluatesTrue("'bob'", "contains", "'bo'");
             AssertEvaluatesTrue("'bob'", "contains", "'ob'");
             AssertEvaluatesTrue("'bob'", "contains", "'bob'");
+            AssertEvaluatesTrue("'bob'", "contains", "''");
+            AssertEvaluatesTrue("''", "contains", "''");
 
             AssertEvaluatesFalse("'bob'", "contains", "'bob2'");
             AssertEvaluatesFalse("'bob'", "contains", "'a'");
@@ -343,6 +345,8 @@ namespace DotLiquid.Tests
             AssertEvaluatesTrue("'dave'", "startswith", "'da'");
             AssertEvaluatesTrue("'dave'", "startswith", "'dav'");
             AssertEvaluatesTrue("'dave'", "startswith", "'dave'");
+            AssertEvaluatesTrue("'dave'", "startswith", "''");
+            AssertEvaluatesTrue("''", "startswith", "''");
 
             AssertEvaluatesFalse("'dave'", "startswith", "'ave'");
             AssertEvaluatesFalse("'dave'", "startswith", "'e'");
@@ -379,6 +383,8 @@ namespace DotLiquid.Tests
             AssertEvaluatesTrue("'dave'", "endswith", "'ve'");
             AssertEvaluatesTrue("'dave'", "endswith", "'ave'");
             AssertEvaluatesTrue("'dave'", "endswith", "'dave'");
+            AssertEvaluatesTrue("'dave'", "endswith", "''");
+            AssertEvaluatesTrue("''", "endswith", "''");
 
             AssertEvaluatesFalse("'dave'", "endswith", "'dav'");
             AssertEvaluatesFalse("'dave'", "endswith", "'d'");

--- a/src/DotLiquid.Tests/ConditionTests.cs
+++ b/src/DotLiquid.Tests/ConditionTests.cs
@@ -170,6 +170,38 @@ namespace DotLiquid.Tests
         }
 
         [Test]
+        public void TestStringInIntArrays()
+        {
+            // NOTE(Rodney Richardson): DotLiquid is inconsistent with string to numeric conversions.
+            // One of these places is the contains and startswith/endswith implementations.
+            // - contains will return false when looking for a string in an int array
+            // - startswith and endswith will return true.
+            _context = new Context(CultureInfo.InvariantCulture);
+            _context["array"] = new[] { 1, 2, 3, 4, 5 };
+
+            AssertEvaluatesFalse(left: "array", op: "contains", right: "'1'");
+
+            AssertEvaluatesTrue(left: "array", op: "startswith", right: "'1'");
+            AssertEvaluatesTrue(left: "array", op: "endswith", right: "'5'");
+        }
+
+        [Test]
+        public void TestIntInStringArrays()
+        {
+            // NOTE(Rodney Richardson): DotLiquid is inconsistent with string to numeric conversions.
+            // One of these places is the contains and startswith/endswith implementations.
+            // - contains will return false when looking for an int in a string array
+            // - startswith and endswith will return true.
+            _context = new Context(CultureInfo.InvariantCulture);
+            _context["array"] = new[] { "1", "2", "3", "4", "5" };
+
+            AssertEvaluatesFalse(left: "array", op: "contains", right: "1");
+
+            AssertEvaluatesTrue(left: "array", op: "startswith", right: "1");
+            AssertEvaluatesTrue(left: "array", op: "endswith", right: "5");
+        }
+
+        [Test]
         public void TestContainsWorksOnLongArrays()
         {
             _context = new Context(CultureInfo.InvariantCulture);
@@ -365,6 +397,8 @@ namespace DotLiquid.Tests
             AssertEvaluatesTrue("array", "startswith", "1");
 
             AssertEvaluatesFalse("array", "startswith", "not_assigned");
+            AssertEvaluatesFalse("array", "startswith", "''");
+            AssertEvaluatesFalse("array", "startswith", null);
         }
 
         [Test]
@@ -403,6 +437,8 @@ namespace DotLiquid.Tests
             AssertEvaluatesTrue("array", "endswith", "5");
 
             AssertEvaluatesFalse("array", "endswith", "not_assigned");
+            AssertEvaluatesFalse("array", "endswith", "''");
+            AssertEvaluatesFalse("array", "endswith", null);
         }
 
         [Test]

--- a/src/DotLiquid.Tests/ConditionTests.cs
+++ b/src/DotLiquid.Tests/ConditionTests.cs
@@ -134,6 +134,11 @@ namespace DotLiquid.Tests
             AssertEvaluatesFalse("'bob'", "contains", "'---'");
 
             AssertEvaluatesFalse("'bob'", "contains", "not_assigned");
+            AssertEvaluatesFalse("not_assigned", "contains", "'bob'");
+
+            AssertEvaluatesFalse(null, "contains", "'bob'");
+            AssertEvaluatesFalse("'bob'", "contains", null);
+            AssertEvaluatesFalse(null, "contains", null);
         }
 
         [Test]
@@ -156,6 +161,7 @@ namespace DotLiquid.Tests
             AssertEvaluatesFalse(left: "array", op: "contains", right: "6");
 
             AssertEvaluatesFalse("array", "contains", "not_assigned");
+            AssertEvaluatesFalse("array", "contains", null);
 
             // NOTE(daviburg): Historically testing for equality cross integer and string boundaries resulted in not equal.
             AssertEvaluatesFalse(left: "array", op: "contains", right: "'1'");
@@ -178,6 +184,7 @@ namespace DotLiquid.Tests
 
             AssertEvaluatesFalse("array", "contains", "'1'");
             AssertEvaluatesFalse("array", "contains", "not_assigned");
+            AssertEvaluatesFalse("array", "contains", null);
         }
 
         [Test]
@@ -202,6 +209,7 @@ namespace DotLiquid.Tests
             AssertEvaluatesFalse(left: "array", op: "contains", right: "'Orang'");
 
             AssertEvaluatesTrue("array", "contains", "not_assigned");
+            AssertEvaluatesTrue("array", "contains", null);
             AssertEvaluatesFalse("array", "startswith", "not_assigned");
             AssertEvaluatesFalse("array", "endswith", "not_assigned");
         }
@@ -226,6 +234,7 @@ namespace DotLiquid.Tests
             AssertEvaluatesFalse(left: "array", op: "contains", right: "camry");
 
             AssertEvaluatesFalse("array", "contains", "not_assigned");
+            AssertEvaluatesFalse("array", "contains", null);
             AssertEvaluatesFalse("array", "startswith", "not_assigned");
             AssertEvaluatesFalse("array", "endswith", "not_assigned");
         }
@@ -246,6 +255,7 @@ namespace DotLiquid.Tests
             AssertEvaluatesFalse(left: "array", op: "contains", right: "'true'"); // to be re-evaluated in #362
 
             AssertEvaluatesFalse("array", "contains", "not_assigned");
+            AssertEvaluatesFalse("array", "contains", null);
             AssertEvaluatesFalse("array", "startswith", "not_assigned");
             AssertEvaluatesFalse("array", "endswith", "not_assigned");
         }
@@ -270,6 +280,7 @@ namespace DotLiquid.Tests
             AssertEvaluatesTrue(left: "array", op: "endsWith", right: "last");
 
             AssertEvaluatesFalse("array", "contains", "not_assigned");
+            AssertEvaluatesFalse("array", "contains", null);
             AssertEvaluatesFalse("array", "startswith", "not_assigned");
             AssertEvaluatesFalse("array", "endswith", "not_assigned");
         }
@@ -292,6 +303,7 @@ namespace DotLiquid.Tests
             AssertEvaluatesTrue(left: "array", op: "endsWith", right: "last");
 
             AssertEvaluatesFalse("array", "contains", "not_assigned");
+            AssertEvaluatesFalse("array", "contains", null);
             AssertEvaluatesFalse("array", "startswith", "not_assigned");
             AssertEvaluatesFalse("array", "endswith", "not_assigned");
         }
@@ -312,6 +324,7 @@ namespace DotLiquid.Tests
 
             AssertEvaluatesFalse("array", "contains", "'1'");
             AssertEvaluatesFalse("array", "contains", "not_assigned");
+            AssertEvaluatesFalse("array", "contains", null);
         }
 
         [Test]

--- a/src/DotLiquid.Tests/ConditionTests.cs
+++ b/src/DotLiquid.Tests/ConditionTests.cs
@@ -126,6 +126,8 @@ namespace DotLiquid.Tests
             AssertEvaluatesFalse("'bob'", "contains", "'bob2'");
             AssertEvaluatesFalse("'bob'", "contains", "'a'");
             AssertEvaluatesFalse("'bob'", "contains", "'---'");
+
+            AssertEvaluatesFalse("'bob'", "contains", "not_assigned");
         }
 
         [Test]
@@ -147,6 +149,8 @@ namespace DotLiquid.Tests
             AssertEvaluatesTrue(left: "array", op: "contains", right: "5");
             AssertEvaluatesFalse(left: "array", op: "contains", right: "6");
 
+            AssertEvaluatesFalse("array", "contains", "not_assigned");
+
             // NOTE(daviburg): Historically testing for equality cross integer and string boundaries resulted in not equal.
             AssertEvaluatesFalse(left: "array", op: "contains", right: "'1'");
         }
@@ -167,6 +171,7 @@ namespace DotLiquid.Tests
             AssertEvaluatesFalse("array", "contains", "6");
 
             AssertEvaluatesFalse("array", "contains", "'1'");
+            AssertEvaluatesFalse("array", "contains", "not_assigned");
         }
 
         [Test]
@@ -189,6 +194,10 @@ namespace DotLiquid.Tests
             AssertEvaluatesTrue(left: "array", op: "contains", right: "'Banana'");
             AssertEvaluatesTrue(left: "array", op: "endsWith", right: "last");
             AssertEvaluatesFalse(left: "array", op: "contains", right: "'Orang'");
+
+            AssertEvaluatesTrue("array", "contains", "not_assigned");
+            AssertEvaluatesFalse("array", "startswith", "not_assigned");
+            AssertEvaluatesFalse("array", "endswith", "not_assigned");
         }
 
         [Test]
@@ -209,6 +218,10 @@ namespace DotLiquid.Tests
             AssertEvaluatesTrue(left: "array", op: "startsWith", right: "clone");
             AssertEvaluatesTrue(left: "array", op: "endsWith", right: "last");
             AssertEvaluatesFalse(left: "array", op: "contains", right: "camry");
+
+            AssertEvaluatesFalse("array", "contains", "not_assigned");
+            AssertEvaluatesFalse("array", "startswith", "not_assigned");
+            AssertEvaluatesFalse("array", "endswith", "not_assigned");
         }
 
         [Test]
@@ -225,6 +238,10 @@ namespace DotLiquid.Tests
             AssertEvaluatesTrue(left: "array", op: "startsWith", right: "'true'");
 
             AssertEvaluatesFalse(left: "array", op: "contains", right: "'true'"); // to be re-evaluated in #362
+
+            AssertEvaluatesFalse("array", "contains", "not_assigned");
+            AssertEvaluatesFalse("array", "startswith", "not_assigned");
+            AssertEvaluatesFalse("array", "endswith", "not_assigned");
         }
 
         [Test]
@@ -245,6 +262,10 @@ namespace DotLiquid.Tests
             AssertEvaluatesTrue(left: "array", op: "contains", right: "'B'");
             AssertEvaluatesTrue(left: "array", op: "contains", right: "'C'");
             AssertEvaluatesTrue(left: "array", op: "endsWith", right: "last");
+
+            AssertEvaluatesFalse("array", "contains", "not_assigned");
+            AssertEvaluatesFalse("array", "startswith", "not_assigned");
+            AssertEvaluatesFalse("array", "endswith", "not_assigned");
         }
 
         [Test]
@@ -263,6 +284,10 @@ namespace DotLiquid.Tests
             AssertEvaluatesTrue(left: "array", op: "contains", right: "first");
             AssertEvaluatesFalse(left: "array", op: "contains", right: "1");
             AssertEvaluatesTrue(left: "array", op: "endsWith", right: "last");
+
+            AssertEvaluatesFalse("array", "contains", "not_assigned");
+            AssertEvaluatesFalse("array", "startswith", "not_assigned");
+            AssertEvaluatesFalse("array", "endswith", "not_assigned");
         }
 
         [Test]
@@ -280,13 +305,16 @@ namespace DotLiquid.Tests
             AssertEvaluatesFalse("array", "contains", "6");
 
             AssertEvaluatesFalse("array", "contains", "'1'");
+            AssertEvaluatesFalse("array", "contains", "not_assigned");
         }
 
         [Test]
         public void TestContainsReturnsFalseForNilCommands()
         {
             AssertEvaluatesFalse("not_assigned", "contains", "0");
+            AssertEvaluatesFalse("not_assigned", "contains", "not_assigned");
             AssertEvaluatesFalse("0", "contains", "not_assigned");
+            AssertEvaluatesFalse("not_assigned", "contains", "'bob'");
         }
 
         [Test]
@@ -300,6 +328,8 @@ namespace DotLiquid.Tests
             AssertEvaluatesFalse("'dave'", "startswith", "'ave'");
             AssertEvaluatesFalse("'dave'", "startswith", "'e'");
             AssertEvaluatesFalse("'dave'", "startswith", "'---'");
+
+            AssertEvaluatesFalse("'dave'", "startswith", "not_assigned");
         }
 
         [Test]
@@ -310,13 +340,17 @@ namespace DotLiquid.Tests
 
             AssertEvaluatesFalse("array", "startswith", "0");
             AssertEvaluatesTrue("array", "startswith", "1");
+
+            AssertEvaluatesFalse("array", "startswith", "not_assigned");
         }
 
         [Test]
         public void TestStartsWithReturnsFalseForNilCommands()
         {
             AssertEvaluatesFalse("not_assigned", "startswith", "0");
+            AssertEvaluatesFalse("not_assigned", "startswith", "'dave'");
             AssertEvaluatesFalse("0", "startswith", "not_assigned");
+            AssertEvaluatesFalse("not_assigned", "startswith", "not_assigned");
         }
 
         [Test]
@@ -330,6 +364,8 @@ namespace DotLiquid.Tests
             AssertEvaluatesFalse("'dave'", "endswith", "'dav'");
             AssertEvaluatesFalse("'dave'", "endswith", "'d'");
             AssertEvaluatesFalse("'dave'", "endswith", "'---'");
+
+            AssertEvaluatesFalse("'dave'", "endswith", "not_assigned");
         }
 
         [Test]
@@ -340,13 +376,17 @@ namespace DotLiquid.Tests
 
             AssertEvaluatesFalse("array", "endswith", "0");
             AssertEvaluatesTrue("array", "endswith", "5");
+
+            AssertEvaluatesFalse("array", "endswith", "not_assigned");
         }
 
         [Test]
         public void TestEndsWithReturnsFalseForNilCommands()
         {
             AssertEvaluatesFalse("not_assigned", "endswith", "0");
+            AssertEvaluatesFalse("not_assigned", "endswith", "'dave'");
             AssertEvaluatesFalse("0", "endswith", "not_assigned");
+            AssertEvaluatesFalse("not_assigned", "endswith", "not_assigned");
         }
 
         [Test]
@@ -362,6 +402,9 @@ namespace DotLiquid.Tests
 
             AssertEvaluatesTrue("dictionary", "haskey", "'bob'");
             AssertEvaluatesFalse("dictionary", "haskey", "'0'");
+
+            AssertEvaluatesFalse("dictionary", "haskey", "not_assigned");
+            AssertEvaluatesFalse("not_assigned", "haskey", "'0'");
         }
 
         [Test]
@@ -377,6 +420,9 @@ namespace DotLiquid.Tests
 
             AssertEvaluatesTrue("dictionary", "hasvalue", "'0'");
             AssertEvaluatesFalse("dictionary", "hasvalue", "'bob'");
+
+            AssertEvaluatesFalse("dictionary", "hasvalue", "not_assigned");
+            AssertEvaluatesFalse("not_assigned", "hasvalue", "'0'");
         }
 
         [Test]

--- a/src/DotLiquid/Condition.cs
+++ b/src/DotLiquid/Condition.cs
@@ -26,10 +26,10 @@ namespace DotLiquid
             { ">", (left, right) => left != null && right != null && Comparer<object>.Default.Compare(left, Convert.ChangeType(right, left.GetType())) == 1 },
             { "<=", (left, right) => left != null && right != null && Comparer<object>.Default.Compare(left, Convert.ChangeType(right, left.GetType())) <= 0 },
             { ">=", (left, right) => left != null && right != null && Comparer<object>.Default.Compare(left, Convert.ChangeType(right, left.GetType())) >= 0 },
-            { "contains", (left, right) => ((left is string) ? ((string)left).Contains((string)right) : (left is IEnumerable) ? Any((IEnumerable) left, (element) => element.BackCompatSafeTypeInsensitiveEqual(right)) : false) },
-            { "startsWith", (left, right) => (left is IList) ? EqualVariables(((IList) left).OfType<object>().FirstOrDefault(), right) : ((left is string) ? ((string)left).StartsWith((string) right) : false) },
-            { "endsWith", (left, right) => (left is IList) ? EqualVariables(((IList) left).OfType<object>().LastOrDefault(), right) : ((left is string) ? ((string)left).EndsWith((string) right) : false) },
-            { "hasKey", (left, right) => (left is IDictionary) ? ((IDictionary) left).Contains(right) : false },
+            { "contains", (left, right) => ((left is string && right != null) ? ((string)left).Contains((string)right) : (left is IEnumerable) ? Any((IEnumerable) left, (element) => element.BackCompatSafeTypeInsensitiveEqual(right)) : false) },
+            { "startsWith", (left, right) => (left is IList) ? EqualVariables(((IList) left).OfType<object>().FirstOrDefault(), right) : ((left is string && right != null) ? ((string)left).StartsWith((string) right) : false) },
+            { "endsWith", (left, right) => (left is IList) ? EqualVariables(((IList) left).OfType<object>().LastOrDefault(), right) : ((left is string && right != null) ? ((string)left).EndsWith((string) right) : false) },
+            { "hasKey", (left, right) => (left is IDictionary) ? ((right != null) && ((IDictionary) left).Contains(right)) : false },
             { "hasValue", (left, right) => (left is IDictionary) ? ((IDictionary) left).Values.Cast<object>().Contains(right) : false }
         };
 

--- a/src/DotLiquid/Condition.cs
+++ b/src/DotLiquid/Condition.cs
@@ -26,9 +26,9 @@ namespace DotLiquid
             { ">", (left, right) => left != null && right != null && Comparer<object>.Default.Compare(left, Convert.ChangeType(right, left.GetType())) == 1 },
             { "<=", (left, right) => left != null && right != null && Comparer<object>.Default.Compare(left, Convert.ChangeType(right, left.GetType())) <= 0 },
             { ">=", (left, right) => left != null && right != null && Comparer<object>.Default.Compare(left, Convert.ChangeType(right, left.GetType())) >= 0 },
-            { "contains", (left, right) => ((left is string && right != null) ? ((string)left).Contains((string)right) : (left is IEnumerable) ? Any((IEnumerable) left, (element) => element.BackCompatSafeTypeInsensitiveEqual(right)) : false) },
-            { "startsWith", (left, right) => (left is IList) ? EqualVariables(((IList) left).OfType<object>().FirstOrDefault(), right) : ((left is string && right != null) ? ((string)left).StartsWith((string) right) : false) },
-            { "endsWith", (left, right) => (left is IList) ? EqualVariables(((IList) left).OfType<object>().LastOrDefault(), right) : ((left is string && right != null) ? ((string)left).EndsWith((string) right) : false) },
+            { "contains", (left, right) => (left is string leftString && right != null) ? leftString.Contains((string)right) : (left is IEnumerable leftList && Any(leftList, (element) => element.BackCompatSafeTypeInsensitiveEqual(right))) },
+            { "startsWith", (left, right) => (left is IList leftList) ? EqualVariables(leftList.OfType<object>().FirstOrDefault(), right) : (left is string leftString && right is string rightString && leftString.StartsWith(rightString)) },
+            { "endsWith", (left, right) => (left is IList leftList) ? EqualVariables(leftList.OfType<object>().LastOrDefault(), right) : (left is string leftString && right is string rightString && leftString.EndsWith(rightString)) },
             {
                 "hasKey", (left, right) => {
                     if (right is null)

--- a/src/DotLiquid/Condition.cs
+++ b/src/DotLiquid/Condition.cs
@@ -26,7 +26,7 @@ namespace DotLiquid
             { ">", (left, right) => left != null && right != null && Comparer<object>.Default.Compare(left, Convert.ChangeType(right, left.GetType())) == 1 },
             { "<=", (left, right) => left != null && right != null && Comparer<object>.Default.Compare(left, Convert.ChangeType(right, left.GetType())) <= 0 },
             { ">=", (left, right) => left != null && right != null && Comparer<object>.Default.Compare(left, Convert.ChangeType(right, left.GetType())) >= 0 },
-            { "contains", (left, right) => (left is string leftString && right != null) ? leftString.Contains((string)right) : (left is IEnumerable leftList && Any(leftList, (element) => element.BackCompatSafeTypeInsensitiveEqual(right))) },
+            { "contains", (left, right) => (left is string leftString && right != null) ? leftString.Contains((string)right) : (left is IEnumerable leftEnumerable && Any(leftEnumerable, (element) => element.BackCompatSafeTypeInsensitiveEqual(right))) },
             { "startsWith", (left, right) => (left is IList leftList) ? EqualVariables(leftList.OfType<object>().FirstOrDefault(), right) : (left is string leftString && right is string rightString && leftString.StartsWith(rightString)) },
             { "endsWith", (left, right) => (left is IList leftList) ? EqualVariables(leftList.OfType<object>().LastOrDefault(), right) : (left is string leftString && right is string rightString && leftString.EndsWith(rightString)) },
             {


### PR DESCRIPTION
Prevents exceptions being thrown when right = null. Also adds test for when left operand is null, but these were handle correctly already.

Replaces stale #513.