### PR TITLE
Change all R.Scan() calls to use Regex

### DIFF
--- a/src/DotLiquid.Tests/RegexpTests.cs
+++ b/src/DotLiquid.Tests/RegexpTests.cs
@@ -30,6 +30,11 @@ namespace DotLiquid.Tests
         }
 #endif
 
+        private static List<string> Run(string input, string pattern)
+        {
+            return R.Scan(input, new Regex(pattern));
+        }
+
         [Test]
         public void TestEmpty()
         {
@@ -74,9 +79,146 @@ namespace DotLiquid.Tests
             Assert.That(Run("arg1 arg2 \"arg 3\" arg4", Liquid.QuotedFragment), Is.EqualTo(new[] { "arg1", "arg2", "\"arg 3\"", "arg4" }).AsCollection);
         }
 
-        private static List<string> Run(string input, string pattern)
+        [Test]
+        public void TestScanWithCallbackNoMatch()
         {
-            return R.Scan(input, new Regex(pattern));
+            string markup = "nomatch";
+            Dictionary<string, string> d = new Dictionary<string, string>();
+            R.Scan(markup, Liquid.TagAttributesRegex, (key, value) => d[key] = value);
+
+            Assert.That(d.Count, Is.EqualTo(0));
         }
+
+        [Test]
+        public void TestScanWithCallbackOneMatch()
+        {
+            string markup = "hello:world";
+            Dictionary<string, string> d = new Dictionary<string, string>();
+            R.Scan(markup, Liquid.TagAttributesRegex, (key, value) => d[key] = value);
+
+            Assert.That(d.Count, Is.EqualTo(1));
+            Assert.That(d["hello"], Is.EqualTo("world"));
+        }
+
+        [Test]
+        public void TestScanWithCallbackTwoMatches()
+        {
+            string markup = "hello:world, hello_again:another_world";
+            Dictionary<string, string> d = new Dictionary<string, string>();
+            R.Scan(markup, Liquid.TagAttributesRegex, (key, value) => d[key] = value);
+
+            Assert.That(d.Count, Is.EqualTo(2));
+            Assert.That(d["hello"], Is.EqualTo("world"));
+            Assert.That(d["hello_again"], Is.EqualTo("another_world"));
+        }
+
+        #region Tests of obsolete functions
+
+        [Obsolete("Tests obsolete function")]
+        private static List<string> Run_Obsolete(string input, string pattern)
+        {
+            return R.Scan(input, pattern);
+        }
+
+        [Test]
+        [Obsolete("Tests obsolete function")]
+        public void TestEmpty_Obsolete()
+        {
+            Assert.That(Run_Obsolete(string.Empty, Liquid.QuotedFragment), Is.Empty);
+        }
+
+        [Test]
+        [Obsolete("Tests obsolete function")]
+        public void TestQuote_Obsolete()
+        {
+            Assert.That(Run_Obsolete("\"arg 1\"", Liquid.QuotedFragment), Is.EqualTo(new[] { "\"arg 1\"" }).AsCollection);
+        }
+
+        [Test]
+        [Obsolete("Tests obsolete function")]
+        public void TestWords_Obsolete()
+        {
+            Assert.That(Run_Obsolete("arg1 arg2", Liquid.QuotedFragment), Is.EqualTo(new[] { "arg1", "arg2" }).AsCollection);
+        }
+
+        [Test]
+        [Obsolete("Tests obsolete function")]
+        public void TestTags_Obsolete()
+        {
+            Assert.That(Run_Obsolete("<tr> </tr>", Liquid.QuotedFragment), Is.EqualTo(new[] { "<tr>", "</tr>" }).AsCollection);
+            Assert.That(Run_Obsolete("<tr></tr>", Liquid.QuotedFragment), Is.EqualTo(new[] { "<tr></tr>" }).AsCollection);
+            Assert.That(Run_Obsolete("<style class=\"hello\">' </style>", Liquid.QuotedFragment), Is.EqualTo(new[] { "<style", "class=\"hello\">", "</style>" }).AsCollection);
+        }
+
+        [Test]
+        [Obsolete("Tests obsolete function")]
+        public void TestQuotedWords_Obsolete()
+        {
+            Assert.That(Run_Obsolete("arg1 arg2 \"arg 3\"", Liquid.QuotedFragment), Is.EqualTo(new[] { "arg1", "arg2", "\"arg 3\"" }).AsCollection);
+        }
+
+        [Test]
+        [Obsolete("Tests obsolete function")]
+        public void TestQuotedWords2_Obsolete()
+        {
+            Assert.That(Run_Obsolete("arg1 arg2 'arg 3'", Liquid.QuotedFragment), Is.EqualTo(new[] { "arg1", "arg2", "'arg 3'" }).AsCollection);
+        }
+
+        [Test]
+        [Obsolete("Tests obsolete function")]
+        public void TestQuotedWordsInTheMiddle_Obsolete()
+        {
+            Assert.That(Run_Obsolete("arg1 arg2 \"arg 3\" arg4", Liquid.QuotedFragment), Is.EqualTo(new[] { "arg1", "arg2", "\"arg 3\"", "arg4" }).AsCollection);
+        }
+
+        [Test]
+        [Obsolete("Tests obsolete function")]
+        public void TestScanWithCallbackNoMatch_Obsolete()
+        {
+            string markup = "nomatch";
+            Dictionary<string, string> d = new Dictionary<string, string>();
+
+            R.Scan(markup, Liquid.TagAttributesRegex.ToString(), (key, value) => d[key] = value);
+
+            Assert.That(d.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        [Obsolete("Tests obsolete function")]
+        public void TestScan_Obsolete()
+        {
+            string markup = "nomatch";
+            List<string> matches = R.Scan(markup, Liquid.TagAttributesRegex);
+
+            Assert.That(matches, Is.Not.Null);
+            Assert.That(matches.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        [Obsolete("Tests obsolete function")]
+        public void TestScanWithCallbackOneMatch_Obsolete()
+        {
+            string markup = "hello:world";
+            Dictionary<string, string> d = new Dictionary<string, string>();
+            R.Scan(markup, Liquid.TagAttributesRegex.ToString(), (key, value) => d[key] = value);
+
+            Assert.That(d.Count, Is.EqualTo(1));
+            Assert.That(d["hello"], Is.EqualTo("world"));
+        }
+
+        [Test]
+        [Obsolete("Tests obsolete function")]
+        public void TestScanWithCallbackTwoMatches_Obsolete()
+        {
+            string markup = "hello:world, hello_again:another_world";
+            Dictionary<string, string> d = new Dictionary<string, string>();
+            R.Scan(markup, Liquid.TagAttributesRegex.ToString(), (key, value) => d[key] = value);
+
+            Assert.That(d.Count, Is.EqualTo(2));
+            Assert.That(d["hello"], Is.EqualTo("world"));
+            Assert.That(d["hello_again"], Is.EqualTo("another_world"));
+        }
+
+        #endregion
     }
 }

--- a/src/DotLiquid.Tests/RegexpTests.cs
+++ b/src/DotLiquid.Tests/RegexpTests.cs
@@ -79,96 +79,68 @@ namespace DotLiquid.Tests
             Assert.That(Run("arg1 arg2 \"arg 3\" arg4", Liquid.QuotedFragment), Is.EqualTo(new[] { "arg1", "arg2", "\"arg 3\"", "arg4" }).AsCollection);
         }
 
-        [Test]
-        public void TestScanWithCallbackNoMatch()
-        {
-            string markup = "nomatch";
-            Dictionary<string, string> d = new Dictionary<string, string>();
-            R.Scan(markup, Liquid.TagAttributesRegex, (key, value) => d[key] = value);
-
-            Assert.That(d.Count, Is.EqualTo(0));
-        }
-
-        [Test]
-        public void TestScanWithCallbackOneMatch()
-        {
-            string markup = "hello:world";
-            Dictionary<string, string> d = new Dictionary<string, string>();
-            R.Scan(markup, Liquid.TagAttributesRegex, (key, value) => d[key] = value);
-
-            Assert.That(d.Count, Is.EqualTo(1));
-            Assert.That(d["hello"], Is.EqualTo("world"));
-        }
-
-        [Test]
-        public void TestScanWithCallbackTwoMatches()
-        {
-            string markup = "hello:world, hello_again:another_world";
-            Dictionary<string, string> d = new Dictionary<string, string>();
-            R.Scan(markup, Liquid.TagAttributesRegex, (key, value) => d[key] = value);
-
-            Assert.That(d.Count, Is.EqualTo(2));
-            Assert.That(d["hello"], Is.EqualTo("world"));
-            Assert.That(d["hello_again"], Is.EqualTo("another_world"));
-        }
-
         #region Tests of obsolete functions
-
-        [Obsolete("Tests obsolete function")]
-        private static List<string> Run_Obsolete(string input, string pattern)
-        {
-            return R.Scan(input, pattern);
-        }
 
         [Test]
         [Obsolete("Tests obsolete function")]
         public void TestEmpty_Obsolete()
         {
-            Assert.That(Run_Obsolete(string.Empty, Liquid.QuotedFragment), Is.Empty);
+            Assert.That(R.Scan(string.Empty, Liquid.QuotedFragment), Is.Empty);
         }
 
         [Test]
         [Obsolete("Tests obsolete function")]
         public void TestQuote_Obsolete()
         {
-            Assert.That(Run_Obsolete("\"arg 1\"", Liquid.QuotedFragment), Is.EqualTo(new[] { "\"arg 1\"" }).AsCollection);
+            Assert.That(R.Scan("\"arg 1\"", Liquid.QuotedFragment), Is.EqualTo(new[] { "\"arg 1\"" }).AsCollection);
         }
 
         [Test]
         [Obsolete("Tests obsolete function")]
         public void TestWords_Obsolete()
         {
-            Assert.That(Run_Obsolete("arg1 arg2", Liquid.QuotedFragment), Is.EqualTo(new[] { "arg1", "arg2" }).AsCollection);
+            Assert.That(R.Scan("arg1 arg2", Liquid.QuotedFragment), Is.EqualTo(new[] { "arg1", "arg2" }).AsCollection);
         }
 
         [Test]
         [Obsolete("Tests obsolete function")]
         public void TestTags_Obsolete()
         {
-            Assert.That(Run_Obsolete("<tr> </tr>", Liquid.QuotedFragment), Is.EqualTo(new[] { "<tr>", "</tr>" }).AsCollection);
-            Assert.That(Run_Obsolete("<tr></tr>", Liquid.QuotedFragment), Is.EqualTo(new[] { "<tr></tr>" }).AsCollection);
-            Assert.That(Run_Obsolete("<style class=\"hello\">' </style>", Liquid.QuotedFragment), Is.EqualTo(new[] { "<style", "class=\"hello\">", "</style>" }).AsCollection);
+            Assert.That(R.Scan("<tr> </tr>", Liquid.QuotedFragment), Is.EqualTo(new[] { "<tr>", "</tr>" }).AsCollection);
+            Assert.That(R.Scan("<tr></tr>", Liquid.QuotedFragment), Is.EqualTo(new[] { "<tr></tr>" }).AsCollection);
+            Assert.That(R.Scan("<style class=\"hello\">' </style>", Liquid.QuotedFragment), Is.EqualTo(new[] { "<style", "class=\"hello\">", "</style>" }).AsCollection);
         }
 
         [Test]
         [Obsolete("Tests obsolete function")]
         public void TestQuotedWords_Obsolete()
         {
-            Assert.That(Run_Obsolete("arg1 arg2 \"arg 3\"", Liquid.QuotedFragment), Is.EqualTo(new[] { "arg1", "arg2", "\"arg 3\"" }).AsCollection);
+            Assert.That(R.Scan("arg1 arg2 \"arg 3\"", Liquid.QuotedFragment), Is.EqualTo(new[] { "arg1", "arg2", "\"arg 3\"" }).AsCollection);
         }
 
         [Test]
         [Obsolete("Tests obsolete function")]
         public void TestQuotedWords2_Obsolete()
         {
-            Assert.That(Run_Obsolete("arg1 arg2 'arg 3'", Liquid.QuotedFragment), Is.EqualTo(new[] { "arg1", "arg2", "'arg 3'" }).AsCollection);
+            Assert.That(R.Scan("arg1 arg2 'arg 3'", Liquid.QuotedFragment), Is.EqualTo(new[] { "arg1", "arg2", "'arg 3'" }).AsCollection);
         }
 
         [Test]
         [Obsolete("Tests obsolete function")]
         public void TestQuotedWordsInTheMiddle_Obsolete()
         {
-            Assert.That(Run_Obsolete("arg1 arg2 \"arg 3\" arg4", Liquid.QuotedFragment), Is.EqualTo(new[] { "arg1", "arg2", "\"arg 3\"", "arg4" }).AsCollection);
+            Assert.That(R.Scan("arg1 arg2 \"arg 3\" arg4", Liquid.QuotedFragment), Is.EqualTo(new[] { "arg1", "arg2", "\"arg 3\"", "arg4" }).AsCollection);
+        }
+
+        [Test]
+        [Obsolete("Tests obsolete function")]
+        public void TestNoMatch_Obsolete()
+        {
+            string markup = "nomatch";
+            List<string> matches = R.Scan(markup, Liquid.TagAttributesRegex);
+
+            Assert.That(matches, Is.Not.Null);
+            Assert.That(matches.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -181,17 +153,6 @@ namespace DotLiquid.Tests
             R.Scan(markup, Liquid.TagAttributesRegex.ToString(), (key, value) => d[key] = value);
 
             Assert.That(d.Count, Is.EqualTo(0));
-        }
-
-        [Test]
-        [Obsolete("Tests obsolete function")]
-        public void TestScan_Obsolete()
-        {
-            string markup = "nomatch";
-            List<string> matches = R.Scan(markup, Liquid.TagAttributesRegex);
-
-            Assert.That(matches, Is.Not.Null);
-            Assert.That(matches.Count, Is.EqualTo(0));
         }
 
         [Test]

--- a/src/DotLiquid.Tests/RegexpTests.cs
+++ b/src/DotLiquid.Tests/RegexpTests.cs
@@ -79,6 +79,19 @@ namespace DotLiquid.Tests
             Assert.That(Run("arg1 arg2 \"arg 3\" arg4", Liquid.QuotedFragment), Is.EqualTo(new[] { "arg1", "arg2", "\"arg 3\"", "arg4" }).AsCollection);
         }
 
+        [Test]
+        public void TestAttributeParser()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(Tokenizer.GetAttributes("cols:3"), Is.EqualTo(new Dictionary<string, string> { { "cols", "3" } }));
+                Assert.That(Tokenizer.GetAttributes("limit:4 offset:2"), Is.EqualTo(new Dictionary<string, string> { { "limit", "4" }, { "offset", "2" } }));
+                Assert.That(Tokenizer.GetAttributes("limit: limit offset: offset"), Is.EqualTo(new Dictionary<string, string> { { "limit", "limit" }, { "offset", "offset" } }));
+                Assert.That(Tokenizer.GetAttributes(" echo1: 'test123'"), Is.EqualTo(new Dictionary<string, string> { { "echo1", "'test123'" } }));
+                Assert.That(Tokenizer.GetAttributes("echo1: echo1, echo2: more_echos.echo2"), Is.EqualTo(new Dictionary<string, string> { { "echo1", "echo1" }, { "echo2", "more_echos.echo2" } }));
+            });
+        }
+
         #region Tests of obsolete functions
 
         [Test]

--- a/src/DotLiquid/Liquid.cs
+++ b/src/DotLiquid/Liquid.cs
@@ -26,7 +26,6 @@ namespace DotLiquid
         public static readonly string QuotedString = R.Q(@"""[^""]*""|'[^']*'");
         public static readonly string QuotedFragment = string.Format(R.Q(@"{0}|(?:[^\s,\|'""]|{0})+"), QuotedString);
         public static readonly string QuotedAssignFragment = string.Format(R.Q(@"{0}|(?:[^\s\|'""]|{0})+"), QuotedString);
-        public static readonly string TagAttributes = string.Format(R.Q(@"(\w+)\s*\:\s*({0})"), QuotedFragment);
         public static readonly string AnyStartingTag = R.Q(@"\{\{|\{\%");
         public static readonly string VariableParser = string.Format(R.Q(@"\[[^\]]+\]|{0}+\??"), VariableSegment);
         public static readonly string LiteralShorthand = R.Q(@"^(?:\{\{\{\s?)(.*?)(?:\s*\}\}\})$");
@@ -38,10 +37,12 @@ namespace DotLiquid
         private static readonly Lazy<Regex> LazyDirectorySeparatorsRegex = new Lazy<Regex>(() => R.C(DirectorySeparators), LazyThreadSafetyMode.ExecutionAndPublication);
         private static readonly Lazy<Regex> LazyLimitRelativePathRegex = new Lazy<Regex>(() => R.C(LimitRelativePath), LazyThreadSafetyMode.ExecutionAndPublication);
         private static readonly Lazy<Regex> LazyVariableSegmentRegex = new Lazy<Regex>(() => R.B(R.Q(@"\A\s*(?<Variable>{0}+)\s*\Z"), Liquid.VariableSegment), LazyThreadSafetyMode.ExecutionAndPublication);
+        private static readonly Lazy<Regex> LazyTagAttributesRegex = new Lazy<Regex>(() => R.B(R.Q(@"(\w+)\s*\:\s*({0})"), QuotedFragment), LazyThreadSafetyMode.ExecutionAndPublication);
 
         internal static Regex DirectorySeparatorsRegex => LazyDirectorySeparatorsRegex.Value;
         internal static Regex LimitRelativePathRegex => LazyLimitRelativePathRegex.Value;
         internal static Regex VariableSegmentRegex => LazyVariableSegmentRegex.Value;
+        internal static Regex TagAttributesRegex => LazyTagAttributesRegex.Value;
 
 
         static Liquid()

--- a/src/DotLiquid/Tags/For.cs
+++ b/src/DotLiquid/Tags/For.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Xml.Linq;
 using DotLiquid.Exceptions;
 using DotLiquid.Util;
 
@@ -82,8 +83,12 @@ namespace DotLiquid.Tags
                 _name = string.Format("{0}-{1}", _variableName, _collectionName);
                 _reversed = (!string.IsNullOrEmpty(match.Groups[3].Value));
                 _attributes = new Dictionary<string, string>(Template.NamingConvention.StringComparer);
-                R.Scan(markup, Liquid.TagAttributesRegex,
-                    (key, value) => _attributes[key] = value);
+                foreach (Match attributeMatch in Liquid.TagAttributesRegex.Matches(markup))
+                {
+                    string key = attributeMatch.Groups[1].Value;
+                    string value = attributeMatch.Groups[2].Value;
+                    _attributes[key] = value;
+                }
             }
             else
             {

--- a/src/DotLiquid/Tags/For.cs
+++ b/src/DotLiquid/Tags/For.cs
@@ -82,7 +82,7 @@ namespace DotLiquid.Tags
                 _name = string.Format("{0}-{1}", _variableName, _collectionName);
                 _reversed = (!string.IsNullOrEmpty(match.Groups[3].Value));
                 _attributes = new Dictionary<string, string>(Template.NamingConvention.StringComparer);
-                R.Scan(markup, Liquid.TagAttributes,
+                R.Scan(markup, Liquid.TagAttributesRegex,
                     (key, value) => _attributes[key] = value);
             }
             else

--- a/src/DotLiquid/Tags/For.cs
+++ b/src/DotLiquid/Tags/For.cs
@@ -82,13 +82,7 @@ namespace DotLiquid.Tags
                 _collectionName = match.Groups[2].Value;
                 _name = string.Format("{0}-{1}", _variableName, _collectionName);
                 _reversed = (!string.IsNullOrEmpty(match.Groups[3].Value));
-                _attributes = new Dictionary<string, string>(Template.NamingConvention.StringComparer);
-                foreach (Match attributeMatch in Liquid.TagAttributesRegex.Matches(markup))
-                {
-                    string key = attributeMatch.Groups[1].Value;
-                    string value = attributeMatch.Groups[2].Value;
-                    _attributes[key] = value;
-                }
+                _attributes = Tokenizer.GetAttributes(markup);
             }
             else
             {

--- a/src/DotLiquid/Tags/Html/TableRow.cs
+++ b/src/DotLiquid/Tags/Html/TableRow.cs
@@ -40,7 +40,7 @@ namespace DotLiquid.Tags.Html
                 _variableName = syntaxMatch.Groups[1].Value;
                 _collectionName = syntaxMatch.Groups[2].Value;
                 _attributes = new Dictionary<string, string>(Template.NamingConvention.StringComparer);
-                R.Scan(markup, Liquid.TagAttributes, (key, value) => _attributes[key] = value);
+                R.Scan(markup, Liquid.TagAttributesRegex, (key, value) => _attributes[key] = value);
             }
             else
                 throw new SyntaxException(Liquid.ResourceManager.GetString("TableRowTagSyntaxException"));

--- a/src/DotLiquid/Tags/Html/TableRow.cs
+++ b/src/DotLiquid/Tags/Html/TableRow.cs
@@ -40,7 +40,12 @@ namespace DotLiquid.Tags.Html
                 _variableName = syntaxMatch.Groups[1].Value;
                 _collectionName = syntaxMatch.Groups[2].Value;
                 _attributes = new Dictionary<string, string>(Template.NamingConvention.StringComparer);
-                R.Scan(markup, Liquid.TagAttributesRegex, (key, value) => _attributes[key] = value);
+                foreach (Match attributeMatch in Liquid.TagAttributesRegex.Matches(markup))
+                {
+                    string key = attributeMatch.Groups[1].Value;
+                    string value = attributeMatch.Groups[2].Value;
+                    _attributes[key] = value;
+                }
             }
             else
                 throw new SyntaxException(Liquid.ResourceManager.GetString("TableRowTagSyntaxException"));

--- a/src/DotLiquid/Tags/Html/TableRow.cs
+++ b/src/DotLiquid/Tags/Html/TableRow.cs
@@ -39,13 +39,7 @@ namespace DotLiquid.Tags.Html
             {
                 _variableName = syntaxMatch.Groups[1].Value;
                 _collectionName = syntaxMatch.Groups[2].Value;
-                _attributes = new Dictionary<string, string>(Template.NamingConvention.StringComparer);
-                foreach (Match attributeMatch in Liquid.TagAttributesRegex.Matches(markup))
-                {
-                    string key = attributeMatch.Groups[1].Value;
-                    string value = attributeMatch.Groups[2].Value;
-                    _attributes[key] = value;
-                }
+                _attributes = Tokenizer.GetAttributes(markup);
             }
             else
                 throw new SyntaxException(Liquid.ResourceManager.GetString("TableRowTagSyntaxException"));

--- a/src/DotLiquid/Tags/Include.cs
+++ b/src/DotLiquid/Tags/Include.cs
@@ -25,13 +25,7 @@ namespace DotLiquid.Tags
                 _variableName = syntaxMatch.Groups[3].Value;
                 if (_variableName == string.Empty)
                     _variableName = null;
-                _attributes = new Dictionary<string, string>(Template.NamingConvention.StringComparer);
-                foreach (Match attributeMatch in Liquid.TagAttributesRegex.Matches(markup))
-                {
-                    string key = attributeMatch.Groups[1].Value;
-                    string value = attributeMatch.Groups[2].Value;
-                    _attributes[key] = value;
-                }
+                _attributes = Tokenizer.GetAttributes(markup);
             }
             else
                 throw new SyntaxException(Liquid.ResourceManager.GetString("IncludeTagSyntaxException"));

--- a/src/DotLiquid/Tags/Include.cs
+++ b/src/DotLiquid/Tags/Include.cs
@@ -26,7 +26,12 @@ namespace DotLiquid.Tags
                 if (_variableName == string.Empty)
                     _variableName = null;
                 _attributes = new Dictionary<string, string>(Template.NamingConvention.StringComparer);
-                R.Scan(markup, Liquid.TagAttributesRegex, (key, value) => _attributes[key] = value);
+                foreach (Match attributeMatch in Liquid.TagAttributesRegex.Matches(markup))
+                {
+                    string key = attributeMatch.Groups[1].Value;
+                    string value = attributeMatch.Groups[2].Value;
+                    _attributes[key] = value;
+                }
             }
             else
                 throw new SyntaxException(Liquid.ResourceManager.GetString("IncludeTagSyntaxException"));

--- a/src/DotLiquid/Tags/Include.cs
+++ b/src/DotLiquid/Tags/Include.cs
@@ -26,7 +26,7 @@ namespace DotLiquid.Tags
                 if (_variableName == string.Empty)
                     _variableName = null;
                 _attributes = new Dictionary<string, string>(Template.NamingConvention.StringComparer);
-                R.Scan(markup, Liquid.TagAttributes, (key, value) => _attributes[key] = value);
+                R.Scan(markup, Liquid.TagAttributesRegex, (key, value) => _attributes[key] = value);
             }
             else
                 throw new SyntaxException(Liquid.ResourceManager.GetString("IncludeTagSyntaxException"));

--- a/src/DotLiquid/Tokenizer.cs
+++ b/src/DotLiquid/Tokenizer.cs
@@ -165,6 +165,24 @@ namespace DotLiquid
         }
 
         /// <summary>
+        /// Extracts attributes from the provided markup string and returns them as a dictionary.
+        /// The keys are the attribute names and the values are the attribute values.
+        /// </summary>
+        /// <param name="markup">The markup string from which attributes will be extracted.</param>
+        /// <returns>A dictionary where each key is an attribute name and each value is the corresponding attribute value.</returns>
+        internal static Dictionary<string, string> GetAttributes(string markup)
+        {
+            var attributes = new Dictionary<string, string>(Template.NamingConvention.StringComparer);
+            foreach (Match attributeMatch in Liquid.TagAttributesRegex.Matches(markup))
+            {
+                string key = attributeMatch.Groups[1].Value;
+                string value = attributeMatch.Groups[2].Value;
+                attributes[key] = value;
+            }
+            return attributes;
+        }
+
+        /// <summary>
         /// Reads a fixed number of characters and advances the enumerator position
         /// </summary>
         /// <param name="markupEnumerator">The string enumerator</param>

--- a/src/DotLiquid/Util/R.cs
+++ b/src/DotLiquid/Util/R.cs
@@ -92,7 +92,7 @@ namespace DotLiquid.Util
         /// <param name="input"></param>
         /// <param name="pattern"></param>
         /// <param name="callback"></param>
-        [Obsolete("Use Scan(string, Regex, Action) instead.")]
+        [Obsolete("Use Scan(string, Regex, Action<string, string>) instead.")]
         public static void Scan(string input, string pattern, Action<string, string> callback)
         {
             foreach (Match match in Regex.Matches(input, pattern, RegexOptions.None, Template.RegexTimeOut))

--- a/src/DotLiquid/Util/R.cs
+++ b/src/DotLiquid/Util/R.cs
@@ -60,6 +60,19 @@ namespace DotLiquid.Util
         }
 
         /// <summary>
+        /// Overload that only works when the pattern contains two groups. The callback
+        /// is called for each match, passing the two group values.
+        /// </summary>
+        /// <param name="input"></param>
+        /// <param name="regex"></param>
+        /// <param name="callback"></param>
+        public static void Scan(string input, Regex regex, Action<string, string> callback)
+        {
+            foreach (Match match in regex.Matches(input))
+                callback(match.Groups[1].Value, match.Groups[2].Value);
+        }
+
+        /// <summary>
         /// Deprecated for performance reasons. New code should not use this.
         /// See comments for Scan(string, Regex) above.
         /// </summary>
@@ -79,7 +92,7 @@ namespace DotLiquid.Util
         /// <param name="input"></param>
         /// <param name="pattern"></param>
         /// <param name="callback"></param>
-        /// <returns></returns>
+        [Obsolete("Use Scan(string, Regex, Action) instead.")]
         public static void Scan(string input, string pattern, Action<string, string> callback)
         {
             foreach (Match match in Regex.Matches(input, pattern, RegexOptions.None, Template.RegexTimeOut))

--- a/src/DotLiquid/Util/R.cs
+++ b/src/DotLiquid/Util/R.cs
@@ -60,25 +60,12 @@ namespace DotLiquid.Util
         }
 
         /// <summary>
-        /// Overload that only works when the pattern contains two groups. The callback
-        /// is called for each match, passing the two group values.
-        /// </summary>
-        /// <param name="input"></param>
-        /// <param name="regex"></param>
-        /// <param name="callback"></param>
-        public static void Scan(string input, Regex regex, Action<string, string> callback)
-        {
-            foreach (Match match in regex.Matches(input))
-                callback(match.Groups[1].Value, match.Groups[2].Value);
-        }
-
-        /// <summary>
         /// Deprecated for performance reasons. New code should not use this.
         /// See comments for Scan(string, Regex) above.
         /// </summary>
         /// <param name="input">input text</param>
         /// <param name="pattern">regex pattern</param>
-        /// <returns>matches</returns>
+        /// <returns>A list of matches</returns>
         [Obsolete("Use Scan(string, Regex) instead.")]
         public static List<string> Scan(string input, string pattern)
         {
@@ -92,7 +79,7 @@ namespace DotLiquid.Util
         /// <param name="input"></param>
         /// <param name="pattern"></param>
         /// <param name="callback"></param>
-        [Obsolete("Use Scan(string, Regex, Action<string, string>) instead.")]
+        [Obsolete("Use Scan(string, Regex) instead.")]
         public static void Scan(string input, string pattern, Action<string, string> callback)
         {
             foreach (Match match in Regex.Matches(input, pattern, RegexOptions.None, Template.RegexTimeOut))


### PR DESCRIPTION
I noticed only one of the overloads were made Obsolete. 

Replace R.Scan(string, string, Action) with R.Scan(string, Regex, Action).