### PR TITLE
Respect decimal scale in output

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,11 +17,7 @@ install:
     choco install opencover.portable -y
 
     choco install codecov -y
-
-    dotnet --list-runtimes | find "Microsoft.NETCore.App 3.1" >nul
-
-    if %errorlevel% neq 0 ( choco install dotnetcore-runtime.install --version=3.1.32 -y )
-
+    
     dotnet restore src/DotLiquid.sln
 cache:
 - C:\ProgramData\chocolatey\bin -> appveyor.yml

--- a/src/DotLiquid.Tests/DotLiquid.Tests.csproj
+++ b/src/DotLiquid.Tests/DotLiquid.Tests.csproj
@@ -1,12 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>DotLiquid.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../Formosatek-OpenSource.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>DotLiquid.Tests</PackageId>
+    <!-- netcoreapp3.1 runtime may not be installed; roll forward to whatever newer major runtime is available. -->
+    <RollForward Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">Major</RollForward>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
@@ -36,18 +38,13 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <Reference Include="Microsoft.CSharp" />
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.1' ">
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
   </ItemGroup>

--- a/src/DotLiquid.Tests/DotLiquid.Tests.csproj
+++ b/src/DotLiquid.Tests/DotLiquid.Tests.csproj
@@ -39,7 +39,6 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>
@@ -47,6 +46,10 @@
   <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.1' ">
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DotLiquid.Tests/Embedded/golden_rules.json
+++ b/src/DotLiquid.Tests/Embedded/golden_rules.json
@@ -211,12 +211,7 @@
     "alternate_test_expectations": {
         "liquid.golden.divided_by_filter - float division": "2.8571428571428571428571428571",
         "liquid.golden.divided_by_filter - integer value and float arg": "5",
-        "liquid.golden.divided_by_filter - render": "5 5",
         "liquid.golden.divided_by_filter - zero divided by float": "0",
-        "liquid.golden.minus_filter - integer value and float arg": "8",
-        "liquid.golden.modulo_filter - integer value and float arg": "0",
-        "liquid.golden.modulo_filter - string value and argument": "0",
-        "liquid.golden.plus_filter - integer value and float arg": "12",
         // With Rails/ActiveSupport these work similar to DotLiquid
         "liquid.golden.first_filter - first of a string": "h",
         "liquid.golden.last_filter - last of a string": "o",

--- a/src/DotLiquid.Tests/VariableTests.cs
+++ b/src/DotLiquid.Tests/VariableTests.cs
@@ -151,15 +151,39 @@ namespace DotLiquid.Tests
             }
         }
 
-        private static string RenderVariable(object data)
+        private static string RenderVariable(object data, SyntaxCompatibility? syntaxCompatibilityLevel = null)
         {
-            Variable variable = new Variable("{{data}}");
+            Variable variable = new Variable("data");
             Context context = new Context(CultureInfo.CurrentCulture);
+            if (syntaxCompatibilityLevel.HasValue)
+                context.SyntaxCompatibilityLevel = syntaxCompatibilityLevel.Value;
             context["data"] = data;
             using (TextWriter writer = new StringWriter(CultureInfo.InvariantCulture))
             {
                 variable.Render(context, writer);
                 return writer.ToString();
+            }
+        }
+
+        [Test]
+        public void TestVariableStringConversion_Decimal_SyntaxCompatibility()
+        {
+            using (CultureHelper.SetCulture("en-US"))
+            {
+                Assert.Multiple(() =>
+                {
+                    // DotLiquid 2.0-2.2 (legacy) behavior: trailing zeroes are always trimmed
+                    Assert.That(RenderVariable(5m, SyntaxCompatibility.DotLiquid20), Is.EqualTo("5"));
+                    Assert.That(RenderVariable(5.0m, SyntaxCompatibility.DotLiquid20), Is.EqualTo("5"));
+                    Assert.That(RenderVariable(5.00m, SyntaxCompatibility.DotLiquid20), Is.EqualTo("5"));
+                    Assert.That(RenderVariable(5.10m, SyntaxCompatibility.DotLiquid20), Is.EqualTo("5.1"));
+
+                    // DotLiquid 2.4+ behavior: preserves the decimal's declared scale, always showing at least one decimal place
+                    Assert.That(RenderVariable(5m, SyntaxCompatibility.DotLiquid24), Is.EqualTo("5"));
+                    Assert.That(RenderVariable(5.0m, SyntaxCompatibility.DotLiquid24), Is.EqualTo("5.0"));
+                    Assert.That(RenderVariable(5.00m, SyntaxCompatibility.DotLiquid24), Is.EqualTo("5.0"));
+                    Assert.That(RenderVariable(5.10m, SyntaxCompatibility.DotLiquid24), Is.EqualTo("5.1"));
+                });
             }
         }
 

--- a/src/DotLiquid/DotLiquid.csproj
+++ b/src/DotLiquid/DotLiquid.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>DotLiquid</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Authors>Tim Jones;Alessandro Petrelli</Authors>
-    <TargetFrameworks>netstandard2.0;net45;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>DotLiquid</AssemblyName>
     <AssemblyOriginatorKeyFile>../Formosatek-OpenSource.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/src/DotLiquid/Variable.cs
+++ b/src/DotLiquid/Variable.cs
@@ -68,12 +68,21 @@ namespace DotLiquid
             // This is not a desirable default for Liquid as it confuses the users as to why '12.5 |times 10' becomes '125.0'.
             // So we overwrite the default serialization behavior to specify a format with maximum significant precision.
             // Decimal type has a maximum of 29 significant digits.
-            string ToFormattedString(object obj, IFormatProvider formatProvider) =>
-                (obj is decimal decimalValue)
-                    ? decimalValue.ToString(format: "0.#############################", provider: formatProvider)
-                    : obj is IFormattable ifo
-                        ? ifo.ToString(format: null, formatProvider: formatProvider)
-                        : (obj?.ToString() ?? "");
+            // NOTE (microalps): Desirable result for v2.4 is the same as reference liquid implementation, which is to always show at least one decimal place for decimal values.
+            string ToFormattedString(object obj) {
+                if (obj is decimal decOutput)
+                {
+                    if (context.SyntaxCompatibilityLevel < SyntaxCompatibility.DotLiquid24)
+                        return decOutput.ToString(format: "0.#############################", provider: result.FormatProvider);
+                    return GetScale(decOutput) == 0
+                        ? decOutput.ToString(result.FormatProvider)
+                        : decOutput.ToString(format: "0.0############################", provider: result.FormatProvider);
+                }
+                else if (obj is IFormattable ifo)
+                    return ifo.ToString(format: null, result.FormatProvider);
+                else
+                    return (obj?.ToString() ?? "");
+            }
 
             object output = RenderInternal(context);
 
@@ -91,15 +100,25 @@ namespace DotLiquid
                 if (!(output is string outputString))
                 {
                     if (output is IEnumerable enumerable)
-                        outputString = string.Join(string.Empty, enumerable.Cast<object>().Select(o => ToFormattedString(o, result.FormatProvider)).ToArray());
+                        outputString = string.Join(string.Empty, enumerable.Cast<object>().Select(ToFormattedString).ToArray());
                     else if (output is bool)
                         outputString = output.ToString().ToLower();
                     else
-                        outputString = ToFormattedString(output, result.FormatProvider);
+                        outputString = ToFormattedString(output);
                 }
 
                 result.Write(outputString);
             }
+        }
+
+        private static int GetScale(decimal value)
+        {
+#if NET8_0_OR_GREATER
+            return value.Scale;
+#else
+            // Extract bits and shift to get scale (bits[3] contains scale info)
+            return (Decimal.GetBits(value)[3] >> 16) & 0x7F;
+#endif
         }
 
         private object RenderInternal(Context context)


### PR DESCRIPTION
This relates to #566 and our solution was to accept the output differences as correct. The cause for this is traced to efd59f61458219a4f8a8d698cc7a0288cdd2186a where the following comment was made:
> NOTE(David Burg): The decimal type default string serialization behavior adds non-significant trailing zeroes
to indicate the precision of the result.
This is not a desirable default for Liquid as it confuses the users as to why '12.5 |times 10' becomes '125.0'.
So we overwrite the default serialization behavior to specify a format with maximum significant precision.
Decimal type has a maximum of 29 significant digits. 

However, for syntax compatibility we should match liquid reference library even if this is not a 'desirable default'. Gated behind the future 2.4 flag.