### PR TITLE
GitHub Compatible License [ci skip]

### DIFF
--- a/LICENSE-Apache
+++ b/LICENSE-Apache
@@ -1,10 +1,3 @@
-DotLiquid is intended to be used in both open-source and commercial environments. To allow its use in as many
-situations as possible, DotLiquid is dual-licensed. You may choose to use DotLiquid under either the Apache License,
-Version 2.0, or the Microsoft Public License (Ms-PL). These licenses are essentially identical, but you are
-encouraged to evaluate both to determine which best fits your intended use.
-
------
-
 Apache License, Version 2.0
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
@@ -133,43 +126,3 @@ License. However, in accepting such obligations, You may act only on Your own be
 responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold
 each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason
 of your accepting any such warranty or additional liability.
-
------
-
-Microsoft Public License (Ms-PL)
-
-This license governs use of the accompanying software. If you use the software, you
-accept this license. If you do not accept the license, do not use the software.
-
-1. Definitions
-The terms "reproduce," "reproduction," "derivative works," and "distribution" have the
-same meaning here as under U.S. copyright law.
-A "contribution" is the original software, or any additions or changes to the software.
-A "contributor" is any person that distributes its contribution under this license.
-"Licensed patents" are a contributor's patent claims that read directly on its contribution.
-
-2. Grant of Rights
-(A) Copyright Grant- Subject to the terms of this license, including the license conditions and
-    limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free
-    copyright license to reproduce its contribution, prepare derivative works of its contribution,
-    and distribute its contribution or any derivative works that you create.
-(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations
-    in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free license under
-    its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose
-    of its contribution in the software or derivative works of the contribution in the software.
-
-3. Conditions and Limitations
-(A) No Trademark License- This license does not grant you rights to use any contributors' name, logo,
-    or trademarks.
-(B) If you bring a patent claim against any contributor over patents that you claim are infringed by
-    the software, your patent license from such contributor to the software ends automatically.
-(C) If you distribute any portion of the software, you must retain all copyright, patent, trademark,
-    and attribution notices that are present in the software.
-(D) If you distribute any portion of the software in source code form, you may do so only under this
-    license by including a complete copy of this license with your distribution. If you distribute
-    any portion of the software in compiled or object code form, you may only do so under a license
-    that complies with this license.
-(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express
-    warranties, guarantees or conditions. You may have additional consumer rights under your local laws
-    which this license cannot change. To the extent permitted under your local laws, the contributors
-    exclude the implied warranties of merchantability, fitness for a particular purpose and non-infringement.

--- a/LICENSE-Ms-PL
+++ b/LICENSE-Ms-PL
@@ -1,0 +1,37 @@
+Microsoft Public License (Ms-PL)
+
+This license governs use of the accompanying software. If you use the software, you
+accept this license. If you do not accept the license, do not use the software.
+
+1. Definitions
+The terms "reproduce," "reproduction," "derivative works," and "distribution" have the
+same meaning here as under U.S. copyright law.
+A "contribution" is the original software, or any additions or changes to the software.
+A "contributor" is any person that distributes its contribution under this license.
+"Licensed patents" are a contributor's patent claims that read directly on its contribution.
+
+2. Grant of Rights
+(A) Copyright Grant- Subject to the terms of this license, including the license conditions and
+    limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free
+    copyright license to reproduce its contribution, prepare derivative works of its contribution,
+    and distribute its contribution or any derivative works that you create.
+(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations
+    in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free license under
+    its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose
+    of its contribution in the software or derivative works of the contribution in the software.
+
+3. Conditions and Limitations
+(A) No Trademark License- This license does not grant you rights to use any contributors' name, logo,
+    or trademarks.
+(B) If you bring a patent claim against any contributor over patents that you claim are infringed by
+    the software, your patent license from such contributor to the software ends automatically.
+(C) If you distribute any portion of the software, you must retain all copyright, patent, trademark,
+    and attribution notices that are present in the software.
+(D) If you distribute any portion of the software in source code form, you may do so only under this
+    license by including a complete copy of this license with your distribution. If you distribute
+    any portion of the software in compiled or object code form, you may only do so under a license
+    that complies with this license.
+(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express
+    warranties, guarantees or conditions. You may have additional consumer rights under your local laws
+    which this license cannot change. To the extent permitted under your local laws, the contributors
+    exclude the implied warranties of merchantability, fitness for a particular purpose and non-infringement.

--- a/README.markdown
+++ b/README.markdown
@@ -82,6 +82,6 @@ Are you using DotLiquid in an open source project? Tell us with a PR!
 
 ### License
 DotLiquid is intended to be used in both open-source and commercial environments. To allow its use in as many
-situations as possible, DotLiquid is dual-licensed. You may choose to use DotLiquid under either the Apache License,
-Version 2.0, or the Microsoft Public License (Ms-PL). These licenses are essentially identical, but you are
+situations as possible, DotLiquid is dual-licensed. You may choose to use DotLiquid under either the [Apache License,
+Version 2.0](LICENSE-Apache), or the [Microsoft Public License (Ms‑PL)](LICENSE-Ms-PL). These licenses are essentially identical, but you are
 encouraged to evaluate both to determine which best fits your intended use.

--- a/README.markdown
+++ b/README.markdown
@@ -79,3 +79,9 @@ Are you using DotLiquid in an open source project? Tell us with a PR!
  - [DotLiquid View Engine for ASP.NET MVC](https://www.nuget.org/packages/DotLiquid.ViewEngine)
  - [DotLiquid View Engine for Nancy](https://www.nuget.org/packages/Nancy.Viewengines.DotLiquid)
  - [GrandNode 2.0](https://github.com/grandnode/grandnode2)
+
+### License
+DotLiquid is intended to be used in both open-source and commercial environments. To allow its use in as many
+situations as possible, DotLiquid is dual-licensed. You may choose to use DotLiquid under either the Apache License,
+Version 2.0, or the Microsoft Public License (Ms-PL). These licenses are essentially identical, but you are
+encouraged to evaluate both to determine which best fits your intended use.


### PR DESCRIPTION
This will show two separate tabs for the license options:
![image](https://github.com/user-attachments/assets/aa113f40-2293-4578-a7ca-aa21889f4b24)
Previously it had the generic "License" as it did not recognize the combination license.