### PR TITLE
Implement replace_last and remove_last filters

### DIFF
--- a/src/DotLiquid.Tests/Embedded/golden_rules.json
+++ b/src/DotLiquid.Tests/Embedded/golden_rules.json
@@ -94,8 +94,6 @@
         "liquid.golden.plus_filter - undefined left value",
         "liquid.golden.remove_filter - undefined argument",
         "liquid.golden.replace_filter - undefined first argument",
-        "liquid.golden.replace_first_filter - undefined first argument",
-        "liquid.golden.replace_first_filter - undefined second argument",
         "liquid.golden.slice_filter - undefined first argument",
         "liquid.golden.slice_filter - undefined second argument",
         "liquid.golden.sort_natural_filter - argument is undefined",

--- a/src/DotLiquid.Tests/Embedded/golden_rules.json
+++ b/src/DotLiquid.Tests/Embedded/golden_rules.json
@@ -8,7 +8,6 @@
         "liquid.golden.liquid_tag", // not yet implemented
         "liquid.golden.reject_filter", // not yet implemented
         "liquid.golden.render_tag", // not yet implemented
-        "liquid.golden.replace_last_filter", // not yet implemented
         "liquid.golden.sum_filter", // not yet implemented
         "liquid.golden.truncatewords_filter" // implemented as truncate_words so these will fail for now
     ],
@@ -94,14 +93,9 @@
         "liquid.golden.plus_filter - undefined argument",
         "liquid.golden.plus_filter - undefined left value",
         "liquid.golden.remove_filter - undefined argument",
-        "liquid.golden.remove_last_filter - undefined argument",
-        "liquid.golden.remove_last_filter - undefined left value",
         "liquid.golden.replace_filter - undefined first argument",
         "liquid.golden.replace_first_filter - undefined first argument",
         "liquid.golden.replace_first_filter - undefined second argument",
-        "liquid.golden.replace_last_filter - undefined first argument",
-        "liquid.golden.replace_last_filter - undefined left value",
-        "liquid.golden.replace_last_filter - undefined second argument",
         "liquid.golden.slice_filter - undefined first argument",
         "liquid.golden.slice_filter - undefined second argument",
         "liquid.golden.sort_natural_filter - argument is undefined",
@@ -191,9 +185,6 @@
         "liquid.golden.range_objects - whitespace before and after dots, for loop",
         "liquid.golden.range_objects - whitespace before dots",
         "liquid.golden.range_objects - whitespace before start",
-        "liquid.golden.remove_last_filter - argument not a string",
-        "liquid.golden.remove_last_filter - not a string",
-        "liquid.golden.remove_last_filter - remove substrings",
         "liquid.golden.replace_filter - left value is an object",
         "liquid.golden.reverse_filter - array of things",
         "liquid.golden.reverse_filter - left value not an array",

--- a/src/DotLiquid.Tests/Filters/StandardFiltersTestsBase.cs
+++ b/src/DotLiquid.Tests/Filters/StandardFiltersTestsBase.cs
@@ -130,8 +130,6 @@ namespace DotLiquid.Tests.Filters
         {
             Assert.That(ReplaceFirst(input: null, @string: "a", replacement: "b"), Is.Null);
             Assert.That(ReplaceFirst(input: "", @string: "a", replacement: "b"), Is.EqualTo(""));
-            Assert.That(ReplaceFirst(input: "a a a a", @string: null, replacement: "b"), Is.EqualTo("a a a a"));
-            Assert.That(ReplaceFirst(input: "a a a a", @string: "", replacement: "b"), Is.EqualTo("a a a a"));
             Assert.That(ReplaceFirst(input: "a a a a", @string: "a", replacement: "b"), Is.EqualTo("b a a a"));
             Helper.AssertTemplateResult(expected: "b a a a", template: "{{ 'a a a a' | replace_first: 'a', 'b' }}", syntax: SyntaxCompatibilityLevel);
         }

--- a/src/DotLiquid.Tests/Filters/StandardFiltersV21Tests.cs
+++ b/src/DotLiquid.Tests/Filters/StandardFiltersV21Tests.cs
@@ -13,9 +13,9 @@ namespace DotLiquid.Tests.Filters
         public override MathDelegate Plus => (i, o) => StandardFilters.Plus(_context, i, o);
         public override MathDelegate Minus => (i, o) => StandardFilters.Minus(_context, i, o);
         public override MathDelegate Modulo => (i, o) => StandardFilters.Modulo(_context, i, o);
-        public override RemoveFirstDelegate RemoveFirst => (a, b) => StandardFilters.RemoveFirst(a, b);
+        public override RemoveFirstDelegate RemoveFirst => (a, b) => LegacyFilters.RemoveFirstV21(a, b);
         public override ReplaceDelegate Replace => (i, s, r) => StandardFilters.Replace(i, s, r);
-        public override ReplaceFirstDelegate ReplaceFirst => (a, b, c) => StandardFilters.ReplaceFirst(a, b, c);
+        public override ReplaceFirstDelegate ReplaceFirst => (a, b, c) => LegacyFilters.ReplaceFirstV21(a, b, c);
         public override SliceDelegate Slice => (a, b, c) => c.HasValue ? LegacyFilters.Slice(a, b, c.Value) : LegacyFilters.Slice(a, b);
         public override SplitDelegate Split => (i, p) => LegacyFilters.Split(i, p);
         public override MathDelegate Times => (i, o) => StandardFilters.Times(_context, i, o);

--- a/src/DotLiquid.Tests/Filters/StandardFiltersV22Tests.cs
+++ b/src/DotLiquid.Tests/Filters/StandardFiltersV22Tests.cs
@@ -13,9 +13,9 @@ namespace DotLiquid.Tests.Filters
         public override MathDelegate Plus => (i, o) => StandardFilters.Plus(_context, i, o);
         public override MathDelegate Minus => (i, o) => StandardFilters.Minus(_context, i, o);
         public override MathDelegate Modulo => (i, o) => StandardFilters.Modulo(_context, i, o);
-        public override RemoveFirstDelegate RemoveFirst => (a, b) => StandardFilters.RemoveFirst(a, b);
+        public override RemoveFirstDelegate RemoveFirst => (a, b) => LegacyFilters.RemoveFirstV21(a, b);
         public override ReplaceDelegate Replace => (i, s, r) => StandardFilters.Replace(i, s, r);
-        public override ReplaceFirstDelegate ReplaceFirst => (i, s, r) => StandardFilters.ReplaceFirst(i, s, r);
+        public override ReplaceFirstDelegate ReplaceFirst => (i, s, r) => LegacyFilters.ReplaceFirstV21(i, s, r);
         public override SliceDelegate Slice => (i, s, l) => l.HasValue ? LegacyFilters.Slice(i, s, l.Value) : LegacyFilters.Slice(i, s);
         public override SplitDelegate Split => (i, p) => LegacyFilters.Split(i, p);
         public override MathDelegate Times => (i, o) => StandardFilters.Times(_context, i, o);

--- a/src/DotLiquid.Tests/Filters/StandardFiltersV22aTests.cs
+++ b/src/DotLiquid.Tests/Filters/StandardFiltersV22aTests.cs
@@ -38,6 +38,13 @@ namespace DotLiquid.Tests.Filters
         }
 
         [Test]
+        public void TestReplaceFirstInvalidSearchReturnsInput()
+        {
+            Assert.That(ReplaceFirst(input: "a a a a", @string: null, replacement: "b"), Is.EqualTo("a a a a"));
+            Assert.That(ReplaceFirst(input: "a a a a", @string: "", replacement: "b"), Is.EqualTo("a a a a"));
+        }
+
+        [Test]
         public void TestSlice()
         {
             // Verify Liquid compliance from V22a syntax:

--- a/src/DotLiquid.Tests/Filters/StandardFiltersV22aTests.cs
+++ b/src/DotLiquid.Tests/Filters/StandardFiltersV22aTests.cs
@@ -13,9 +13,9 @@ namespace DotLiquid.Tests.Filters
         public override MathDelegate Plus => (i, o) => StandardFilters.Plus(_context, i, o);
         public override MathDelegate Minus => (i, o) => StandardFilters.Minus(_context, i, o);
         public override MathDelegate Modulo => (i, o) => StandardFilters.Modulo(_context, i, o);
-        public override RemoveFirstDelegate RemoveFirst => (a, b) => StandardFilters.RemoveFirst(a, b);
+        public override RemoveFirstDelegate RemoveFirst => (a, b) => LegacyFilters.RemoveFirstV21(a, b);
         public override ReplaceDelegate Replace => (i, s, r) => StandardFilters.Replace(i, s, r);
-        public override ReplaceFirstDelegate ReplaceFirst => (a, b, c) => StandardFilters.ReplaceFirst(a, b, c);
+        public override ReplaceFirstDelegate ReplaceFirst => (i, s, r) => LegacyFilters.ReplaceFirstV21(i, s, r);
         public override SliceDelegate Slice => (a, b, c) => c.HasValue ? StandardFilters.Slice(a, b, c.Value) : StandardFilters.Slice(a, b);
         public override SplitDelegate Split => (i, p) => LegacyFilters.Split(i, p);
         public override MathDelegate Times => (i, o) => StandardFilters.Times(_context, i, o);

--- a/src/DotLiquid.Tests/Filters/StandardFiltersV24Tests.cs
+++ b/src/DotLiquid.Tests/Filters/StandardFiltersV24Tests.cs
@@ -38,6 +38,13 @@ namespace DotLiquid.Tests.Filters
         }
 
         [Test]
+        public void TestReplaceFirstInvalidSearchPrepends()
+        {
+            Assert.That(ReplaceFirst(input: "a a a a", @string: null, replacement: "b"), Is.EqualTo("ba a a a"));
+            Assert.That(ReplaceFirst(input: "a a a a", @string: "", replacement: "b"), Is.EqualTo("ba a a a"));
+        }
+
+        [Test]
         public void TestSplitNullReturnsEmptyArray()
         {
             Assert.That(Split(null, null), Has.Exactly(0).Items);

--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -1274,6 +1274,7 @@ PaulGeorge",
             Assert.That(StandardFilters.ReplaceLast(input: "", @string: "a", replacement: "b"), Is.EqualTo(""));
             Assert.That(StandardFilters.ReplaceLast(input: "a a a a", @string: null, replacement: "b"), Is.EqualTo("a a a ab"));
             Assert.That(StandardFilters.ReplaceLast(input: "a a a a", @string: "", replacement: "b"), Is.EqualTo("a a a ab"));
+            Assert.That(StandardFilters.ReplaceLast(input: "a a a a", @string: "", replacement: null), Is.EqualTo("a a a a"));
             Assert.That(StandardFilters.ReplaceLast(input: "a a b a", @string: " a", replacement: null), Is.EqualTo("a a b"));
 
             //Adapted from Shopify Tests

--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -1274,6 +1274,7 @@ PaulGeorge",
             Assert.That(StandardFilters.ReplaceLast(input: "", @string: "a", replacement: "b"), Is.EqualTo(""));
             Assert.That(StandardFilters.ReplaceLast(input: "a a a a", @string: null, replacement: "b"), Is.EqualTo("a a a ab"));
             Assert.That(StandardFilters.ReplaceLast(input: "a a a a", @string: "", replacement: "b"), Is.EqualTo("a a a ab"));
+            Assert.That(StandardFilters.ReplaceLast(input: "a a b a", @string: " a", replacement: null), Is.EqualTo("a a b"));
 
             //Adapted from Shopify Tests
             Assert.That(StandardFilters.ReplaceLast(input: "a a a a", @string: "a", replacement: "b"), Is.EqualTo("a a a b"));

--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -1090,6 +1090,12 @@ PaulGeorge",
         [Test]
         public void TestRemoveLast()
         {
+            Assert.That(StandardFilters.RemoveLast(input: null, @string: "a"), Is.Null);
+            Assert.That(StandardFilters.RemoveLast(input: "", @string: "a"), Is.EqualTo(""));
+            Assert.That(StandardFilters.RemoveLast(input: "  ", @string: " "), Is.EqualTo(" "));
+            Assert.That(StandardFilters.RemoveLast(input: "a a a a", @string: null), Is.EqualTo("a a a a"));
+            Assert.That(StandardFilters.RemoveLast(input: "a a a a", @string: ""), Is.EqualTo("a a a a"));
+            Assert.That(StandardFilters.RemoveLast(input: "a a a a", @string: "b"), Is.EqualTo("a a a a"));
             Assert.That(StandardFilters.RemoveLast(input: "a b a a", @string: "a "), Is.EqualTo("a b a"));
             Assert.That(StandardFilters.RemoveLast(input: "a a b a", @string: " a"), Is.EqualTo("a a b"));
         }

--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -1267,6 +1267,28 @@ PaulGeorge",
         }
 
         [Test]
+        public void TestReplaceLast()
+        {
+            //Adapted from ReplaceFirst Tests
+            Assert.That(StandardFilters.ReplaceLast(input: null, @string: "a", replacement: "b"), Is.Null);
+            Assert.That(StandardFilters.ReplaceLast(input: "", @string: "a", replacement: "b"), Is.EqualTo(""));
+            Assert.That(StandardFilters.ReplaceLast(input: "a a a a", @string: null, replacement: "b"), Is.EqualTo("a a a ab"));
+            Assert.That(StandardFilters.ReplaceLast(input: "a a a a", @string: "", replacement: "b"), Is.EqualTo("a a a ab"));
+
+            //Adapted from Shopify Tests
+            Assert.That(StandardFilters.ReplaceLast(input: "a a a a", @string: "a", replacement: "b"), Is.EqualTo("a a a b"));
+            Assert.That(StandardFilters.ReplaceLast(input: "1 1 1 1", @string: "1", replacement: "2"), Is.EqualTo("1 1 1 2"));
+            Assert.That(StandardFilters.ReplaceLast(input: "1 1 1 1", @string: "2", replacement: "3"), Is.EqualTo("1 1 1 1"));
+        }
+
+        [Test]
+        public void TestRemoveLast()
+        {
+            Assert.That(StandardFilters.RemoveLast(input: "a b a a", @string: "a "), Is.EqualTo("a b a"));
+            Assert.That(StandardFilters.RemoveLast(input: "a a b a", @string: " a"), Is.EqualTo("a a b"));
+        }
+
+        [Test]
         public void TestPipesInStringArguments()
         {
             Helper.AssertTemplateResult("foobar", "{{ 'foo|bar' | remove: '|' }}");

--- a/src/DotLiquid/LegacyFilters.cs
+++ b/src/DotLiquid/LegacyFilters.cs
@@ -42,12 +42,25 @@ namespace DotLiquid
         /// </summary>
         /// <param name="input">Input to be transformed by this filter</param>
         /// <param name="string">String to be removed from input</param>
-        [LiquidFilter(MaxVersion = SyntaxCompatibility.DotLiquid21)]
+        [LiquidFilter(MaxVersion = SyntaxCompatibility.DotLiquid20)]
         public static string RemoveFirst(string input, string @string)
         {
             return input.IsNullOrWhiteSpace()
                 ? input
                 : ReplaceFirst(input: input, @string: @string, replacement: string.Empty);
+        }
+
+        /// <summary>
+        /// Remove the first occurrence of a substring
+        /// </summary>
+        /// <param name="input">Input to be transformed by this filter</param>
+        /// <param name="string">String to be removed from input</param>
+        [LiquidFilter(Name = nameof(RemoveFirst), MinVersion = SyntaxCompatibility.DotLiquid21, MaxVersion = SyntaxCompatibility.DotLiquid22a)]
+        public static string RemoveFirstV21(string input, string @string)
+        {
+            return input.IsNullOrWhiteSpace()
+                ? input
+                : ReplaceFirstV21(input: input, @string: @string, replacement: string.Empty);
         }
 
         /// <summary>
@@ -71,7 +84,7 @@ namespace DotLiquid
         /// <param name="input">Input to be transformed by this filter</param>
         /// <param name="string">Substring to be replaced</param>
         /// <param name="replacement">Replacement string to be inserted</param>
-        [LiquidFilter(MaxVersion = SyntaxCompatibility.DotLiquid21)]
+        [LiquidFilter(MaxVersion = SyntaxCompatibility.DotLiquid20)]
         public static string ReplaceFirst(string input, string @string, string replacement = "")
         {
             if (string.IsNullOrEmpty(input) || string.IsNullOrEmpty(@string))
@@ -86,7 +99,22 @@ namespace DotLiquid
                 doneReplacement = true;
                 return replacement;
             }, RegexOptions.None, Template.RegexTimeOut);
-        }            
+        }
+
+        /// <summary>
+        /// Replace the first occurrence of a string with another
+        /// </summary>
+        /// <param name="input">Input to be transformed by this filter</param>
+        /// <param name="string">Substring to be replaced</param>
+        /// <param name="replacement">Replacement string to be inserted</param>
+        [LiquidFilter(Name = nameof(ReplaceFirst), MinVersion = SyntaxCompatibility.DotLiquid21, MaxVersion = SyntaxCompatibility.DotLiquid22a)]
+        public static string ReplaceFirstV21(string input, string @string, string replacement = "")
+        {
+            if (string.IsNullOrEmpty(input) || string.IsNullOrEmpty(@string))
+                return input;
+            int position = input.IndexOf(@string);
+            return position < 0 ? input : input.Remove(position, @string.Length).Insert(position, replacement);
+        }
 
         /// <summary>
         /// Addition

--- a/src/DotLiquid/StandardFilters.cs
+++ b/src/DotLiquid/StandardFilters.cs
@@ -460,13 +460,17 @@ namespace DotLiquid
         /// <param name="input">Input to be transformed by this filter</param>
         /// <param name="string">Substring to be replaced</param>
         /// <param name="replacement">Replacement string to be inserted</param>
-        [LiquidFilter(MinVersion = SyntaxCompatibility.DotLiquid22)]
+        [LiquidFilter(MinVersion = SyntaxCompatibility.DotLiquid24)]
         public static string ReplaceFirst(string input, string @string, string replacement = "")
         {
-            if (string.IsNullOrEmpty(input) || string.IsNullOrEmpty(@string))
+            if (string.IsNullOrEmpty(input))
                 return input;
-                int position = input.IndexOf(@string);
-                return position < 0 ? input : input.Remove(position, @string.Length).Insert(position, replacement);
+
+            if (string.IsNullOrEmpty(@string))
+                return input.Insert(0, replacement ?? string.Empty);
+
+            int position = input.IndexOf(@string);
+            return position < 0 ? input : input.Remove(position, @string.Length).Insert(position, replacement ?? string.Empty);
         }
 
         /// <summary>
@@ -504,25 +508,15 @@ namespace DotLiquid
         /// </summary>
         /// <param name="input">Input to be transformed by this filter</param>
         /// <param name="string">String to be removed from input</param>
-        [LiquidFilter(MinVersion = SyntaxCompatibility.DotLiquid22)]
-        public static string RemoveFirst(string input, string @string)
-        {
-            return input.IsNullOrWhiteSpace()
-                ? input
-                : ReplaceFirst(input: input, @string: @string, replacement: string.Empty);
-        }
+        [LiquidFilter(MinVersion = SyntaxCompatibility.DotLiquid24)]
+        public static string RemoveFirst(string input, string @string) => ReplaceFirst(input: input, @string: @string, replacement: string.Empty);
 
         /// <summary>
         /// Remove the last occurrence of a substring
         /// </summary>
         /// <param name="input">Input to be transformed by this filter</param>
         /// <param name="string">String to be removed from input</param>
-        public static string RemoveLast(string input, string @string)
-        {
-            return input.IsNullOrWhiteSpace()
-                ? input
-                : ReplaceLast(input: input, @string: @string, replacement: string.Empty);
-        }
+        public static string RemoveLast(string input, string @string) => ReplaceLast(input: input, @string: @string, replacement: string.Empty);
 
         /// <summary>
         /// Add one string to another

--- a/src/DotLiquid/StandardFilters.cs
+++ b/src/DotLiquid/StandardFilters.cs
@@ -543,6 +543,23 @@ namespace DotLiquid
         }
 
         /// <summary>
+        /// Replace the first occurrence of a string with another
+        /// </summary>
+        /// <param name="input">Input to be transformed by this filter</param>
+        /// <param name="string">Substring to be replaced</param>
+        /// <param name="replacement">Replacement string to be inserted</param>
+        public static string ReplaceLast(string input, string @string, string replacement)
+        {
+            if (string.IsNullOrEmpty(input))
+                return input;
+            @string = @string ?? string.Empty;
+            replacement = replacement ?? string.Empty;
+
+            int position = input.LastIndexOf(@string);
+            return position < 0 ? input : input.Remove(position, @string.Length).Insert(position, replacement);
+        }
+
+        /// <summary>
         /// Removes every occurrence of the specified substring from a string.
         /// </summary>
         /// <param name="input">Input to be transformed by this filter</param>
@@ -565,6 +582,18 @@ namespace DotLiquid
             return input.IsNullOrWhiteSpace()
                 ? input
                 : ReplaceFirst(context: context, input: input, @string: @string, replacement: string.Empty);
+        }
+
+        /// <summary>
+        /// Remove the first occurrence of a substring
+        /// </summary>
+        /// <param name="input">Input to be transformed by this filter</param>
+        /// <param name="string">String to be removed from input</param>
+        public static string RemoveLast(string input, string @string)
+        {
+            return input.IsNullOrWhiteSpace()
+                ? input
+                : ReplaceLast(input: input, @string: @string, replacement: string.Empty);
         }
 
         /// <summary>

--- a/src/DotLiquid/StandardFilters.cs
+++ b/src/DotLiquid/StandardFilters.cs
@@ -543,7 +543,7 @@ namespace DotLiquid
         }
 
         /// <summary>
-        /// Replace the first occurrence of a string with another
+        /// Replace the last occurrence of a string with another
         /// </summary>
         /// <param name="input">Input to be transformed by this filter</param>
         /// <param name="string">Substring to be replaced</param>
@@ -552,11 +552,12 @@ namespace DotLiquid
         {
             if (string.IsNullOrEmpty(input))
                 return input;
-            @string = @string ?? string.Empty;
-            replacement = replacement ?? string.Empty;
+
+            if (string.IsNullOrEmpty(@string))
+                return input.Insert(input.Length, replacement ?? string.Empty);
 
             int position = input.LastIndexOf(@string);
-            return position < 0 ? input : input.Remove(position, @string.Length).Insert(position, replacement);
+            return position < 0 ? input : input.Remove(position, @string.Length).Insert(position, replacement ?? string.Empty);
         }
 
         /// <summary>
@@ -585,7 +586,7 @@ namespace DotLiquid
         }
 
         /// <summary>
-        /// Remove the first occurrence of a substring
+        /// Remove the last occurrence of a substring
         /// </summary>
         /// <param name="input">Input to be transformed by this filter</param>
         /// <param name="string">String to be removed from input</param>


### PR DESCRIPTION
Added in Shopify Liquid 5.2.0.
_Note: These do not match the replace_first and remove_first filters rather as identified by Golden Liquid tests._