### PR TITLE
Drop unsupported netstandard1.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,6 @@ install:
 
     choco install codecov -y
 
-    choco install dotnetcore-runtime.install --version=1.1.13 --allow-downgrade -y
-
     choco install dotnetcore-runtime.install --version=2.1.30 -y
 
     dotnet restore src/DotLiquid.sln

--- a/src/DotLiquid.Tests/BlockTests.cs
+++ b/src/DotLiquid.Tests/BlockTests.cs
@@ -69,6 +69,7 @@ namespace DotLiquid.Tests
         public void TestWithCustomTag()
         {
             Template.RegisterTag<Block>("testtag");
+            Assert.That(Template.GetTagType("testtag"), Is.EqualTo(typeof(Block)));
             Assert.DoesNotThrow(() => Template.Parse("{% testtag %} {% endtesttag %}"));
         }
 
@@ -76,6 +77,8 @@ namespace DotLiquid.Tests
         public void TestWithCustomTagFactory()
         {
             Template.RegisterTagFactory(new CustomTagFactory());
+            Assert.That(Template.GetTagType("custom"), Is.Null);
+
             Template result = null;
             Assert.DoesNotThrow(() => result = Template.Parse("{% custom %}"));
             Assert.That(result.Render(), Is.EqualTo("I am a custom tag" + Environment.NewLine));

--- a/src/DotLiquid.Tests/ContextTests.cs
+++ b/src/DotLiquid.Tests/ContextTests.cs
@@ -233,6 +233,24 @@ namespace DotLiquid.Tests
             Assert.That(_context["nil"], Is.EqualTo(null));
         }
 
+        [Test]
+        public void TestVariablesArray()
+        {
+            List<int> list = new List<int> { 1, 2, 3, 4, 5 };
+            _context["list"] = list;
+            Assert.That(_context["list"], Is.EqualTo(list));
+            Assert.That(_context["list[0]"], Is.EqualTo(1));
+            Assert.That(_context["list[-1]"], Is.EqualTo(5));
+            Assert.That(_context["list[12]"], Is.Null);
+            Assert.That(_context["list[-12]"], Is.Null);
+
+            List<string> emptyList = new List<string>();
+            _context["empty_list"] = emptyList;
+            Assert.That(_context["empty_list"], Is.EqualTo(emptyList));
+            Assert.That(_context["empty_list[0]"], Is.Null);
+            Assert.That(_context["empty_list[-1]"], Is.Null);
+        }
+
 #if NET6_0_OR_GREATER
         [Test]
         public void TestVariables_NET60()

--- a/src/DotLiquid.Tests/ContextTests.cs
+++ b/src/DotLiquid.Tests/ContextTests.cs
@@ -322,18 +322,18 @@ namespace DotLiquid.Tests
         }
 #endif
 
-        private enum TestEnum { Yes, No }
+        private enum YesOrNo { Yes, No }
 
         [Test]
         public void TestGetVariable_Enum()
         {
-            _context["yes"] = TestEnum.Yes;
-            _context["no"] = TestEnum.No;
-            _context["not_enum"] = TestEnum.Yes.ToString();
+            _context["yes"] = YesOrNo.Yes;
+            _context["no"] = YesOrNo.No;
+            _context["not_enum"] = YesOrNo.Yes.ToString();
 
-            Assert.That(_context["yes"], Is.EqualTo(TestEnum.Yes));
-            Assert.That(_context["no"], Is.EqualTo(TestEnum.No));
-            Assert.That(_context["not_enum"], Is.Not.EqualTo(TestEnum.Yes));
+            Assert.That(_context["yes"], Is.EqualTo(YesOrNo.Yes));
+            Assert.That(_context["no"], Is.EqualTo(YesOrNo.No));
+            Assert.That(_context["not_enum"], Is.Not.EqualTo(YesOrNo.Yes));
         }
 
         [Test]
@@ -450,31 +450,54 @@ namespace DotLiquid.Tests
         public void TestAddFilter()
         {
             Context context = new Context(CultureInfo.InvariantCulture);
-            context.AddFilters(new[] { typeof(TestFilters) });
+            context.AddFilter<string, string>("hi", TestFilters.Hi);
             Assert.That(context.Invoke("hi", new List<object> { "hi?" }), Is.EqualTo("hi? hi!"));
             context.SyntaxCompatibilityLevel = SyntaxCompatibility.DotLiquid22;
             Assert.That(context.Invoke("hi", new List<object> { "hi?" }), Is.EqualTo("hi? hi!"));
-
-            context = new Context(CultureInfo.InvariantCulture);
-            Assert.That(context.Invoke("hi", new List<object> { "hi?" }), Is.EqualTo("hi?"));
-            context.SyntaxCompatibilityLevel = SyntaxCompatibility.DotLiquid22;
-            Assert.Throws<FilterNotFoundException>(() => context.Invoke("hi", new List<object> { "hi?" }));
         }
 
         [Test]
         public void TestAddContextFilter()
         {
-            // This test differs from TestAddFilter only in that the Hi method within this class has a Context parameter in addition to the input string
-            Context context = new Context(CultureInfo.InvariantCulture) { SyntaxCompatibilityLevel = SyntaxCompatibility.DotLiquid20 };
+            Context context = new Context(CultureInfo.InvariantCulture);
+            context["name"] = "King Kong";
+
+            context.AddFilter<Context, string, string>("hi", TestContextFilters.Hi);
+            Assert.That(context.Invoke("hi", new List<object> { "hi?" }), Is.EqualTo("hi? hi from King Kong!"));
+            context.SyntaxCompatibilityLevel = SyntaxCompatibility.DotLiquid22;
+            Assert.That(context.Invoke("hi", new List<object> { "hi?" }), Is.EqualTo("hi? hi from King Kong!"));
+        }
+
+        [Test]
+        public void TestAddFilters()
+        {
+            Context context = new Context(CultureInfo.InvariantCulture);
+            context.AddFilters(new[] { typeof(TestFilters) });
+            Assert.That(context.Invoke("hi", new List<object> { "hi?" }), Is.EqualTo("hi? hi!"));
+            context.SyntaxCompatibilityLevel = SyntaxCompatibility.DotLiquid22;
+            Assert.That(context.Invoke("hi", new List<object> { "hi?" }), Is.EqualTo("hi? hi!"));
+        }
+
+        [Test]
+        public void TestAddContextFilters()
+        {
+            Context context = new Context(CultureInfo.InvariantCulture);
             context["name"] = "King Kong";
 
             context.AddFilters(new[] { typeof(TestContextFilters) });
             Assert.That(context.Invoke("hi", new List<object> { "hi?" }), Is.EqualTo("hi? hi from King Kong!"));
             context.SyntaxCompatibilityLevel = SyntaxCompatibility.DotLiquid22;
             Assert.That(context.Invoke("hi", new List<object> { "hi?" }), Is.EqualTo("hi? hi from King Kong!"));
+        }
 
-            context = new Context(CultureInfo.InvariantCulture) { SyntaxCompatibilityLevel = SyntaxCompatibility.DotLiquid20 };
+        [Test]
+        public void TestFilterNotFound()
+        {
+            Context context = new Context(CultureInfo.InvariantCulture);
+
+            context.SyntaxCompatibilityLevel = SyntaxCompatibility.DotLiquid20;
             Assert.That(context.Invoke("hi", new List<object> { "hi?" }), Is.EqualTo("hi?"));
+
             context.SyntaxCompatibilityLevel = SyntaxCompatibility.DotLiquid22;
             Assert.Throws<FilterNotFoundException>(() => context.Invoke("hi", new List<object> { "hi?" }));
         }

--- a/src/DotLiquid.Tests/CultureHelper.cs
+++ b/src/DotLiquid.Tests/CultureHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 
 namespace DotLiquid
@@ -8,12 +8,7 @@ namespace DotLiquid
         public static IDisposable SetCulture(string name)
         {
             var scope = new CultureScope(CultureInfo.CurrentCulture);
-            
-#if CORE
-            CultureInfo.CurrentCulture = new CultureInfo(name);
-#else
             System.Threading.Thread.CurrentThread.CurrentCulture = new CultureInfo(name);
-#endif
             return scope;
         }
 
@@ -28,11 +23,7 @@ namespace DotLiquid
 
             public void Dispose()
             {
-#if CORE
-                CultureInfo.CurrentCulture = this.culture;
-#else
                 System.Threading.Thread.CurrentThread.CurrentCulture =  this.culture;
-#endif
             }
         }
     }

--- a/src/DotLiquid.Tests/DotLiquid.Tests.csproj
+++ b/src/DotLiquid.Tests/DotLiquid.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net6.0;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.0;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>DotLiquid.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../Formosatek-OpenSource.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -31,7 +31,7 @@
     <ProjectReference Include="..\DotLiquid\DotLiquid.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net6.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'netcoreapp2.0'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
@@ -39,7 +39,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />

--- a/src/DotLiquid.Tests/DotLiquid.Tests.csproj
+++ b/src/DotLiquid.Tests/DotLiquid.Tests.csproj
@@ -1,15 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net6.0;netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>DotLiquid.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../Formosatek-OpenSource.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>DotLiquid.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);portable-net451+win8;dnxcore5</PackageTargetFallback>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.0.16</RuntimeFrameworkVersion>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.9</RuntimeFrameworkVersion>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
@@ -32,7 +30,7 @@
   <ItemGroup>
     <ProjectReference Include="..\DotLiquid\DotLiquid.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup Condition=" '$(TargetFramework)' != 'net6.0' ">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
@@ -60,20 +58,8 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
-    <DefineConstants>$(DefineConstants);CORE</DefineConstants>
-  </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
-    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
-  </ItemGroup>
-
   <ItemGroup>
     <!-- This is simply to ensure formatting differences of .NET 5+ don't cause tests to fail -->
     <RuntimeHostConfigurationOption Include="System.Globalization.UseNls" Value="true" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-7mfr-774f-w5r9" /><!-- 'Microsoft.NETCore.App' 1.x Unpatched -->
   </ItemGroup>
 </Project>

--- a/src/DotLiquid.Tests/DotLiquid.Tests.csproj
+++ b/src/DotLiquid.Tests/DotLiquid.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp2.0;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>DotLiquid.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../Formosatek-OpenSource.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -31,7 +31,7 @@
     <ProjectReference Include="..\DotLiquid\DotLiquid.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'netcoreapp2.0'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netcoreapp2.0'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
@@ -47,7 +47,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <Reference Include="System.Data" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/DotLiquid.Tests/DropTests.cs
+++ b/src/DotLiquid.Tests/DropTests.cs
@@ -145,7 +145,6 @@ namespace DotLiquid.Tests
             }
         }
 
-#if !CORE
         internal class DataRowDrop : Drop
         {
             private readonly System.Data.DataRow _dataRow;
@@ -162,7 +161,6 @@ namespace DotLiquid.Tests
                 return null;
             }
         }
-#endif
 
         internal class CamelCaseDrop : Drop
         {
@@ -375,7 +373,6 @@ namespace DotLiquid.Tests
             Assert.That(Template.Parse("{{ nulldrop.a_method }}").Render(Hash.FromAnonymousObject(new { nulldrop = new NullDrop() })), Is.EqualTo(""));
         }
 
-#if !CORE
         [Test]
         public void TestDataRowDrop()
         {
@@ -390,7 +387,6 @@ namespace DotLiquid.Tests
             Template tpl = Template.Parse(" {{ row.column1 }} ");
             Assert.That(tpl.Render(Hash.FromAnonymousObject(new { row = new DataRowDrop(dataRow) })), Is.EqualTo(" Hello "));
         }
-#endif
 
         [Test]
         public void TestRubyNamingConventionPrintsHelpfulErrorIfMissingPropertyWouldMatchCSharpNamingConvention()

--- a/src/DotLiquid.Tests/GoldenLiquidTests.cs
+++ b/src/DotLiquid.Tests/GoldenLiquidTests.cs
@@ -61,12 +61,7 @@ namespace DotLiquid.Tests
         private static T DeserializeResource<T>(string resourceName)
         {
             // Load the JSON content
-#if NETCOREAPP1_0
-            var assembly = typeof(GoldenLiquidTests).GetTypeInfo().Assembly;
-#else
             var assembly = Assembly.GetExecutingAssembly();
-#endif
-
             var jsonContent = string.Empty;
             using (Stream stream = assembly.GetManifestResourceStream(resourceName))
             using (StreamReader reader = new StreamReader(stream))

--- a/src/DotLiquid.Tests/RegexpTests.cs
+++ b/src/DotLiquid.Tests/RegexpTests.cs
@@ -12,7 +12,6 @@ namespace DotLiquid.Tests
     [TestFixture]
     public class RegexpTests
     {
-#if !NETCOREAPP1_0
         [Test]
         public void TestAllRegexesAreCompiled()
         {
@@ -28,7 +27,6 @@ namespace DotLiquid.Tests
                 }
             }
         }
-#endif
 
         [Test]
         public void TestEmpty()

--- a/src/DotLiquid.Tests/TemplateTests.cs
+++ b/src/DotLiquid.Tests/TemplateTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using System.IO;
 using System.Net;
@@ -156,7 +157,7 @@ namespace DotLiquid.Tests
         }
 
         [Test]
-        public void TestRenderToStreamWriter()
+        public void TestRenderToTextWriter()
         {
             Template template = Template.Parse("{{test}}");
 
@@ -181,6 +182,66 @@ namespace DotLiquid.Tests
             using (TextReader reader = new StreamReader(output))
             {
                 Assert.That(reader.ReadToEnd(), Is.EqualTo("worked"));
+            }
+        }
+
+        [Test]
+        public void TestRenderEmptyDocument()
+        {
+            Template template = Template.Parse(null);
+            Assert.That(template.Render(CultureInfo.CurrentCulture), Is.EqualTo(String.Empty));
+        }
+
+        [Test]
+        public void TestRenderNoRoot()
+        {
+            Template template = Template.Parse(null);
+            template.Root = null;
+
+            Assert.That(template.Render(CultureInfo.CurrentCulture), Is.EqualTo(String.Empty));
+        }
+
+        [Test]
+        public void TestRenderToNullStream()
+        {
+            Template template = Template.Parse("{{test}}");
+            Stream stream = null;
+            Assert.Throws<ArgumentNullException>(() => template.Render(stream, new RenderParameters(CultureInfo.InvariantCulture)));
+        }
+
+        [Test]
+        public void TestRenderToNullTextWriter()
+        {
+            Template template = Template.Parse("{{test}}");
+            TextWriter writer = null;
+            Assert.Throws<ArgumentNullException>(() => template.Render(writer, new RenderParameters(CultureInfo.InvariantCulture)));
+        }
+
+        [Test]
+        public void TestRenderNullParameters()
+        {
+            Template template = Template.Parse("{{test}}");
+            RenderParameters parameters = null;
+            Assert.Throws<ArgumentNullException>(() => template.Render(parameters));
+        }
+
+        [Test]
+        public void TestRenderToStreamNullParameters()
+        {
+            Template template = Template.Parse("{{test}}");
+            using (Stream stream = new MemoryStream())
+            {
+                Assert.Throws<ArgumentNullException>(() => template.Render(stream, null));
+            }
+        }
+
+        [Test]
+        public void TestRenderToTextWriterNullParameters()
+        {
+            Template template = Template.Parse("{{test}}");
+            using (TextWriter writer = new StringWriter(CultureInfo.InvariantCulture))
+            {
+                Assert.Throws<ArgumentNullException>(() => template.Render(writer, null));
             }
         }
 

--- a/src/DotLiquid.Tests/TemplateTests.cs
+++ b/src/DotLiquid.Tests/TemplateTests.cs
@@ -245,6 +245,12 @@ namespace DotLiquid.Tests
             }
         }
 
+        [Test]
+        public void TestGetTagTypeUnknownTag()
+        {
+            Assert.That(Template.GetTagType("unknown"), Is.Null);
+        }
+
         public class MySimpleType
         {
             public string Name { get; set; }

--- a/src/DotLiquid.Tests/Util/ObjectExtensionMethodsTests.cs
+++ b/src/DotLiquid.Tests/Util/ObjectExtensionMethodsTests.cs
@@ -133,6 +133,8 @@ namespace DotLiquid.Tests.Util
             Assert.That(ObjectExtensionMethods.RespondTo(instance, "GetValue"), Is.True);
 
             Assert.That(ObjectExtensionMethods.RespondTo(instance, "NotFound"), Is.False);
+
+            Assert.Throws<ArgumentNullException>(() => ObjectExtensionMethods.RespondTo(NIL, "GetValue"));
         }
 
         [Test]
@@ -143,6 +145,8 @@ namespace DotLiquid.Tests.Util
             Assert.That(ObjectExtensionMethods.Send(instance, "GetValue"), Is.EqualTo(35));
 
             Assert.That(ObjectExtensionMethods.Send(instance, "NotFound"), Is.Null);
+
+            Assert.Throws<ArgumentNullException>(() => ObjectExtensionMethods.Send(NIL, "GetValue"));
         }
     }
 }

--- a/src/DotLiquid.Tests/Util/ObjectExtensionMethodsTests.cs
+++ b/src/DotLiquid.Tests/Util/ObjectExtensionMethodsTests.cs
@@ -8,6 +8,12 @@ namespace DotLiquid.Tests.Util
     [TestFixture]
     public class ObjectExtensionMethodsTests
     {
+        private class DummyClass
+        {
+            public int IntProperty { get; set; } = 42;
+            public int GetValue() => 35;
+        }
+
         private static readonly object NIL = null;
 
         [Test]
@@ -117,6 +123,26 @@ namespace DotLiquid.Tests.Util
 
             Assert.That(keyValuePair.GetPropertyValue("Key"), Is.EqualTo("*key*"));
             Assert.That(keyValuePair.GetPropertyValue("Value"), Is.EqualTo("*value*"));
+        }
+
+        [Test]
+        public void TestRepondTo()
+        {
+            DummyClass instance = new DummyClass();
+            Assert.That(ObjectExtensionMethods.RespondTo(instance, "IntProperty"), Is.True);
+            Assert.That(ObjectExtensionMethods.RespondTo(instance, "GetValue"), Is.True);
+
+            Assert.That(ObjectExtensionMethods.RespondTo(instance, "NotFound"), Is.False);
+        }
+
+        [Test]
+        public void TestSend()
+        {
+            DummyClass instance = new DummyClass();
+            Assert.That(ObjectExtensionMethods.Send(instance, "IntProperty"), Is.EqualTo(42));
+            Assert.That(ObjectExtensionMethods.Send(instance, "GetValue"), Is.EqualTo(35));
+
+            Assert.That(ObjectExtensionMethods.Send(instance, "NotFound"), Is.Null);
         }
     }
 }

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -637,7 +637,11 @@ namespace DotLiquid
                 || (key is decimal dec && Math.Truncate(dec) == dec) || (key is double dbl && Math.Truncate(dbl) == dbl) || (key is float flt && Math.Truncate(flt) == flt)))
             {
                 var index = Convert.ToInt32(key);
-                value = listObj[index < 0 ? listObj.Count + index : index];
+                index = index < 0 ? listObj.Count + index : index;
+                if (index >= 0 && index < listObj.Count)
+                    value = listObj[index];
+                else
+                    return false;
             }
 
             else if (TypeUtility.IsAnonymousType(obj.GetType()) && obj.GetType().GetRuntimeProperty((string)key) != null)

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -698,11 +698,7 @@ namespace DotLiquid
             }
 
             var valueType = obj.GetType();
-#if NETSTANDARD1_3
-            if (valueType.GetTypeInfo().IsPrimitive)
-#else
             if (valueType.IsPrimitive)
-#endif
             {
                 return obj;
             }
@@ -737,11 +733,7 @@ namespace DotLiquid
             if (obj != null)
             {
                 Type valueType = obj.GetType();
-#if NETSTANDARD1_3
-                if (valueType.GetTypeInfo().IsGenericType)
-#else
                 if (valueType.IsGenericType)
-#endif
                 {
                     Type baseType = valueType.GetGenericTypeDefinition();
                     if (baseType == typeof(KeyValuePair<,>))

--- a/src/DotLiquid/DotLiquid.csproj
+++ b/src/DotLiquid/DotLiquid.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>DotLiquid</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Authors>Tim Jones;Alessandro Petrelli</Authors>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;net45;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45;net6.0</TargetFrameworks>
     <AssemblyName>DotLiquid</AssemblyName>
     <AssemblyOriginatorKeyFile>../Formosatek-OpenSource.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -41,13 +41,8 @@
     </None>
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <DefineConstants>$(DefineConstants);CORE</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-
 </Project>

--- a/src/DotLiquid/DotLiquid.csproj
+++ b/src/DotLiquid/DotLiquid.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>DotLiquid</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Authors>Tim Jones;Alessandro Petrelli</Authors>
-    <TargetFrameworks>netstandard2.0;net45;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>DotLiquid</AssemblyName>
     <AssemblyOriginatorKeyFile>../Formosatek-OpenSource.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -41,7 +41,7 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/DotLiquid/DotLiquid.csproj
+++ b/src/DotLiquid/DotLiquid.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>DotLiquid</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Authors>Tim Jones;Alessandro Petrelli</Authors>
-    <TargetFrameworks>netstandard2.0;net461;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>DotLiquid</AssemblyName>
     <AssemblyOriginatorKeyFile>../Formosatek-OpenSource.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/src/DotLiquid/DotLiquid.nuspec
+++ b/src/DotLiquid/DotLiquid.nuspec
@@ -29,10 +29,10 @@
     <file src="bin\Release\netstandard2.0\it\DotLiquid.resources.dll" target="lib\netstandard2.0\it" />
     <file src="bin\Release\netstandard2.0\DotLiquid.pdb" target="lib\netstandard2.0" />
     <file src="bin\Release\netstandard2.0\DotLiquid.xml" target="lib\netstandard2.0" />
-    <file src="bin\Release\net461\DotLiquid.dll" target="lib\net461" />
-    <file src="bin\Release\net461\it\DotLiquid.resources.dll" target="lib\net461\it" />
-    <file src="bin\Release\net461\DotLiquid.pdb" target="lib\net461" />
-    <file src="bin\Release\net461\DotLiquid.xml" target="lib\net461" />
+    <file src="bin\Release\net462\DotLiquid.dll" target="lib\net462" />
+    <file src="bin\Release\net462\it\DotLiquid.resources.dll" target="lib\net462\it" />
+    <file src="bin\Release\net462\DotLiquid.pdb" target="lib\net462" />
+    <file src="bin\Release\net462\DotLiquid.xml" target="lib\net462" />
     <file src="bin\Release\net6.0\DotLiquid.dll" target="lib\net6.0" />
     <file src="bin\Release\net6.0\it\DotLiquid.resources.dll" target="lib\net6.0\it" />
     <file src="bin\Release\net6.0\DotLiquid.pdb" target="lib\net6.0" />

--- a/src/DotLiquid/DotLiquid.nuspec
+++ b/src/DotLiquid/DotLiquid.nuspec
@@ -16,9 +16,10 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <tags>template templating language liquid markup</tags>
     <dependencies>
-      <group targetFramework="net45" />
+      <group targetFramework="net461" />
       <group targetFramework="netstandard2.0" />
-      <group targetFramework="net6.0" />        
+      <group targetFramework="net6.0" />
+      <group targetFramework="net8.0" />
     </dependencies>
   </metadata>
   <files>
@@ -28,14 +29,18 @@
     <file src="bin\Release\netstandard2.0\it\DotLiquid.resources.dll" target="lib\netstandard2.0\it" />
     <file src="bin\Release\netstandard2.0\DotLiquid.pdb" target="lib\netstandard2.0" />
     <file src="bin\Release\netstandard2.0\DotLiquid.xml" target="lib\netstandard2.0" />
-    <file src="bin\Release\net45\DotLiquid.dll" target="lib\net45" />
-    <file src="bin\Release\net45\it\DotLiquid.resources.dll" target="lib\net45\it" />
-    <file src="bin\Release\net45\DotLiquid.pdb" target="lib\net45" />
-    <file src="bin\Release\net45\DotLiquid.xml" target="lib\net45" />
+    <file src="bin\Release\net461\DotLiquid.dll" target="lib\net461" />
+    <file src="bin\Release\net461\it\DotLiquid.resources.dll" target="lib\net461\it" />
+    <file src="bin\Release\net461\DotLiquid.pdb" target="lib\net461" />
+    <file src="bin\Release\net461\DotLiquid.xml" target="lib\net461" />
     <file src="bin\Release\net6.0\DotLiquid.dll" target="lib\net6.0" />
     <file src="bin\Release\net6.0\it\DotLiquid.resources.dll" target="lib\net6.0\it" />
     <file src="bin\Release\net6.0\DotLiquid.pdb" target="lib\net6.0" />
     <file src="bin\Release\net6.0\DotLiquid.xml" target="lib\net6.0" />
+    <file src="bin\Release\net8.0\DotLiquid.dll" target="lib\net8.0" />
+    <file src="bin\Release\net8.0\it\DotLiquid.resources.dll" target="lib\net8.0\it" />
+    <file src="bin\Release\net8.0\DotLiquid.pdb" target="lib\net8.0" />
+    <file src="bin\Release\net8.0\DotLiquid.xml" target="lib\net8.0" />
     <file src="**\*.cs" target="src" />
   </files>
 </package>

--- a/src/DotLiquid/DotLiquid.nuspec
+++ b/src/DotLiquid/DotLiquid.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <package>
   <metadata>
     <id>DotLiquid</id>
@@ -17,7 +17,6 @@
     <tags>template templating language liquid markup</tags>
     <dependencies>
       <group targetFramework="net45" />
-      <group targetFramework="netstandard1.3" />
       <group targetFramework="netstandard2.0" />
       <group targetFramework="net6.0" />        
     </dependencies>
@@ -25,10 +24,6 @@
   <files>
     <file src="LICENSE.txt" target="" />
     <file src="readme.txt" target="" />
-    <file src="bin\Release\netstandard1.3\DotLiquid.dll" target="lib\netstandard1.3" />
-    <file src="bin\Release\netstandard1.3\it\DotLiquid.resources.dll" target="lib\netstandard1.3\it" />
-    <file src="bin\Release\netstandard1.3\DotLiquid.pdb" target="lib\netstandard1.3" />
-    <file src="bin\Release\netstandard1.3\DotLiquid.xml" target="lib\netstandard1.3" />
     <file src="bin\Release\netstandard2.0\DotLiquid.dll" target="lib\netstandard2.0" />
     <file src="bin\Release\netstandard2.0\it\DotLiquid.resources.dll" target="lib\netstandard2.0\it" />
     <file src="bin\Release\netstandard2.0\DotLiquid.pdb" target="lib\netstandard2.0" />

--- a/src/DotLiquid/Exceptions/ArgumentException.cs
+++ b/src/DotLiquid/Exceptions/ArgumentException.cs
@@ -2,9 +2,7 @@ using System;
 
 namespace DotLiquid.Exceptions
 {
-#if !CORE
     [Serializable]
-#endif
     public class ArgumentException : LiquidException
     {
         public ArgumentException(string message, params string[] args)

--- a/src/DotLiquid/Exceptions/ContextException.cs
+++ b/src/DotLiquid/Exceptions/ContextException.cs
@@ -2,9 +2,7 @@ using System;
 
 namespace DotLiquid.Exceptions
 {
-#if !CORE
     [Serializable]
-#endif
     public class ContextException : LiquidException
     {
         public ContextException(string message, params string[] args)

--- a/src/DotLiquid/Exceptions/FileSystemException.cs
+++ b/src/DotLiquid/Exceptions/FileSystemException.cs
@@ -2,9 +2,7 @@ using System;
 
 namespace DotLiquid.Exceptions
 {
-#if !CORE
     [Serializable]
-#endif
     public class FileSystemException : LiquidException
     {
         public FileSystemException(string message, params string[] args)

--- a/src/DotLiquid/Exceptions/FilterNotFoundException.cs
+++ b/src/DotLiquid/Exceptions/FilterNotFoundException.cs
@@ -2,9 +2,7 @@ using System;
 
 namespace DotLiquid.Exceptions
 {
-#if !CORE
     [Serializable]
-#endif
     public class FilterNotFoundException : LiquidException
     {
         public FilterNotFoundException(string message, FilterNotFoundException innerException)

--- a/src/DotLiquid/Exceptions/LiquidException.cs
+++ b/src/DotLiquid/Exceptions/LiquidException.cs
@@ -3,7 +3,7 @@ using System;
 namespace DotLiquid.Exceptions
 {
     [Serializable]
-    public abstract class LiquidException : ApplicationException
+    public abstract class LiquidException : Exception
     {
         protected LiquidException(string message, Exception innerException)
             : base(message, innerException)

--- a/src/DotLiquid/Exceptions/LiquidException.cs
+++ b/src/DotLiquid/Exceptions/LiquidException.cs
@@ -2,15 +2,8 @@ using System;
 
 namespace DotLiquid.Exceptions
 {
-#if !CORE
     [Serializable]
-#endif
-    public abstract class LiquidException :
-#if CORE
-        Exception
-#else
-        ApplicationException
-#endif
+    public abstract class LiquidException : ApplicationException
     {
         protected LiquidException(string message, Exception innerException)
             : base(message, innerException)

--- a/src/DotLiquid/Exceptions/RenderException.cs
+++ b/src/DotLiquid/Exceptions/RenderException.cs
@@ -1,16 +1,9 @@
-﻿using System;
+using System;
 
 namespace DotLiquid.Exceptions
 {
-#if !CORE
     [Serializable]
-#endif
-    public abstract class RenderException :
-#if CORE
-        Exception
-#else
-        ApplicationException
-#endif
+    public abstract class RenderException : LiquidException
     {
         protected RenderException(string message, Exception innerException)
             : base(message, innerException)

--- a/src/DotLiquid/Exceptions/StackLevelException.cs
+++ b/src/DotLiquid/Exceptions/StackLevelException.cs
@@ -2,9 +2,7 @@ using System;
 
 namespace DotLiquid.Exceptions
 {
-#if !CORE
     [Serializable]
-#endif
     public class StackLevelException : LiquidException
     {
         public StackLevelException(string message)

--- a/src/DotLiquid/Exceptions/SyntaxException.cs
+++ b/src/DotLiquid/Exceptions/SyntaxException.cs
@@ -5,9 +5,7 @@ namespace DotLiquid.Exceptions
     /// <summary>
     /// An exception that is thrown when an invalid or unknown syntax is encountered in a template.
     /// </summary>
-#if !CORE
     [Serializable]
-#endif
     public class SyntaxException : LiquidException
     {
         /// <summary>

--- a/src/DotLiquid/Exceptions/VariableNotFoundException.cs
+++ b/src/DotLiquid/Exceptions/VariableNotFoundException.cs
@@ -2,9 +2,7 @@ using System;
 
 namespace DotLiquid.Exceptions
 {
-#if !CORE
     [Serializable]
-#endif
     public class VariableNotFoundException : LiquidException
     {
         public VariableNotFoundException(string message, params string[] args)

--- a/src/DotLiquid/ExtendedFilters.cs
+++ b/src/DotLiquid/ExtendedFilters.cs
@@ -16,12 +16,7 @@ namespace DotLiquid
         public static string Titleize(Context context, string input)
         {
             return input.IsNullOrWhiteSpace()
-                ? input
-#if CORE
-                : Regex.Replace(input, @"\b(\w)", m => m.Value.ToUpper(), RegexOptions.None, Template.RegexTimeOut);
-#else
-                : context.CurrentCulture.TextInfo.ToTitleCase(input);
-#endif
+                ? input : context.CurrentCulture.TextInfo.ToTitleCase(input);
         }
 
         /// <summary>

--- a/src/DotLiquid/StandardFilters.cs
+++ b/src/DotLiquid/StandardFilters.cs
@@ -23,33 +23,6 @@ namespace DotLiquid
         private static readonly Lazy<Regex> StripHtmlBlocks = new Lazy<Regex>(() => R.C(@"<script.*?</script>|<!--.*?-->|<style.*?</style>", RegexOptions.Singleline | RegexOptions.IgnoreCase), LazyThreadSafetyMode.ExecutionAndPublication);
         private static readonly Lazy<Regex> StripHtmlTags = new Lazy<Regex>(() => R.C(@"<.*?>", RegexOptions.Singleline), LazyThreadSafetyMode.ExecutionAndPublication);
 
-#if NETSTANDARD1_3
-        private class StringAwareObjectComparer : IComparer
-        {
-            private readonly StringComparer _stringComparer;
-
-            public StringAwareObjectComparer(StringComparer stringComparer)
-            {
-                _stringComparer = stringComparer;
-            }
-
-            public int Compare(Object x, Object y)
-            {
-                if (x == y)
-                    return 0;
-                if (x == null)
-                    return -1;
-                if (y == null)
-                    return 1;
-
-                if (x is string textX && y is string textY)
-                    return _stringComparer.Compare(textX, textY);
-
-                return Comparer<object>.Default.Compare(x, y);
-            }
-        }
-#endif
-
         /// <summary>
         /// Return the size of an array or of an string
         /// </summary>
@@ -446,12 +419,7 @@ namespace DotLiquid
             if (!ary.Any())
                 return ary;
 
-#if NETSTANDARD1_3
-            var comparer = new StringAwareObjectComparer(stringComparer);
-#else
             var comparer = stringComparer;
-#endif 
-
             if (string.IsNullOrEmpty(property))
             {
                 ary.Sort((a, b) => comparer.Compare(a, b));
@@ -643,11 +611,7 @@ namespace DotLiquid
             }
             else if ((input is decimal) || (input is double) || (input is float) || (input is int) || (input is uint) || (input is long) || (input is ulong) || (input is short) || (input is ushort))
             {
-#if CORE
-                dateTimeOffset = DateTimeOffset.FromUnixTimeSeconds(Convert.ToInt64(input)).ToLocalTime();
-#else
                 dateTimeOffset = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero).AddSeconds(Convert.ToDouble(input)).ToLocalTime();
-#endif
             }
             else
             {

--- a/src/DotLiquid/Strainer.cs
+++ b/src/DotLiquid/Strainer.cs
@@ -143,7 +143,7 @@ namespace DotLiquid
                 {
                     var parameterType = parameterInfos[argumentIndex].ParameterType;
                     if (convertibleArg.GetType() != parameterType
-                        && !parameterType.IsAssignableFrom(convertibleArg.GetType()))
+                        && !parameterType.IsInstanceOfType(convertibleArg))
                     {
                         args[argumentIndex] = Convert.ChangeType(convertibleArg, parameterType);
                     }

--- a/src/DotLiquid/Strainer.cs
+++ b/src/DotLiquid/Strainer.cs
@@ -150,14 +150,16 @@ namespace DotLiquid
                 }
             }
 
+            object result = null;
             try
             {
-                return methodInfo.Item2.Invoke(methodInfo.Item1, args.ToArray());
+                result = methodInfo.Item2.Invoke(methodInfo.Item1, args.ToArray());
             }
             catch (TargetInvocationException ex)
             {
                 ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
             }
+            return result;
         }
     }
 }

--- a/src/DotLiquid/Strainer.cs
+++ b/src/DotLiquid/Strainer.cs
@@ -143,18 +143,7 @@ namespace DotLiquid
                 {
                     var parameterType = parameterInfos[argumentIndex].ParameterType;
                     if (convertibleArg.GetType() != parameterType
-                        && !parameterType
-#if NETSTANDARD1_3
-                            .GetTypeInfo()
-#endif
-                            .IsAssignableFrom(
-                                convertibleArg
-                                    .GetType()
-#if NETSTANDARD1_3
-                                    .GetTypeInfo()
-#endif
-                                    )
-                        )
+                        && !parameterType.IsAssignableFrom(convertibleArg.GetType()))
                     {
                         args[argumentIndex] = Convert.ChangeType(convertibleArg, parameterType);
                     }

--- a/src/DotLiquid/Strainer.cs
+++ b/src/DotLiquid/Strainer.cs
@@ -157,7 +157,6 @@ namespace DotLiquid
             catch (TargetInvocationException ex)
             {
                 ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-                throw;
             }
         }
     }

--- a/src/DotLiquid/Tags/Param.cs
+++ b/src/DotLiquid/Tags/Param.cs
@@ -82,11 +82,7 @@ namespace DotLiquid.Tags
                 value = String.Empty; // String.Empty will ensure the InvariantCulture is returned
             try
             {
-#if CORE
-                context.CurrentCulture = new CultureInfo(value);
-#else
                 context.CurrentCulture = CultureInfo.GetCultureInfo(value);
-#endif
             }
             catch (CultureNotFoundException exception)
             {

--- a/src/DotLiquid/Template.cs
+++ b/src/DotLiquid/Template.cs
@@ -100,8 +100,9 @@ namespace DotLiquid
         /// <returns></returns>
         public static Type GetTagType(string name)
         {
-            Tags.TryGetValue(name, out Tuple<ITagFactory, Type> result);
-            return result.Item2;
+            if (Tags.TryGetValue(name, out Tuple<ITagFactory, Type> result))
+                return result.Item2;
+            return null;
         }
 
         /// <summary>
@@ -111,16 +112,16 @@ namespace DotLiquid
         /// <returns></returns>
         internal static bool IsRawTag(string name)
         {
-            Tags.TryGetValue(name, out Tuple<ITagFactory, Type> result);
-            return typeof(RawBlock).IsAssignableFrom(result?.Item2);
+            if (Tags.TryGetValue(name, out Tuple<ITagFactory, Type> result))
+                return typeof(RawBlock).IsAssignableFrom(result?.Item2);
+            return false;
         }
 
         internal static Tag CreateTag(string name)
         {
             Tag tagInstance = null;
-            Tags.TryGetValue(name, out Tuple<ITagFactory, Type> result);
-
-            if (result != null)
+            if (Tags.TryGetValue(name, out Tuple<ITagFactory, Type> result) &&
+                result != null)
             {
                 tagInstance = result.Item1.Create();
             }

--- a/src/DotLiquid/Template.cs
+++ b/src/DotLiquid/Template.cs
@@ -392,6 +392,9 @@ namespace DotLiquid
         /// <returns>The rendering result as string.</returns>
         public string Render(RenderParameters parameters)
         {
+            if (parameters == null)
+                throw new ArgumentNullException(paramName: nameof(parameters));
+
             using (var writer = new StringWriter(parameters.FormatProvider))
             {
                 return this.Render(writer, parameters);
@@ -430,6 +433,11 @@ namespace DotLiquid
         /// <param name="parameters">The render parameters.</param>
         public void Render(Stream stream, RenderParameters parameters)
         {
+            if (stream == null)
+                throw new ArgumentNullException(paramName: nameof(stream));
+            if (parameters == null)
+                throw new ArgumentNullException(paramName: nameof(parameters));
+
             // Can't dispose this new StreamWriter, because it would close the
             // passed-in stream, which isn't up to us.
             StreamWriter streamWriter = new StreamWriterWithFormatProvider(stream, parameters.FormatProvider);

--- a/src/DotLiquid/Template.cs
+++ b/src/DotLiquid/Template.cs
@@ -112,15 +112,7 @@ namespace DotLiquid
         internal static bool IsRawTag(string name)
         {
             Tags.TryGetValue(name, out Tuple<ITagFactory, Type> result);
-            return typeof(RawBlock)
-#if NETSTANDARD1_3
-                .GetTypeInfo()
-#endif
-                .IsAssignableFrom(result?.Item2
-#if NETSTANDARD1_3
-                    ?.GetTypeInfo()
-#endif
-                );
+            return typeof(RawBlock).IsAssignableFrom(result?.Item2);
         }
 
         internal static Tag CreateTag(string name)

--- a/src/DotLiquid/Util/ObjectExtensionMethods.cs
+++ b/src/DotLiquid/Util/ObjectExtensionMethods.cs
@@ -15,7 +15,7 @@ namespace DotLiquid.Util
         public static bool RespondTo(this object value, string member, bool ensureNoParameters = true)
         {
             if (value == null)
-                throw new ArgumentNullException("value");
+                throw new ArgumentNullException(nameof(value));
 
             Type type = value.GetType();
 
@@ -40,7 +40,7 @@ namespace DotLiquid.Util
         public static object Send(this object value, string member, object[] parameters = null)
         {
             if (value == null)
-                throw new ArgumentNullException("value");
+                throw new ArgumentNullException(nameof(value));
 
             Type type = value.GetType();
 

--- a/src/DotLiquid/Util/R.cs
+++ b/src/DotLiquid/Util/R.cs
@@ -32,10 +32,7 @@ namespace DotLiquid.Util
         /// <returns>the regex</returns>
         public static Regex C(string pattern, RegexOptions options = RegexOptions.None)
         {
-#if !CORE
-            options = options | RegexOptions.Compiled;
-#endif
-            var regex = new Regex(pattern, options, Template.RegexTimeOut);
+            Regex regex = new Regex(pattern, options | RegexOptions.Compiled, Template.RegexTimeOut);
 
             // execute once to trigger the lazy compilation (not strictly necessary, but avoids the first real execution taking a longer time than subsequent ones)
             regex.IsMatch(string.Empty);

--- a/src/DotLiquid/Util/ReflectionCacheValue.cs
+++ b/src/DotLiquid/Util/ReflectionCacheValue.cs
@@ -24,20 +24,11 @@ namespace DotLiquid.Util
 
         private bool IsAnonymousInternal()
         {
-#if NETSTANDARD1_3
-            var typeInfo = _type.GetTypeInfo();
-#endif
             return (_type.Name.StartsWith("<>") || _type.Name.StartsWith("VB$"))
                 && (_type.Name.Contains("AnonymousType") || _type.Name.Contains("AnonType"))
-#if NETSTANDARD1_3
-                    && typeInfo.GetCustomAttribute<CompilerGeneratedAttribute>() != null
-                        && typeInfo.IsGenericType
-                            && (typeInfo.Attributes & AnonymousTypeAttributes) == AnonymousTypeAttributes;
-#else
                     && _type.GetCustomAttribute<CompilerGeneratedAttribute>() != null
                         && _type.IsGenericType
                             && (_type.Attributes & AnonymousTypeAttributes) == AnonymousTypeAttributes;
-#endif
         }
     }
 }


### PR DESCRIPTION
Remove TargetFramework netstandard1.0, and associated code (`#if CORE`, `#if NETSTANDARD_1_3`). Support stopped in 2020.

Anyone starting new code should not be using this, and anyone maintaining older code can stick with older releases of DotLiquid.

Also: Add net8.0 support, and bump net461 to net462 (which is the oldest supported). We'll leave in net6.0 for now, as support has only just ended (Nov 2024) and there are probably some projects still using it. 


