### PR TITLE
Implement Expression Caching For Math Ops

### DIFF
--- a/src/DotLiquid.Tests/Util/ExpressionUtilityTest.cs
+++ b/src/DotLiquid.Tests/Util/ExpressionUtilityTest.cs
@@ -2,6 +2,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 
 namespace DotLiquid.Tests.Util
 {
@@ -55,6 +56,26 @@ namespace DotLiquid.Tests.Util
             Assert.That(typeLimits[result].Item1 >= typeLimits[t2].Item1, Is.True);
             Assert.That(typeLimits[result].Item2 <= typeLimits[t1].Item2, Is.True);
             Assert.That(typeLimits[result].Item2 <= typeLimits[t1].Item2, Is.True);
+        }
+
+        /// <summary>
+        /// Repeated calls to CreateExpression with the same operation/operand types must reuse a cached
+        /// compiled delegate instead of re-compiling an Expression.Lambda every time. This guards against
+        /// regressions to an unbounded compile-per-call cost (e.g. when a maths filter is applied within a loop).
+        /// </summary>
+        [Test]
+        public void TestCreateExpressionCachesCompiledDelegate()
+        {
+            Func<Expression, Expression, BinaryExpression> operation = Expression.AddChecked;
+
+            var first = DotLiquid.Util.ExpressionUtility.CreateExpression(operation, typeof(int), typeof(int));
+            var second = DotLiquid.Util.ExpressionUtility.CreateExpression(operation, typeof(int), typeof(int));
+
+            Assert.That(second, Is.SameAs(first), "Expected the same compiled delegate instance to be returned for repeated calls with identical operation/operand types.");
+
+            // A different operand type combination must still produce a working, independently cached delegate.
+            var third = DotLiquid.Util.ExpressionUtility.CreateExpression(operation, typeof(long), typeof(long));
+            Assert.That(third, Is.Not.SameAs(first));
         }
     }
 }

--- a/src/DotLiquid.Tests/Util/ExpressionUtilityTest.cs
+++ b/src/DotLiquid.Tests/Util/ExpressionUtilityTest.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 
 namespace DotLiquid.Tests.Util
 {
@@ -76,6 +77,47 @@ namespace DotLiquid.Tests.Util
             // A different operand type combination must still produce a working, independently cached delegate.
             var third = DotLiquid.Util.ExpressionUtility.CreateExpression(operation, typeof(long), typeof(long));
             Assert.That(third, Is.Not.SameAs(first));
+        }
+
+        /// <summary>
+        /// Instance-method delegates share the same MethodInfo regardless of the delegate's target instance, but
+        /// different target instances can produce different expression bodies. Caching solely by MethodInfo would
+        /// cause the wrong (stale) compiled delegate to be returned for a different target. This test ensures such
+        /// delegates skip the cache and are compiled correctly for each distinct target/body.
+        /// </summary>
+        [Test]
+        public void TestCreateExpressionSkipsCacheForInstanceMethodDelegates()
+        {
+            var addFactory = new BinaryExpressionFactory(useAdd: true);
+            var subtractFactory = new BinaryExpressionFactory(useAdd: false);
+
+            Func<Expression, Expression, BinaryExpression> addOperation = addFactory.CreateBinaryExpression;
+            Func<Expression, Expression, BinaryExpression> subtractOperation = subtractFactory.CreateBinaryExpression;
+
+            // Both delegates target the same instance method (MethodInfo), but different target instances,
+            // and therefore must compile to different, independently correct delegates.
+            Assert.That(addOperation.GetMethodInfo(), Is.EqualTo(subtractOperation.GetMethodInfo()));
+
+            var addDelegate = DotLiquid.Util.ExpressionUtility.CreateExpression(addOperation, typeof(int), typeof(int));
+            var subtractDelegate = DotLiquid.Util.ExpressionUtility.CreateExpression(subtractOperation, typeof(int), typeof(int));
+
+            Assert.That(addDelegate.DynamicInvoke(3, 4), Is.EqualTo(7));
+            Assert.That(subtractDelegate.DynamicInvoke(3, 4), Is.EqualTo(-1));
+        }
+
+        private class BinaryExpressionFactory
+        {
+            private readonly bool _useAdd;
+
+            public BinaryExpressionFactory(bool useAdd)
+            {
+                _useAdd = useAdd;
+            }
+
+            public BinaryExpression CreateBinaryExpression(Expression lhs, Expression rhs)
+            {
+                return _useAdd ? Expression.Add(lhs, rhs) : Expression.Subtract(lhs, rhs);
+            }
         }
     }
 }

--- a/src/DotLiquid/Util/ExpressionUtility.cs
+++ b/src/DotLiquid/Util/ExpressionUtility.cs
@@ -91,6 +91,12 @@ namespace DotLiquid.Util
              , Type leftType
              , Type rightType)
         {
+            // Skip the cache for instance-method delegates, since different targets can share a MethodInfo but produce different bodies.
+            if (body.Target != null)
+            {
+                return CompileExpression(body, leftType, rightType);
+            }
+
             // Level 1: left-type cache for this operation (e.g. Expression.AddChecked, a static framework method).
             var delegatesByLeftType = CompiledExpressionCache.GetOrAdd(
                 body.GetMethodInfo(),

--- a/src/DotLiquid/Util/ExpressionUtility.cs
+++ b/src/DotLiquid/Util/ExpressionUtility.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace DotLiquid.Util
 {
@@ -12,6 +15,14 @@ namespace DotLiquid.Util
     public static class ExpressionUtility
     {
         private static readonly Dictionary<Type, Type[]> NumericTypePromotions;
+
+        /// <summary>
+        /// Cache of compiled binary operation delegates, keyed by operation method, left operand type and right operand type,
+        /// avoiding recompiling an Expression.Lambda on every filter call. Uses nested ConditionalWeakTables keyed on the
+        /// operand Types (rather than a flat dictionary) so entries don't pin arbitrary/dynamic operand Types in memory forever.
+        /// </summary>
+        private static readonly ConcurrentDictionary<MethodInfo, ConditionalWeakTable<Type, ConditionalWeakTable<Type, Delegate>>> CompiledExpressionCache
+            = new ConcurrentDictionary<MethodInfo, ConditionalWeakTable<Type, ConditionalWeakTable<Type, Delegate>>>();
 
         static ExpressionUtility()
         {
@@ -76,6 +87,27 @@ namespace DotLiquid.Util
         /// <exception cref="System.ArgumentException"></exception>
         /// <returns>Compiled function delegate</returns>
         public static Delegate CreateExpression
+            (Func<Expression, Expression, BinaryExpression> body
+             , Type leftType
+             , Type rightType)
+        {
+            // Level 1: left-type cache for this operation (e.g. Expression.AddChecked, a static framework method).
+            var delegatesByLeftType = CompiledExpressionCache.GetOrAdd(
+                body.GetMethodInfo(),
+                _ => new ConditionalWeakTable<Type, ConditionalWeakTable<Type, Delegate>>());
+
+            // Level 2: right-type cache for this left operand type.
+            var delegatesByRightType = delegatesByLeftType.GetValue(
+                leftType,
+                _ => new ConditionalWeakTable<Type, Delegate>());
+
+            // Level 3: compiled delegate for this (operation, leftType, rightType), compiling on a miss.
+            return delegatesByRightType.GetValue(
+                rightType,
+                _ => CompileExpression(body, leftType, rightType));
+        }
+
+        private static Delegate CompileExpression
             (Func<Expression, Expression, BinaryExpression> body
              , Type leftType
              , Type rightType)


### PR DESCRIPTION
Resolves #617 

Performance after fix:

Plus(int,int): n=1000, elapsed=1 ms, allocated=0.36 MB
Plus(int,int): n=10000, elapsed=21 ms, allocated=3.59 MB
